### PR TITLE
Update/fix crash issues with Android-Iconics library for Android 10.0 devices

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -156,9 +156,9 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.12.1'
 
     //Icons
-    implementation "com.mikepenz:iconics-core:3.2.5@aar"
-    implementation "com.mikepenz:iconics-views:3.2.5@aar"
-    implementation 'com.mikepenz:community-material-typeface:3.5.95.1@aar'
+    implementation "com.mikepenz:iconics-core:4.0.1@aar"
+    implementation "com.mikepenz:iconics-views:4.0.1@aar"
+    implementation 'com.mikepenz:community-material-typeface:3.5.95.1-kotlin@aar'
 
     // Job scheduling
     implementation 'com.evernote:android-job:1.2.5'

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -5,8 +5,8 @@ import android.content.Context
 import android.content.res.Configuration
 import androidx.multidex.MultiDex
 import com.evernote.android.job.JobManager
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
 import com.mikepenz.iconics.Iconics
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import eu.kanade.tachiyomi.data.backup.BackupCreatorJob
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.data.notification.Notifications
@@ -29,7 +29,7 @@ open class App : Application() {
         setupNotificationChannels()
 
         Iconics.init(applicationContext)
-        Iconics.registerFont(CommunityMaterial())
+        Iconics.registerFont(CommunityMaterial)
 
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCatalogueController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCatalogueController.kt
@@ -14,9 +14,11 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.f2prateek.rx.preferences.Preference
 import com.google.android.material.snackbar.Snackbar
 import com.jakewharton.rxbinding.support.v7.widget.queryTextChangeEvents
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.utils.IconicsMenuInflaterUtil
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.IFlexible
 import eu.kanade.tachiyomi.R
@@ -266,7 +268,8 @@ open class BrowseCatalogueController(bundle: Bundle) :
                 CommunityMaterial.Icon2.cmd_view_module
             else
                 CommunityMaterial.Icon2.cmd_view_list
-            setIcon(IconicsDrawable(applicationContext!!).icon(icon).color(Color.WHITE).sizeDp(20))
+            setIcon(IconicsDrawable(applicationContext!!)
+                    .icon(icon).colorInt(Color.WHITE).sizeDp(20))
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/filter/GroupItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/filter/GroupItem.kt
@@ -5,8 +5,10 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.AbstractExpandableHeaderItem
 import eu.davidea.flexibleadapter.items.IFlexible
@@ -41,7 +43,11 @@ class GroupItem(val filter: Filter.Group<*>) : AbstractExpandableHeaderItem<Grou
         else
             CommunityMaterial.Icon.cmd_chevron_right
 
-        holder.icon.setImageDrawable(IconicsDrawable(holder.contentView.context).icon(icon).color(Color.WHITE).sizeDp(16))
+        holder.icon
+                .setImageDrawable(IconicsDrawable(holder.contentView.context)
+                        .icon(icon)
+                        .colorInt(Color.WHITE)
+                        .sizeDp(16))
 
         holder.itemView.setOnClickListener(holder)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/filter/SortGroup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/filter/SortGroup.kt
@@ -3,8 +3,10 @@ package eu.kanade.tachiyomi.ui.catalogue.filter
 import android.graphics.Color
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.AbstractExpandableHeaderItem
 import eu.davidea.flexibleadapter.items.IFlexible
@@ -38,7 +40,10 @@ class SortGroup(val filter: Filter.Sort) : AbstractExpandableHeaderItem<SortGrou
         else
             CommunityMaterial.Icon.cmd_chevron_right
 
-        holder.icon.setImageDrawable(IconicsDrawable(holder.contentView.context).icon(icon).color(Color.WHITE).sizeDp(16))
+        holder.icon
+                .setImageDrawable(IconicsDrawable(holder.contentView.context)
+                        .icon(icon)
+                        .colorInt(Color.WHITE).sizeDp(16))
 
         holder.itemView.setOnClickListener(holder)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/filter/SortItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/filter/SortItem.kt
@@ -4,8 +4,10 @@ import android.view.View
 import android.widget.CheckedTextView
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.AbstractSectionableItem
 import eu.davidea.flexibleadapter.items.IFlexible
@@ -37,9 +39,9 @@ class SortItem(val name: String, val group: SortGroup) : AbstractSectionableItem
 
         fun getIcon() = when (filter.state) {
             Filter.Sort.Selection(i, false) -> IconicsDrawable(view.context).icon(CommunityMaterial.Icon.cmd_arrow_down)
-                    .sizeDp(16).color(view.context.getResourceColor(R.attr.colorAccent))
+                    .sizeDp(16).colorInt(view.context.getResourceColor(R.attr.colorAccent))
             Filter.Sort.Selection(i, true) -> IconicsDrawable(view.context).icon(CommunityMaterial.Icon.cmd_arrow_up)
-                    .sizeDp(16).color(view.context.getResourceColor(R.attr.colorAccent))
+                    .sizeDp(16).colorInt(view.context.getResourceColor(R.attr.colorAccent))
             else -> ContextCompat.getDrawable(view.context, R.drawable.empty_drawable_16dp)
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/filter/TriStateItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/filter/TriStateItem.kt
@@ -5,8 +5,10 @@ import android.view.View
 import android.widget.CheckedTextView
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.R
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.AbstractFlexibleItem
 import eu.davidea.flexibleadapter.items.IFlexible
@@ -45,7 +47,7 @@ open class TriStateItem(val filter: Filter.TriState) : AbstractFlexibleItem<TriS
             else
                 view.context.getResourceColor(android.R.attr.textColorSecondary)
 
-            return IconicsDrawable(view.context).icon(icon).sizeDp(18).color(color)
+            return IconicsDrawable(view.context).icon(icon).sizeDp(18).colorInt(color)
         }
 
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryController.kt
@@ -7,7 +7,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
 import com.jakewharton.rxbinding.view.clicks
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.utils.IconicsMenuInflaterUtil
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.SelectableAdapter

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryHolder.kt
@@ -1,8 +1,10 @@
 package eu.kanade.tachiyomi.ui.category
 
 import android.view.View
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.ui.base.holder.BaseFlexibleViewHolder
 import eu.kanade.tachiyomi.util.getResourceColor
@@ -38,9 +40,12 @@ class CategoryHolder(view: View, val adapter: CategoryAdapter) : BaseFlexibleVie
 
         // Update circle letter image.
         itemView.post {
-            image.setImageDrawable(image.getRound(category.name.take(1).toUpperCase(),false))
+            image.setImageDrawable(image.getRound(category.name.take(1).toUpperCase(), false))
         }
-        reorder.setImageDrawable(IconicsDrawable(contentView.context).icon(CommunityMaterial.Icon2.cmd_reorder_horizontal).sizeDp(18).color(contentView.context.getResourceColor(android.R.attr.textColorPrimary)))
+        reorder.setImageDrawable(IconicsDrawable(contentView.context)
+                .icon(CommunityMaterial.Icon2.cmd_reorder_horizontal)
+                .sizeDp(18)
+                .colorInt(contentView.context.getResourceColor(android.R.attr.textColorPrimary)))
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadController.kt
@@ -3,8 +3,10 @@ package eu.kanade.tachiyomi.ui.download
 import android.graphics.Color
 import android.view.*
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.DownloadService
 import eu.kanade.tachiyomi.data.download.model.Download
@@ -99,16 +101,19 @@ class DownloadController : NucleusController<DownloadPresenter>() {
         // Set start button visibility.
         menu.findItem(R.id.start_queue).isVisible = !isRunning && !presenter.downloadQueue.isEmpty()
         menu.findItem(R.id.start_queue).icon = IconicsDrawable(applicationContext!!)
-                .icon(CommunityMaterial.Icon2.cmd_play).color(Color.WHITE).sizeDp(18)
+                .icon(CommunityMaterial.Icon2.cmd_play)
+                .colorInt(Color.WHITE).sizeDp(18)
 
         // Set pause button visibility.
         menu.findItem(R.id.pause_queue).isVisible = isRunning
         menu.findItem(R.id.pause_queue).icon = IconicsDrawable(applicationContext!!)
-                .icon(CommunityMaterial.Icon2.cmd_pause).color(Color.WHITE).sizeDp(18)
+                .icon(CommunityMaterial.Icon2.cmd_pause)
+                .colorInt(Color.WHITE).sizeDp(18)
         // Set clear button visibility.
         menu.findItem(R.id.clear_queue).isVisible = !presenter.downloadQueue.isEmpty()
         menu.findItem(R.id.clear_queue).icon = IconicsDrawable(applicationContext!!)
-                .icon(CommunityMaterial.Icon2.cmd_notification_clear_all).color(Color.WHITE).sizeDp(20)
+                .icon(CommunityMaterial.Icon2.cmd_notification_clear_all)
+                .colorInt(Color.WHITE).sizeDp(20)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -19,7 +19,7 @@ import com.jakewharton.rxbinding.support.v4.view.pageSelections
 import com.jakewharton.rxbinding.support.v7.widget.queryTextChanges
 import com.jakewharton.rxrelay.BehaviorRelay
 import com.jakewharton.rxrelay.PublishRelay
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.utils.IconicsMenuInflaterUtil
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Category

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -11,7 +11,7 @@ import androidx.appcompat.graphics.drawable.DrawerArrowDrawable
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import com.bluelinelabs.conductor.*
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.context.IconicsContextWrapper
 import com.mikepenz.iconics.typeface.IIcon

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaController.kt
@@ -16,8 +16,10 @@ import com.bluelinelabs.conductor.support.RouterPagerAdapter
 import com.google.android.material.tabs.TabLayout
 import com.jakewharton.rxrelay.BehaviorRelay
 import com.jakewharton.rxrelay.PublishRelay
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Manga
@@ -140,7 +142,10 @@ class MangaController : RxController, TabbedController {
     private fun setTrackingIconInternal(visible: Boolean) {
         val tab = activity?.tabs?.getTabAt(TRACK_CONTROLLER) ?: return
         val drawable = if (visible)
-            IconicsDrawable(applicationContext!!).icon(CommunityMaterial.Icon.cmd_check).color(Color.WHITE).sizeDp(12)
+            IconicsDrawable(applicationContext!!)
+                    .icon(CommunityMaterial.Icon.cmd_check)
+                    .colorInt(Color.WHITE)
+                    .sizeDp(12)
         else null
 
         val view = tabField.get(tab) as LinearLayout

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChapterHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChapterHolder.kt
@@ -2,8 +2,10 @@ package eu.kanade.tachiyomi.ui.manga.chapter
 
 import android.view.View
 import android.widget.PopupMenu
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.model.Download
@@ -39,7 +41,7 @@ class ChapterHolder(
         // Set the correct drawable for dropdown and update the tint to match theme.
         // Set the correct drawable for dropdown and update the tint to match theme.
         chapter_menu.setImageDrawable(IconicsDrawable(view.context).icon(CommunityMaterial.Icon.cmd_dots_vertical)
-                .sizeDp(18).color(view.context.getResourceColor(R.attr.icon_color)))
+                .sizeDp(18).colorInt(view.context.getResourceColor(R.attr.icon_color)))
         // Set correct text color
         chapter_title.setTextColor(if (chapter.read) adapter.readColor else adapter.unreadColor)
         if (chapter.bookmark) chapter_title.setTextColor(adapter.bookmarkedColor)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersController.kt
@@ -14,9 +14,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.jakewharton.rxbinding.support.v4.widget.refreshes
 import com.jakewharton.rxbinding.view.clicks
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.utils.IconicsMenuInflaterUtil
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.SelectableAdapter
 import eu.kanade.tachiyomi.R
@@ -89,7 +91,10 @@ class ChaptersController : NucleusController<ChaptersPresenter>(),
         swipe_refresh.refreshes().subscribeUntilDestroy { fetchChaptersFromSource() }
 
         fab.setImageDrawable(
-                IconicsDrawable(applicationContext!!).icon(CommunityMaterial.Icon2.cmd_play).color(Color.WHITE).sizeDp(20)
+                IconicsDrawable(applicationContext!!)
+                        .icon(CommunityMaterial.Icon2.cmd_play)
+                        .colorInt(Color.WHITE)
+                        .sizeDp(20)
         )
 
         fab.clicks().subscribeUntilDestroy {
@@ -144,7 +149,7 @@ class ChaptersController : NucleusController<ChaptersPresenter>(),
 
 
         menu.findItem(R.id.action_sort).icon = IconicsDrawable(applicationContext!!).icon(CommunityMaterial.Icon2.cmd_sort_numeric)
-                .sizeDp(20).color(Color.WHITE)
+                .sizeDp(20).colorInt(Color.WHITE)
 
         // Set correct checkbox values.
         menuFilterRead.isChecked = presenter.onlyRead()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
@@ -24,8 +24,10 @@ import com.bumptech.glide.request.transition.Transition
 import com.jakewharton.rxbinding.support.v4.widget.refreshes
 import com.jakewharton.rxbinding.view.clicks
 import com.jakewharton.rxbinding.view.longClicks
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.database.models.Manga
@@ -102,17 +104,17 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
             copyToClipboard(manga_artist_label.text.toString(), manga_artist.text.toString())
         }
 
-       /* manga_artist.clicks().subscribeUntilDestroy {
-            performGlobalSearch(manga_artist.text.toString())
-        }*/
+        /* manga_artist.clicks().subscribeUntilDestroy {
+             performGlobalSearch(manga_artist.text.toString())
+         }*/
 
         manga_author.longClicks().subscribeUntilDestroy {
             copyToClipboard(manga_author.text.toString(), manga_author.text.toString())
         }
 
-       /* manga_author.clicks().subscribeUntilDestroy {
-            performGlobalSearch(manga_author.text.toString())
-        }*/
+        /* manga_author.clicks().subscribeUntilDestroy {
+             performGlobalSearch(manga_author.text.toString())
+         }*/
 
         manga_summary.longClicks().subscribeUntilDestroy {
             copyToClipboard(view.context.getString(R.string.description), manga_summary.text.toString())
@@ -127,7 +129,11 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.manga_info, menu)
-        menu.findItem(R.id.action_share).icon = IconicsDrawable(applicationContext!!).icon(CommunityMaterial.Icon2.cmd_share_variant).sizeDp(18).color(Color.WHITE)
+        menu.findItem(R.id.action_share).icon =
+                IconicsDrawable(applicationContext!!)
+                        .icon(CommunityMaterial.Icon2.cmd_share_variant)
+                        .sizeDp(18)
+                        .colorInt(Color.WHITE)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -321,7 +327,7 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
         }
 
         parentController?.router?.pushController(MangaWebViewController(source.id, url)
-            .withFadeTransaction())
+                .withFadeTransaction())
     }
 
     /**
@@ -354,9 +360,15 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
 
         fab_favorite?.setImageDrawable(
                 if (isFavorite) {
-                    IconicsDrawable(applicationContext!!).icon(CommunityMaterial.Icon2.cmd_heart).color(Color.WHITE).sizeDp(20)
+                    IconicsDrawable(applicationContext!!)
+                            .icon(CommunityMaterial.Icon2.cmd_heart)
+                            .colorInt(Color.WHITE)
+                            .sizeDp(20)
                 } else {
-                    IconicsDrawable(applicationContext!!).icon(CommunityMaterial.Icon2.cmd_heart_outline).color(Color.WHITE).sizeDp(20)
+                    IconicsDrawable(applicationContext!!)
+                            .icon(CommunityMaterial.Icon2.cmd_heart_outline)
+                            .colorInt(Color.WHITE)
+                            .sizeDp(20)
                 })
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/PageIndicatorTextView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/PageIndicatorTextView.kt
@@ -2,15 +2,13 @@ package eu.kanade.tachiyomi.ui.reader
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.graphics.Canvas
 import android.graphics.Color
-import android.graphics.Paint
 import androidx.appcompat.widget.AppCompatTextView
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.ScaleXSpan
 import android.util.AttributeSet
-import android.widget.TextView
+import eu.kanade.tachiyomi.util.OutlineSpan
 
 /**
  * Page indicator found at the bottom of the reader
@@ -20,19 +18,8 @@ class PageIndicatorTextView(
         attrs: AttributeSet? = null
 ) : AppCompatTextView(context, attrs) {
 
-    private val fillColor = Color.rgb(235, 235, 235)
-    private val strokeColor = Color.rgb(45, 45, 45)
-
-    override fun onDraw(canvas: Canvas) {
-        textColorField.set(this, strokeColor)
-        paint.strokeWidth = 4f
-        paint.style = Paint.Style.STROKE
-        super.onDraw(canvas)
-
-        textColorField.set(this, fillColor)
-        paint.strokeWidth = 0f
-        paint.style = Paint.Style.FILL
-        super.onDraw(canvas)
+    init {
+        setTextColor(Color.rgb(235, 235, 235))
     }
 
     @SuppressLint("SetTextI18n")
@@ -42,20 +29,22 @@ class PageIndicatorTextView(
         val currText = " $text "
 
         // Also add a bit of spacing between each character, as the stroke overlaps them
-        val finalText = SpannableString(currText.asIterable().joinToString("\u00A0"))
+        val finalText = SpannableString(currText.asIterable().joinToString("\u00A0")).apply {
+            // Apply text outline
+            setSpan(spanOutline, 1, length-1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
 
-        for (i in 1..finalText.lastIndex step 2) {
-            finalText.setSpan(ScaleXSpan(0.1f), i, i + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            for (i in 1..lastIndex step 2) {
+                setSpan(ScaleXSpan(0.3f), i, i + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
         }
-
-        super.setText(finalText, TextView.BufferType.SPANNABLE)
+        super.setText(finalText, BufferType.SPANNABLE)
     }
 
     private companion object {
-        // We need to use reflection to set the text color instead of using [setTextColor],
-        // otherwise the view is invalidated inside [onDraw] and there's an infinite loop
-        val textColorField = TextView::class.java.getDeclaredField("mCurTextColor").apply {
-            isAccessible = true
-        }!!
+        // A span object with text outlining properties
+        val spanOutline = OutlineSpan(
+                strokeColor = Color.rgb(45, 45, 45),
+                strokeWidth = 4f
+        )
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -15,9 +15,11 @@ import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.SeekBar
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.utils.IconicsMenuInflaterUtil
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
@@ -241,7 +243,10 @@ class ReaderActivity : BaseRxActivity<ReaderPresenter>() {
                 }
             }
         })
-        left_chapter.setImageDrawable(IconicsDrawable(applicationContext).icon(CommunityMaterial.Icon2.cmd_skip_previous).color(Color.WHITE).sizeDp(18))
+        left_chapter.setImageDrawable(IconicsDrawable(applicationContext)
+                .icon(CommunityMaterial.Icon2.cmd_skip_previous)
+                .colorInt(Color.WHITE)
+                .sizeDp(18))
 
         left_chapter.setOnClickListener {
             if (viewer != null) {
@@ -251,7 +256,11 @@ class ReaderActivity : BaseRxActivity<ReaderPresenter>() {
                     loadPreviousChapter()
             }
         }
-        right_chapter.setImageDrawable(IconicsDrawable(applicationContext).icon(CommunityMaterial.Icon2.cmd_skip_next).color(Color.WHITE).sizeDp(18))
+        right_chapter.setImageDrawable(IconicsDrawable(applicationContext)
+                .icon(CommunityMaterial.Icon2.cmd_skip_next)
+                .colorInt(Color.WHITE)
+                .sizeDp(18))
+
         right_chapter.setOnClickListener {
             if (viewer != null) {
                 if (viewer is R2LPagerViewer)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPageSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPageSheet.kt
@@ -6,8 +6,10 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import android.view.View
 import android.view.ViewGroup
 import com.afollestad.materialdialogs.MaterialDialog
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
@@ -43,13 +45,13 @@ class ReaderPageSheet(
     }
 
     override fun setContentView(view: View?) {
-        super.setContentView(view)
+        super.setContentView(view!!)
         set_as_cover_image.setImageDrawable(IconicsDrawable(context).icon(CommunityMaterial.Icon2.cmd_image)
-                .color(Color.GRAY).sizeDp(20))
+                .colorInt(Color.GRAY).sizeDp(20))
         share_image.setImageDrawable(IconicsDrawable(context).icon(CommunityMaterial.Icon2.cmd_share_variant)
-                .color(Color.GRAY).sizeDp(20))
+                .colorInt(Color.GRAY).sizeDp(20))
         save_image.setImageDrawable(IconicsDrawable(context).icon(CommunityMaterial.Icon.cmd_download)
-                .color(Color.GRAY).sizeDp(20))
+                .colorInt(Color.GRAY).sizeDp(20))
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent_updates/RecentChapterHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent_updates/RecentChapterHolder.kt
@@ -3,8 +3,10 @@ package eu.kanade.tachiyomi.ui.recent_updates
 import android.view.View
 import android.widget.PopupMenu
 import com.bumptech.glide.load.engine.DiskCacheStrategy
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.glide.GlideApp
@@ -65,8 +67,10 @@ class RecentChapterHolder(private val view: View, private val adapter: RecentCha
         manga_title.text = item.manga.title
 
         // Set the correct drawable for dropdown and update the tint to match theme.
-        chapter_menu_icon.setImageDrawable(IconicsDrawable(view.context).icon(CommunityMaterial.Icon.cmd_dots_horizontal)
-                .sizeDp(18).color(view.context.getResourceColor(R.attr.icon_color)))
+        chapter_menu_icon.setImageDrawable(IconicsDrawable(view.context)
+                .icon(CommunityMaterial.Icon.cmd_dots_horizontal)
+                .sizeDp(18)
+                .colorInt(view.context.getResourceColor(R.attr.icon_color)))
 
         // Set cover
         GlideApp.with(itemView.context).clear(manga_cover)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent_updates/RecentChaptersController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent_updates/RecentChaptersController.kt
@@ -7,7 +7,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.jakewharton.rxbinding.support.v4.widget.refreshes
 import com.jakewharton.rxbinding.support.v7.widget.scrollStateChanges
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.utils.IconicsMenuInflaterUtil
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.SelectableAdapter

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recently_read/RecentlyReadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recently_read/RecentlyReadController.kt
@@ -4,7 +4,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.History

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsMainController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsMainController.kt
@@ -1,8 +1,10 @@
 package eu.kanade.tachiyomi.ui.setting
 
 import androidx.preference.PreferenceScreen
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.base.controller.withFadeTransaction
 import eu.kanade.tachiyomi.util.getResourceColor
@@ -15,42 +17,82 @@ class SettingsMainController : SettingsController() {
         val size = 18
 
         preference {
-            iconDrawable = IconicsDrawable(context).icon(CommunityMaterial.Icon2.cmd_tune_vertical).color(tintColor).sizeDp(size)
+            iconDrawable =
+                    IconicsDrawable(context)
+                            .icon(CommunityMaterial.Icon2.cmd_tune_vertical)
+                            .colorInt(tintColor)
+                            .sizeDp(size)
+
             titleRes = R.string.pref_category_general
             onClick { navigateTo(SettingsGeneralController()) }
         }
         preference {
-            iconDrawable = IconicsDrawable(context).icon(CommunityMaterial.Icon.cmd_google_chrome).color(tintColor).sizeDp(size)
+            iconDrawable =
+                    IconicsDrawable(context)
+                            .icon(CommunityMaterial.Icon.cmd_google_chrome)
+                            .colorInt(tintColor)
+                            .sizeDp(size)
+
             titleRes = R.string.pref_category_site_specific
             onClick { navigateTo(SettingsSiteController()) }
         }
         preference {
-            iconDrawable = IconicsDrawable(context).icon(CommunityMaterial.Icon.cmd_book_open_page_variant).color(tintColor).sizeDp(size)
+            iconDrawable =
+                    IconicsDrawable(context)
+                            .icon(CommunityMaterial.Icon.cmd_book_open_page_variant)
+                            .colorInt(tintColor)
+                            .sizeDp(size)
+
             titleRes = R.string.pref_category_reader
             onClick { navigateTo(SettingsReaderController()) }
         }
         preference {
-            iconDrawable = IconicsDrawable(context).icon(CommunityMaterial.Icon.cmd_download).color(tintColor).sizeDp(size)
+            iconDrawable =
+                    IconicsDrawable(context)
+                            .icon(CommunityMaterial.Icon.cmd_download)
+                            .colorInt(tintColor)
+                            .sizeDp(size)
+
             titleRes = R.string.pref_category_downloads
             onClick { navigateTo(SettingsDownloadController()) }
         }
         preference {
-            iconDrawable = IconicsDrawable(context).icon(CommunityMaterial.Icon2.cmd_sync).color(tintColor).sizeDp(size)
+            iconDrawable =
+                    IconicsDrawable(context)
+                            .icon(CommunityMaterial.Icon2.cmd_sync)
+                            .colorInt(tintColor)
+                            .sizeDp(size)
+
             titleRes = R.string.pref_category_tracking
             onClick { navigateTo(SettingsTrackingController()) }
         }
         preference {
-            iconDrawable = IconicsDrawable(context).icon(CommunityMaterial.Icon.cmd_cloud_upload).color(tintColor).sizeDp(size)
+            iconDrawable =
+                    IconicsDrawable(context)
+                            .icon(CommunityMaterial.Icon.cmd_cloud_upload)
+                            .colorInt(tintColor)
+                            .sizeDp(size)
+
             titleRes = R.string.backup
             onClick { navigateTo(SettingsBackupController()) }
         }
         preference {
-            iconDrawable = IconicsDrawable(context).icon(CommunityMaterial.Icon.cmd_code_tags).color(tintColor).sizeDp(size)
+            iconDrawable =
+                    IconicsDrawable(context)
+                            .icon(CommunityMaterial.Icon.cmd_code_tags)
+                            .colorInt(tintColor)
+                            .sizeDp(size)
+
             titleRes = R.string.pref_category_advanced
             onClick { navigateTo(SettingsAdvancedController()) }
         }
         preference {
-            iconDrawable = IconicsDrawable(context).icon(CommunityMaterial.Icon2.cmd_help_circle).color(tintColor).sizeDp(size)
+            iconDrawable =
+                    IconicsDrawable(context)
+                            .icon(CommunityMaterial.Icon2.cmd_help_circle)
+                            .colorInt(tintColor)
+                            .sizeDp(size)
+
             titleRes = R.string.pref_category_about
             onClick { navigateTo(SettingsAboutController()) }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/OutlineSpan.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/OutlineSpan.kt
@@ -1,0 +1,58 @@
+package eu.kanade.tachiyomi.util
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.text.style.ReplacementSpan
+import androidx.annotation.ColorInt
+import androidx.annotation.Dimension
+
+/**
+ * Source: https://github.com/santaevpavel
+ *
+ * A class that draws the outlines of a text when given a stroke color and stroke width.
+ *
+ */
+class OutlineSpan(
+        @ColorInt private val strokeColor: Int,
+        @Dimension private val strokeWidth: Float
+): ReplacementSpan() {
+
+    override fun getSize(
+            paint: Paint,
+            text: CharSequence,
+            start: Int,
+            end: Int,
+            fm: Paint.FontMetricsInt?
+    ): Int {
+        return paint.measureText(text.toString().substring(start until end)).toInt()
+    }
+
+    override fun draw(
+            canvas: Canvas,
+            text: CharSequence,
+            start: Int,
+            end: Int,
+            x: Float,
+            top: Int,
+            y: Int,
+            bottom: Int,
+            paint: Paint
+    ) {
+        val originTextColor = paint.color
+
+        paint.apply {
+            color = strokeColor
+            style = Paint.Style.STROKE
+            this.strokeWidth = this@OutlineSpan.strokeWidth
+        }
+        canvas.drawText(text, start, end, x, y.toFloat(), paint)
+
+        paint.apply {
+            color = originTextColor
+            style = Paint.Style.FILL
+        }
+
+        canvas.drawText(text, start, end, x, y.toFloat(), paint)
+    }
+
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/widget/EmptyView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/widget/EmptyView.kt
@@ -6,12 +6,14 @@ import android.view.View
 import android.widget.RelativeLayout
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.typeface.IIcon
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.util.getResourceColor
 import kotlinx.android.synthetic.main.common_view_empty.view.*
 
 class EmptyView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
-        RelativeLayout (context, attrs) {
+        RelativeLayout(context, attrs) {
 
     init {
         inflate(context, R.layout.common_view_empty, this)
@@ -30,7 +32,9 @@ class EmptyView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
      * @param textResource text of information view
      */
     fun show(icon: IIcon, textResource: Int) {
-        image_view.setImageDrawable(IconicsDrawable(context).icon(icon).sizeDp(96).color(context.getResourceColor(android.R.attr.textColorHint)))
+        image_view.setImageDrawable(IconicsDrawable(context)
+                .icon(icon).sizeDp(96)
+                .colorInt(context.getResourceColor(android.R.attr.textColorHint)))
         text_label.text = context.getString(textResource)
         this.visibility = View.VISIBLE
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/widget/ExtendedNavigationView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/widget/ExtendedNavigationView.kt
@@ -8,8 +8,10 @@ import android.view.ViewGroup
 import androidx.annotation.CallSuper
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.util.getResourceColor
 
@@ -90,9 +92,9 @@ open class ExtendedNavigationView @JvmOverloads constructor(
             override fun getStateDrawable(context: Context): Drawable? {
                 return when (state) {
                     SORT_ASC -> IconicsDrawable(context).icon(CommunityMaterial.Icon.cmd_arrow_up)
-                            .sizeDp(16).color(context.getResourceColor(R.attr.colorAccent))
+                            .sizeDp(16).colorInt(context.getResourceColor(R.attr.colorAccent))
                     SORT_DESC -> IconicsDrawable(context).icon(CommunityMaterial.Icon.cmd_arrow_down)
-                            .sizeDp(16).color(context.getResourceColor(R.attr.colorAccent))
+                            .sizeDp(16).colorInt(context.getResourceColor(R.attr.colorAccent))
                     SORT_NONE -> ContextCompat.getDrawable(context, R.drawable.empty_drawable_16dp)
                     else -> null
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/widget/StateImageViewTarget.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/widget/StateImageViewTarget.kt
@@ -6,9 +6,11 @@ import android.widget.ImageView
 import android.widget.ImageView.ScaleType
 import com.bumptech.glide.request.target.ImageViewTarget
 import com.bumptech.glide.request.transition.Transition
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.typeface.IIcon
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.util.getResourceColor
 import eu.kanade.tachiyomi.util.gone
 import eu.kanade.tachiyomi.util.visible
@@ -46,8 +48,9 @@ class StateImageViewTarget(view: ImageView,
         progress?.gone()
         view.scaleType = errorScaleType
 
-        view.setImageDrawable(IconicsDrawable(view.context).icon(errorIconic).sizeDp(24)
-                .color(view.context.getResourceColor(android.R.attr.textColorSecondary)))
+        view.setImageDrawable(IconicsDrawable(view.context)
+                .icon(errorIconic).sizeDp(24)
+                .colorInt(view.context.getResourceColor(android.R.attr.textColorSecondary)))
     }
 
     override fun onLoadCleared(placeholder: Drawable?) {

--- a/app/src/main/java/eu/kanade/tachiyomi/widget/preference/LoginCheckBoxPreference.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/widget/preference/LoginCheckBoxPreference.kt
@@ -6,8 +6,10 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
 import android.util.AttributeSet
 import android.view.View
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.source.online.HttpSource
 import kotlinx.android.synthetic.main.pref_item_source.view.*
@@ -35,7 +37,11 @@ class LoginCheckBoxPreference @JvmOverloads constructor(
         else
             ContextCompat.getColor(context, R.color.material_blue_grey_300)
 
-        holder.itemView.login.setImageDrawable(IconicsDrawable(context).icon(CommunityMaterial.Icon.cmd_account_circle).sizeDp(24).color(color))
+        holder.itemView.login
+                .setImageDrawable(IconicsDrawable(context)
+                        .icon(CommunityMaterial.Icon.cmd_account_circle)
+                        .sizeDp(24)
+                        .colorInt(color))
 
         loginFrame.visibility = View.VISIBLE
         loginFrame.setOnClickListener {

--- a/app/src/main/java/eu/kanade/tachiyomi/widget/preference/LoginPreference.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/widget/preference/LoginPreference.kt
@@ -5,8 +5,10 @@ import androidx.core.content.ContextCompat
 import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
 import android.util.AttributeSet
-import com.mikepenz.community_material_typeface_library.CommunityMaterial
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import eu.kanade.tachiyomi.R
 import kotlinx.android.synthetic.main.pref_widget_imageview.view.*
 
@@ -25,7 +27,9 @@ class LoginPreference @JvmOverloads constructor(context: Context, attrs: Attribu
             holder.itemView.image_view.setImageResource(android.R.color.transparent)
         } else {
             holder.itemView.image_view.setImageDrawable(IconicsDrawable(context)
-                    .icon(CommunityMaterial.Icon.cmd_check).color(ContextCompat.getColor(context, R.color.md_green_500)).sizeDp(20))
+                    .icon(CommunityMaterial.Icon.cmd_check)
+                    .colorInt(ContextCompat.getColor(context, R.color.md_green_500))
+                    .sizeDp(20))
 
         }
     }


### PR DESCRIPTION
Closes #99 .

Some refactoring has been done in order to upgrade to the new version of Android-Iconics so some method calls have been changed. 

Also, I removed the reflection usage in the `PageIndicatorTextView `which was used to create an outlining effect for the text. An alternative was to use a span object that creates the outline and set it in the `setText` method.