### PR TITLE
Fix unclickable filter header when stickied

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/filter/GroupItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/filter/GroupItem.kt
@@ -49,7 +49,7 @@ class GroupItem(val filter: Filter.Group<*>) : AbstractExpandableHeaderItem<Grou
                         .colorInt(Color.WHITE)
                         .sizeDp(16))
 
-        holder.itemView.setOnClickListener(holder)
+        holder.contentView.setOnClickListener(holder)
 
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/filter/SortGroup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/filter/SortGroup.kt
@@ -45,7 +45,7 @@ class SortGroup(val filter: Filter.Sort) : AbstractExpandableHeaderItem<SortGrou
                         .icon(icon)
                         .colorInt(Color.WHITE).sizeDp(16))
 
-        holder.itemView.setOnClickListener(holder)
+        holder.contentView.setOnClickListener(holder)
 
     }
 


### PR DESCRIPTION
Closes #67 

Seems like the FlexibleAdapter lib uses the contentView onClick rather than the itemView's onClick when the header item becomes stickied.