### PR TITLE
Use low quality covers if enabled in Follows and Related

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FollowsHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FollowsHandler.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.source.online.handlers
 
 import eu.kanade.tachiyomi.data.database.models.Track
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.track.TrackManager
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
@@ -25,8 +26,11 @@ import okhttp3.Request
 import okhttp3.Response
 import rx.Observable
 import timber.log.Timber
+import uy.kohesive.injekt.injectLazy
 
 class FollowsHandler(val client: OkHttpClient, val headers: Headers) {
+
+    private val preferences: PreferencesHelper by injectLazy()
 
     /**
      * fetch follows by page
@@ -94,8 +98,8 @@ class FollowsHandler(val client: OkHttpClient, val headers: Headers) {
     private fun followFromElement(result: Result): SManga {
         val manga = SManga.create()
         manga.title = MdUtil.cleanString(result.title)
-        manga.thumbnail_url = "${MdUtil.cdnUrl}/images/manga/${result.manga_id}.jpg"
         manga.url = "/manga/${result.manga_id}/"
+        manga.thumbnail_url = MdUtil.formThumbUrl(manga.url, preferences.lowQualityCovers())
         manga.follow_status = FollowStatus.fromInt(result.follow_type)
         return manga
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/RelatedHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/RelatedHandler.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.source.online.handlers
 
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.utils.MdUtil
@@ -9,8 +10,11 @@ import org.json.JSONArray
 import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import uy.kohesive.injekt.injectLazy
 
 class RelatedHandler {
+
+    private val preferences: PreferencesHelper by injectLazy()
 
     /**
      * fetch our related mangas
@@ -18,11 +22,11 @@ class RelatedHandler {
     fun fetchRelated(manga: Manga): Observable<MangasPage> {
 
         // Parse the Mangadex id from the URL
-        var mangaid = MdUtil.getMangaId(manga.url).toLong()
+        val mangaid = MdUtil.getMangaId(manga.url).toLong()
 
         // Get our current database
-        var db = Injekt.get<DatabaseHelper>()
-        var relatedMangasDb = db.getRelated(mangaid).executeAsBlocking()
+        val db = Injekt.get<DatabaseHelper>()
+        val relatedMangasDb = db.getRelated(mangaid).executeAsBlocking()
 
         // Check if we have a result
         if (relatedMangasDb == null) {
@@ -30,15 +34,15 @@ class RelatedHandler {
         }
 
         // Loop through and create a manga for each match
-        var relatedMangaTitles = JSONArray(relatedMangasDb.matched_titles)
-        var relatedMangaIds = JSONArray(relatedMangasDb.matched_ids)
-        var relatedMangas = mutableListOf<SManga>()
+        val relatedMangaTitles = JSONArray(relatedMangasDb.matched_titles)
+        val relatedMangaIds = JSONArray(relatedMangasDb.matched_ids)
+        val relatedMangas = mutableListOf<SManga>()
         for (i in 0 until relatedMangaIds.length()) {
             val matchedManga = SManga.create()
             val id = relatedMangaIds.getLong(i)
             matchedManga.title = relatedMangaTitles.getString(i)
-            matchedManga.thumbnail_url = "${MdUtil.cdnUrl}/images/manga/$id.jpg"
             matchedManga.url = "/manga/$id/"
+            matchedManga.thumbnail_url = MdUtil.formThumbUrl(matchedManga.url, preferences.lowQualityCovers())
             relatedMangas.add(matchedManga)
         }
 


### PR DESCRIPTION
Use the preferences to load the low quality covers if enabled.
Also change this in the Follow handler.
Should allow for use of the same cache file instead of pulling a new image down?