### PR TITLE
Better image cache handling and improved cover update in background

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/CoverCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/CoverCache.kt
@@ -20,7 +20,7 @@ class CoverCache(private val context: Context) {
     /**
      * Cache directory used for cache management.
      */
-    private val cacheDir = context.getExternalFilesDir("covers")
+    val cacheDir = context.getExternalFilesDir("covers")
             ?: File(context.filesDir, "covers").also { it.mkdirs() }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
@@ -26,7 +26,7 @@ class ApiMangaParser(val lang: String) {
             val networkApiManga = Json.nonstrict.parse(ApiMangaSerializer.serializer(), jsonData)
             val networkManga = networkApiManga.manga
             manga.title = MdUtil.cleanString(networkManga.title)
-            manga.thumbnail_url = MdUtil.cdnUrl + networkManga.cover_url
+            manga.thumbnail_url = MdUtil.cdnUrl + MdUtil.removeTimeParamUrl(networkManga.cover_url)
             manga.description = MdUtil.cleanString(networkManga.description)
             manga.author = networkManga.author
             manga.artist = networkManga.artist

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/RelatedHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/RelatedHandler.kt
@@ -30,15 +30,17 @@ class RelatedHandler {
         }
 
         // Loop through and create a manga for each match
-        var relatedMangaTitles = JSONArray(relatedMangasDb.matched_titles)
-        var relatedMangaIds = JSONArray(relatedMangasDb.matched_ids)
-        var relatedMangas = mutableListOf<SManga>()
+        // Note: we say this is not initialized so the browser presenter can load it
+        // Note: the browser presenter will load the one from db or pull the latest details
+        val relatedMangaTitles = JSONArray(relatedMangasDb.matched_titles)
+        val relatedMangaIds = JSONArray(relatedMangasDb.matched_ids)
+        val relatedMangas = mutableListOf<SManga>()
         for (i in 0 until relatedMangaIds.length()) {
             val matchedManga = SManga.create()
             val id = relatedMangaIds.getLong(i)
             matchedManga.title = relatedMangaTitles.getString(i)
-            matchedManga.thumbnail_url = "${MdUtil.cdnUrl}/images/manga/$id.jpg"
             matchedManga.url = "/manga/$id/"
+            matchedManga.initialized = false
             relatedMangas.add(matchedManga)
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/utils/MdUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/utils/MdUtil.kt
@@ -39,11 +39,7 @@ class MdUtil {
         fun modifyMangaUrl(url: String): String = url.replace("/title/", "/manga/").substringBeforeLast("/") + "/"
 
         // Removes the ?timestamp from image urls
-        fun removeTimeParamUrl(url: String): String {
-            val index = url.indexOf("?")
-            return if (index < 0) url
-            else url.substring(0, index)
-        }
+        fun removeTimeParamUrl(url: String): String = url.substringBeforeLast("?")
 
         fun cleanString(string: String): String {
             val bbRegex = """\[(\w+)[^]]*](.*?)\[/\1]""".toRegex()

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/utils/MdUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/utils/MdUtil.kt
@@ -38,6 +38,13 @@ class MdUtil {
         // creates the manga url from the browse for the api
         fun modifyMangaUrl(url: String): String = url.replace("/title/", "/manga/").substringBeforeLast("/") + "/"
 
+        // Removes the ?timestamp from image urls
+        fun removeTimeParamUrl(url: String): String {
+            val index = url.indexOf("?")
+            return if (index < 0) url
+            else url.substring(0, index)
+        }
+
         fun cleanString(string: String): String {
             val bbRegex = """\[(\w+)[^]]*](.*?)\[/\1]""".toRegex()
             var intermediate = string

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCatalogueController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCatalogueController.kt
@@ -504,7 +504,6 @@ open class BrowseCatalogueController(bundle: Bundle) :
      */
     override fun onItemClick(view: View, position: Int): Boolean {
         val item = adapter?.getItem(position) as? CatalogueItem ?: return false
-        item.manga.initialized = false
 
         // We should check if the parent is the base controller
         // If it is, then we are in a nested view, thus we should append

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryGridHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryGridHolder.kt
@@ -60,7 +60,7 @@ class LibraryGridHolder(
             text = badge.toSpannable()
         }
 
-// Update the cover.
+        // Update the cover.
         GlideApp.with(view.context)
             .load(item.manga)
             .diskCacheStrategy(DiskCacheStrategy.RESOURCE)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsAdvancedController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsAdvancedController.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.ui.setting
 
 import android.app.Dialog
 import android.os.Bundle
+import android.text.format.Formatter
 import android.widget.Toast
 import androidx.preference.PreferenceScreen
 import com.afollestad.materialdialogs.MaterialDialog
@@ -9,14 +10,17 @@ import com.bluelinelabs.conductor.RouterTransaction
 import com.bluelinelabs.conductor.changehandler.FadeChangeHandler
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.cache.ChapterCache
+import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.glide.GlideApp
 import eu.kanade.tachiyomi.data.library.LibraryUpdateService
 import eu.kanade.tachiyomi.data.library.LibraryUpdateService.Target
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.ui.base.controller.DialogController
 import eu.kanade.tachiyomi.ui.library.LibraryController
+import eu.kanade.tachiyomi.util.DiskUtil
 import eu.kanade.tachiyomi.util.launchUI
 import eu.kanade.tachiyomi.util.toast
 import kotlinx.coroutines.CoroutineStart
@@ -37,6 +41,8 @@ class SettingsAdvancedController : SettingsController() {
 
     private val chapterCache: ChapterCache by injectLazy()
 
+    private val coverCache: CoverCache by injectLazy()
+
     private val db: DatabaseHelper by injectLazy()
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) = with(screen) {
@@ -48,6 +54,13 @@ class SettingsAdvancedController : SettingsController() {
             summary = context.getString(R.string.used_cache, chapterCache.readableSize)
 
             onClick { clearChapterCache() }
+        }
+        preference {
+            key = CLEAR_CACHE_IMAGES_KEY
+            titleRes = R.string.pref_clear_image_cache
+            summary = context.getString(R.string.used_cache, getChaperCacheSize())
+
+            onClick { clearImageCache() }
         }
         preference {
             titleRes = R.string.pref_clear_cookies
@@ -110,12 +123,57 @@ class SettingsAdvancedController : SettingsController() {
         }
     }
 
+    private fun getChaperCacheSize(): String {
+        val dirCache = GlideApp.getPhotoCacheDir(activity!!)
+        val realSize1 = DiskUtil.getDirectorySize(dirCache!!)
+        val realSize2 = DiskUtil.getDirectorySize(coverCache.cacheDir)
+        return Formatter.formatFileSize(activity!!, realSize1 + realSize2)
+    }
+
+    private fun clearImageCache() {
+        if (activity == null) return
+
+        // Clear the glide disk cache for our chapters
+        // Note: small hack since we require the glide clear to be in a background thread
+        // https://stackoverflow.com/a/46292711
+        val thread = Thread(Runnable {
+            GlideApp.get(activity!!).clearDiskCache()
+        })
+        thread.start()
+        GlideApp.get(activity!!).clearMemory()
+        thread.join()
+
+        // Delete all files from the image cache folder
+        val files = coverCache.cacheDir.listFiles() ?: return
+        var deletedFiles = 0
+        Observable.defer { Observable.from(files) }
+                .doOnNext { file ->
+                    if (file.delete()) {
+                        deletedFiles++
+                    }
+                }
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                }, {
+                    activity?.toast(R.string.cache_delete_error)
+                }, {
+                    activity?.toast(
+                            resources?.getQuantityString(
+                                    R.plurals.cache_deleted,
+                                    deletedFiles, deletedFiles
+                            )
+                    )
+                    findPreference(CLEAR_CACHE_IMAGES_KEY)?.summary =
+                            resources?.getString(R.string.used_cache, getChaperCacheSize())
+                })
+    }
+
     private fun clearChapterCache() {
         if (activity == null) return
+
         val files = chapterCache.cacheDir.listFiles() ?: return
-
         var deletedFiles = 0
-
         Observable.defer { Observable.from(files) }
             .doOnNext { file ->
                 if (chapterCache.removeFileFromCache(file.name)) {
@@ -164,6 +222,7 @@ class SettingsAdvancedController : SettingsController() {
 
     private companion object {
         const val CLEAR_CACHE_KEY = "pref_clear_cache_key"
+        const val CLEAR_CACHE_IMAGES_KEY = "pref_clear_cache_images_key"
 
         private var job: Job? = null
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -314,6 +314,7 @@
 
     <!-- Advanced section -->
     <string name="pref_clear_chapter_cache">Clear chapter cache</string>
+    <string name="pref_clear_image_cache">Clear image cover cache</string>
     <string name="used_cache">Used: %1$s</string>
     <plurals name="cache_deleted">
         <item quantity="one">Cache cleared. %d file has been deleted</item>


### PR DESCRIPTION
- Cover cache should be preloaded when we are pulling updates
- Added advance option to clear this cache and see its size
- Remove time param from url so cache remains valid for longer
- Properly get related manga image urls and correctly record if they are initialized

This seems to reduce the number of network calls that where happening. With this if you don't pull a manual update and all related manga are loaded, then no network calls are made (as expected if everything is loaded from cache/database). This should make offline / poor network browsing a lot better experience.