### PR TITLE
Remove unused "rest of the world" server

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/Mangadex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/Mangadex.kt
@@ -241,7 +241,7 @@ open class Mangadex(
         private const val ONLY_R18 = 2
         private const val REMEMBER_ME = "mangadex_rememberme_token"
 
-        val SERVER_PREF_ENTRIES = listOf("Automatic", "NA/EU 1", "NA/EU 2", "Rest of the world")
-        val SERVER_PREF_ENTRY_VALUES = listOf("0", "na", "na2", "row")
+        val SERVER_PREF_ENTRIES = listOf("Automatic", "NA/EU 1", "NA/EU 2")
+        val SERVER_PREF_ENTRY_VALUES = listOf("0", "na", "na2")
     }
 }


### PR DESCRIPTION
Doesn't seem to be available any more based on the dropdown on the website and their dns A records (s2 = na, and s5 = na2).
![image](https://user-images.githubusercontent.com/2222562/76548747-9dcaa780-6465-11ea-8138-4865ad688f1e.png)
