### PR TITLE
Fix - thumbnail url parsing on browse/search/follow pages

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FollowsHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FollowsHandler.kt
@@ -102,8 +102,8 @@ class FollowsHandler(val client: OkHttpClient, val headers: Headers) {
         val manga = SManga.create()
         manga.title = MdUtil.cleanString(result.title)
         manga.url = "/manga/${result.manga_id}/"
-        manga.thumbnail_url = MdUtil.formThumbUrl(manga.url, preferences.lowQualityCovers())
         manga.follow_status = FollowStatus.fromInt(result.follow_type)
+        manga.initialized = false
         return manga
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/PopularHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/PopularHandler.kt
@@ -53,8 +53,18 @@ class PopularHandler(val client: OkHttpClient, private val headers: Headers) {
             manga.setUrlWithoutDomain(url)
             manga.title = it.text().trim()
         }
-        manga.thumbnail_url = MdUtil.formThumbUrl(manga.url, preferences.lowQualityCovers())
-
+        // For our image, the file endings are not very consistent
+        // Thus we should try to parse the full image from the website
+        // If we can't find it then we will construct a guess of the image url
+        element.select("div.large_logo").first().let {
+            val elementImg = it.selectFirst("img")
+            if(elementImg != null) {
+                val urlClean = MdUtil.removeTimeParamUrl(elementImg.absUrl("src"))
+                manga.thumbnail_url = MdUtil.convertThumbUrlIfNeeded(urlClean, preferences.lowQualityCovers())
+            } else {
+                manga.thumbnail_url = MdUtil.formThumbUrl(manga.url, preferences.lowQualityCovers())
+            }
+        }
         return manga
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/utils/MdUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/utils/MdUtil.kt
@@ -59,12 +59,18 @@ class MdUtil {
         // guess the thumbnail url is .jpg  this has a ~80% success rate
         fun formThumbUrl(mangaUrl: String, lowQuality: Boolean): String {
             var ext = ".jpg"
-
             if (lowQuality) {
                 ext = ".thumb$ext"
             }
-
             return cdnUrl + "/images/manga/" + getMangaId(mangaUrl) + ext
+        }
+
+        // will change from large to thumbnail size images if needed
+        fun convertThumbUrlIfNeeded(thumbUrl: String, lowQuality: Boolean): String {
+            if (lowQuality) {
+                return thumbUrl.replace(".large.",".thumb.")
+            }
+            return thumbUrl.replace(".thumb.",".large.")
         }
 
         // Get the ID from the manga url


### PR DESCRIPTION
Key changes:
- Will try to parse the thumbnail url
- These will be .large.ext images by default which are smaller then the full .ext images
- If using small thumbnails, then it will substitute .large.ext -> .thumb.ext
- Normally no images should fail to load due to this
