### PR TITLE
Gzip Similar and Fixed Image Url

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/similar/SimilarHttpService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/similar/SimilarHttpService.kt
@@ -4,6 +4,7 @@ import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFact
 import eu.kanade.tachiyomi.network.NetworkHelper
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Call
 import retrofit2.Retrofit
@@ -14,17 +15,32 @@ import uy.kohesive.injekt.api.get
 interface SimilarHttpService {
     companion object {
         fun create(): SimilarHttpService {
+
+            // unzip interceptor which will add the correct headers
+            val unzipInterceptor = Interceptor {
+                val res = it.proceed(it.request())
+                res.newBuilder()
+                    .header("Content-Encoding", "gzip")
+                    .header("Content-Type", "application/json")
+                    .build()
+            }
+
+            // actual builder, which will parse the underlying json file
             val contentType = "application/json".toMediaType()
             val restAdapter = Retrofit.Builder()
                 .baseUrl("https://github.com")
                 .addConverterFactory(Json.asConverterFactory(contentType))
-                .client(Injekt.get<NetworkHelper>().client)
+                .client(
+                    Injekt.get<NetworkHelper>().client
+                    .newBuilder()
+                    .addNetworkInterceptor(unzipInterceptor)
+                    .build()
+                )
                 .build()
-
             return restAdapter.create(SimilarHttpService::class.java)
         }
     }
 
-    @GET("/goldbattle/MangadexRecomendations/releases/download/v1.0.0/mangas_compressed.json")
+    @GET("/goldbattle/MangadexRecomendations/releases/download/v1.0.0/mangas_compressed.json.gz")
     fun getSimilarResults(): Call<JsonObject>
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt
@@ -43,7 +43,7 @@ class SimilarHandler(val preferences: PreferencesHelper) {
             val id = similarMangaIds.getLong(i)
             matchedManga.title = similarMangaTitles.getString(i)
             matchedManga.url = "/manga/$id/"
-            manga.thumbnail_url = MdUtil.formThumbUrl(manga.url, lowQualityCovers)
+            matchedManga.thumbnail_url = MdUtil.formThumbUrl(matchedManga.url, lowQualityCovers)
             similarMangas.add(matchedManga)
         }
 


### PR DESCRIPTION
Now this will download a json.gz file instead of the standard json. Also fixed a copy paste error which wasn't setting the url correctly for the `matchedManga` object. Now the similar page will only load the images, and when the user clicks through it will load the manga details.