### PR TITLE
Open mangadex chapter links in Neko

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,31 @@
         </activity>
         <activity
             android:name=".ui.reader.ReaderActivity"
-            android:theme="@style/Theme.Tachiyomi" />
+            android:theme="@style/Theme.Splash" >
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="www.mangadex.org"
+                    android:pathPattern="/chapter/..*" />
+                <data
+                    android:scheme="https"
+                    android:host="mangadex.org"
+                    android:pathPattern="/chapter/..*" />
+                <data
+                    android:scheme="https"
+                    android:host="www.mangadex.cc"
+                    android:pathPattern="/chapter/..*" />
+                <data
+                    android:scheme="https"
+                    android:host="mangadex.cc"
+                    android:pathPattern="/chapter/..*" />
+            </intent-filter>
+        </activity>
         <activity
             android:name=".ui.webview.WebViewActivity"
             android:configChanges="uiMode|orientation|screenSize" />

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
@@ -57,6 +57,15 @@ interface MangaQueries : DbProvider {
                     .build())
             .prepare()
 
+    fun getMangadexManga(url: String) = db.get()
+            .`object`(Manga::class.java)
+            .withQuery(Query.builder()
+                    .table(MangaTable.TABLE)
+                    .where("${MangaTable.COL_URL} = ?")
+                    .whereArgs(url)
+                    .build())
+            .prepare()
+
     fun getManga(id: Long) = db.get()
             .`object`(Manga::class.java)
             .withQuery(Query.builder()

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
@@ -10,11 +10,7 @@ import java.security.MessageDigest
 open class SourceManager {
 
     // private val sourcesMap = mutableMapOf<Long, Source>()
-    private val source: Source
-
-    init {
-        source = MangaDex()
-    }
+    private val source: MangaDex = MangaDex()
 
     open fun get(sourceKey: Long): Source? {
         return source

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDex.kt
@@ -127,6 +127,10 @@ open class MangaDex() : HttpSource() {
         ).fetchChapterListObservable(manga)
     }
 
+    suspend fun getMangaIdFromChapterId(urlChapterId: String): Int {
+        return MangaHandler(clientBuilder(), headers, getLangsToShow()).getMangaIdFromChapterId(urlChapterId)
+    }
+
     override suspend fun fetchChapterList(manga: SManga): List<SChapter> {
         return MangaHandler(clientBuilder(), headers, getLangsToShow()).fetchChapterList(manga)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
@@ -1,5 +1,9 @@
 package eu.kanade.tachiyomi.source.online.handlers
 
+import android.util.JsonReader
+import com.github.salomonbrys.kotson.nullInt
+import com.github.salomonbrys.kotson.obj
+import com.google.gson.JsonParser
 import eu.kanade.tachiyomi.network.consumeBody
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
@@ -171,6 +175,22 @@ class ApiMangaParser(val langs: List<String>) {
         }
 
         return chapters
+    }
+
+    fun chapterParseForMangaId(response: Response): Int {
+        try {
+            if (response.code != 200) throw Exception("HTTP error ${response.code}")
+            val body = response.body?.string().orEmpty()
+            if (body.isEmpty()) {
+                throw Exception("Null Response")
+            }
+
+            val jsonObject = JsonParser.parseString(body).obj
+            return jsonObject["manga_id"]?.nullInt ?: throw Exception("No manga associated with chapter")
+        } catch (e: Exception) {
+            Timber.e(e)
+            throw e
+        }
     }
 
     private fun mapChapter(

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/MangaHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/MangaHandler.kt
@@ -32,6 +32,14 @@ class MangaHandler(val client: OkHttpClient, val headers: Headers, val langs: Li
         }
     }
 
+    suspend fun getMangaIdFromChapterId(urlChapterId: String): Int {
+        return withContext(Dispatchers.IO) {
+            val request = GET(MdUtil.baseUrl + MdUtil.apiChapter + urlChapterId + MdUtil.apiChapterSuffix, headers, CacheControl.FORCE_NETWORK)
+            val response = client.newCall(request).execute()
+            ApiMangaParser(langs).chapterParseForMangaId(response)
+        }
+    }
+
     suspend fun fetchMangaDetails(manga: SManga): SManga {
         return withContext(Dispatchers.IO) {
             val response = client.newCall(apiRequest(manga)).execute()

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/DatabaseExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/DatabaseExtensions.kt
@@ -7,18 +7,10 @@ import com.pushtorefresh.storio.sqlite.operations.put.PreparedPutObject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-suspend fun <T> PreparedGetListOfObjects<T>.executeOnIO(): List<T> {
-    return withContext(Dispatchers.IO) { executeAsBlocking() }
-}
+suspend fun <T> PreparedGetListOfObjects<T>.executeOnIO(): List<T> = withContext(Dispatchers.IO) { executeAsBlocking() }
 
-suspend fun <T> PreparedGetObject<T>.executeOnIO(): T? {
-    return withContext(Dispatchers.IO) { executeAsBlocking() }
-}
+suspend fun <T> PreparedGetObject<T>.executeOnIO(): T? = withContext(Dispatchers.IO) { executeAsBlocking() }
 
-suspend fun <T> PreparedPutObject<T>.executeOnIO() {
-    withContext(Dispatchers.IO) { executeAsBlocking() }
-}
+suspend fun <T> PreparedPutObject<T>.executeOnIO() = withContext(Dispatchers.IO) { executeAsBlocking() }
 
-suspend fun <T> PreparedPutCollectionOfObjects<T>.executeOnIO() {
-    withContext(Dispatchers.IO) { executeAsBlocking() }
-}
+suspend fun <T> PreparedPutCollectionOfObjects<T>.executeOnIO() = withContext(Dispatchers.IO) { executeAsBlocking() }

--- a/app/src/main/res/layout/reader_activity.xml
+++ b/app/src/main/res/layout/reader_activity.xml
@@ -38,7 +38,8 @@
     <FrameLayout
         android:id="@+id/reader_menu"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:visibility="gone" >
 
         <FrameLayout
             android:id="@+id/appbar"


### PR DESCRIPTION
Some notes:

- The app will first check for the chapter in the db, and if not it will called the chapter api, get the manga id then fetch the manga/chapter from the api
- I added the same logic as I did with search activity, where pressing back takes you back to the you were in before, and pressing the up button in the toolbar takes you back to main activity, let me know if you want something different
- Because there isn't a way to filter out certain urls with /chapter/, I'm taking the github app approach: If the url clicked is /chapter/#/comments a custom tab is opened. It has to be a custom tab instead of regular browser since neko is handling those links now. 
- Side note to this: there's additional logic added to opening the custom tab so the app doesn't end up in an infinite intent loop, however if you rather it open those links in the webview instead that can be done.