### PR TITLE
Recs Load from Disk

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/similar/SimilarUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/similar/SimilarUpdateJob.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.data.similar
 
+import android.net.Uri
 import android.content.Context
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -7,6 +8,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
+import androidx.work.Data
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
@@ -19,7 +21,8 @@ class SimilarUpdateJob(private val context: Context, workerParams: WorkerParamet
     Worker(context, workerParams) {
 
     override fun doWork(): Result {
-        SimilarUpdateService.start(context)
+        val localFile =  inputData.getString("localFile")
+        SimilarUpdateService.start(context, localFile)
         return Result.success()
     }
 
@@ -69,5 +72,14 @@ class SimilarUpdateJob(private val context: Context, workerParams: WorkerParamet
         fun doWorkNow() {
             WorkManager.getInstance().enqueue(OneTimeWorkRequestBuilder<SimilarUpdateJob>().build())
         }
+
+        fun doWorkNowLocal(localFile: Uri) {
+            val data = Data.Builder()
+            data.putString("localFile", localFile.toString())
+            val work = OneTimeWorkRequestBuilder<SimilarUpdateJob>()
+            work.setInputData(data.build())
+            WorkManager.getInstance().enqueue(work.build())
+        }
+
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsSimilarController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsSimilarController.kt
@@ -1,10 +1,13 @@
 package eu.kanade.tachiyomi.ui.setting
 
+import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import androidx.core.net.toUri
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.similar.SimilarUpdateJob
+import eu.kanade.tachiyomi.util.system.getFilePicker
 import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.data.preference.PreferenceKeys as Keys
 
@@ -67,6 +70,21 @@ class SettingsSimilarController : SettingsController() {
         }
 
         preference {
+            titleRes = R.string.similar_from_file
+            summary = context.resources.getString(R.string.similar_from_file_message)
+            onClick {
+                val chooseFile = Intent(Intent.ACTION_GET_CONTENT)
+                chooseFile.type = "*/*"
+                val intent = Intent.createChooser(chooseFile, "Choose a file")
+                try {
+                    startActivityForResult(intent, RELATED_FILE_PATH_L)
+                } catch (e: ActivityNotFoundException) {
+                    startActivityForResult(preferences.context.getFilePicker("/"), RELATED_FILE_PATH_L)
+                }
+            }
+        }
+
+        preference {
             title = "Credits"
             val url = "https://github.com/goldbattle/MangadexRecomendations"
             summary = context.resources.getString(R.string.similar_credit_message, url)
@@ -77,4 +95,27 @@ class SettingsSimilarController : SettingsController() {
             isIconSpaceReserved = true
         }
     }
+
+    /**
+     * This function is the callback from our file listing activity.
+     */
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        when (requestCode) {
+            RELATED_FILE_PATH_L -> if (data != null && resultCode == Activity.RESULT_OK) {
+                val context = applicationContext ?: return
+                val selectedFile = data.data
+                if (selectedFile != null) {
+                    SimilarUpdateJob.doWorkNowLocal(selectedFile)
+                    context.toast(R.string.similar_manually_toast)
+                } else {
+                    context.toast(R.string.similar_loading_complete_error)
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val RELATED_FILE_PATH_L = 105
+    }
+
 }

--- a/app/src/main/res/values/strings_neko.xml
+++ b/app/src/main/res/values/strings_neko.xml
@@ -77,6 +77,11 @@
         Download the latest similar manga database.
         This is around 9MB in size and is updated daily.
     </string>
+    <string name="similar_from_file">Load database from file</string>
+    <string name="similar_from_file_message">
+        Load a local JSON file from disk.
+        Use this if the network download isn\'t working.
+    </string>
     <string name="similar_update_fequency">Similar update frequency</string>
     <string name="similar_loading_percent">Updating similar manga (%1$d / %2$d updated)</string>
     <string name="similar_loading_complete">Updating similar manga complete</string>


### PR DESCRIPTION
Added support for loading of a .json recommendation file from disk.
Useful for debugging / testing with variations of the recommendation databases.

I am not sure if there is a cleaner way to get the file URI into the intent.
Right now I pass it through the `setInputData` function.