### PR TITLE
Change Similar Manga Settings layout

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsSimilarController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsSimilarController.kt
@@ -17,7 +17,6 @@ class SettingsSimilarController : SettingsController() {
         titleRes = R.string.similar_settings
 
         preference {
-            titleRes = R.string.similar_screen
             summary = context.resources.getString(R.string.similar_screen_summary_message)
             isIconSpaceReserved = true
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsSimilarController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsSimilarController.kt
@@ -85,7 +85,7 @@ class SettingsSimilarController : SettingsController() {
         }
 
         preference {
-            title = "Credits"
+            titleRes = R.string.similar_credit_title
             val url = "https://github.com/goldbattle/MangadexRecomendations"
             summary = context.resources.getString(R.string.similar_credit_message, url)
             onClick {
@@ -117,5 +117,4 @@ class SettingsSimilarController : SettingsController() {
     private companion object {
         const val RELATED_FILE_PATH_L = 105
     }
-
 }

--- a/app/src/main/res/values/strings_neko.xml
+++ b/app/src/main/res/values/strings_neko.xml
@@ -93,6 +93,7 @@
         demographics, content type, themes, and then using term frequency–inverse document frequency (tf–idf) to get the
         similarity of two manga\'s descriptions. When enabled this file will download immediately!! The file is about 9 MB in size.
     </string>
+    <string name="similar_credit_title">Credits</string>
     <string name="similar_credit_message">
         For more information and to view the source code:\n%s
     </string>


### PR DESCRIPTION
This PR makes two changes to the Similar Manga Settings layout

Two changes made are:
1. Remove redundant R.string.similar_screen text from the settings
2. Replace the "Credits" string with a new appropriate element in strings_sy.xml, aiding complete translation


| before | after |
|----------|--------|
| ![Screenshot_1614514772](https://user-images.githubusercontent.com/72807749/109421614-20919d00-79fe-11eb-9772-caff116d7fe2.png) | ![Screenshot_1614520061](https://user-images.githubusercontent.com/72807749/109421616-225b6080-79fe-11eb-8a03-d89732e62c43.png) |
