### PR TITLE
Add cache mangadex option toggle to allow for merging / browsing of similar

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/models/BackupManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/models/BackupManga.kt
@@ -36,6 +36,7 @@ data class BackupManga(
     @ProtoNumber(102) var history: List<BackupHistory> = emptyList(),
     // Neko Values
     @ProtoNumber(900) var mergedMangaUrl: String? = null,
+    @ProtoNumber(902) var mergedMangaImageUrl: String? = null,
     @ProtoNumber(901) var scanlatorFilter: String? = null
 ) {
     fun getMangaImpl(): MangaImpl {
@@ -54,6 +55,7 @@ data class BackupManga(
             viewer = this@BackupManga.viewer
             chapter_flags = this@BackupManga.chapterFlags
             merge_manga_url = this@BackupManga.mergedMangaUrl
+            merge_manga_image_url = this@BackupManga.mergedMangaImageUrl
             scanlator_filter = this@BackupManga.scanlatorFilter
         }
     }
@@ -87,6 +89,7 @@ data class BackupManga(
                 viewer = manga.viewer,
                 chapterFlags = manga.chapter_flags,
                 mergedMangaUrl = manga.merge_manga_url,
+                mergedMangaImageUrl = manga.merge_manga_image_url,
                 scanlatorFilter = manga.scanlator_filter,
             )
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenCallback.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenCallback.kt
@@ -21,7 +21,7 @@ class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
         /**
          * Version of the database.
          */
-        const val DATABASE_VERSION = 22
+        const val DATABASE_VERSION = 23
     }
 
     override fun onCreate(db: SupportSQLiteDatabase) = with(db) {
@@ -92,6 +92,9 @@ class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
         }
         if (oldVersion < 22) {
             db.execSQL(MangaTable.addNextUpdateCol)
+        }
+        if (oldVersion < 23) {
+            db.execSQL(MangaTable.addMergeMangaImageCol)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/mappers/MangaTypeMapping.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/mappers/MangaTypeMapping.kt
@@ -30,6 +30,7 @@ import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_LAST_UPDATE
 import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_NEXT_UPDATE
 import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_MANGA_LAST_CHAPTER
 import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_MANGA_UPDATES_ID
+import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_MERGE_MANGA_IMAGE_URL
 import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_MERGE_MANGA_URL
 import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_MISSING_CHAPTERS
 import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_MY_ANIME_LIST_ID
@@ -63,7 +64,7 @@ class MangaPutResolver : DefaultPutResolver<Manga>() {
         .whereArgs(obj.id)
         .build()
 
-    override fun mapToContentValues(obj: Manga) = ContentValues(15).apply {
+    override fun mapToContentValues(obj: Manga) = ContentValues(16).apply {
         put(COL_ID, obj.id)
         put(COL_SOURCE, obj.source)
         put(COL_URL, obj.url)
@@ -95,6 +96,7 @@ class MangaPutResolver : DefaultPutResolver<Manga>() {
         put(COL_USERS, obj.users)
         put(COL_MERGE_MANGA_URL, obj.merge_manga_url)
         put(COL_MANGA_LAST_CHAPTER, obj.last_chapter_number)
+        put(COL_MERGE_MANGA_IMAGE_URL, obj.merge_manga_image_url)
     }
 }
 
@@ -131,6 +133,7 @@ interface BaseMangaGetResolver {
         last_chapter_number = cursor.getIntOrNull(cursor.getColumnIndex(COL_MANGA_LAST_CHAPTER))
         follow_status =
             cursor.getInt(cursor.getColumnIndex(COL_FOLLOW_STATUS)).let { FollowStatus.fromInt(it) }
+        merge_manga_image_url = cursor.getString(cursor.getColumnIndex(COL_MERGE_MANGA_IMAGE_URL))
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/MangaImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/MangaImpl.kt
@@ -105,6 +105,8 @@ open class MangaImpl : Manga {
 
     override var merge_manga_url: String? = null
 
+    override var merge_manga_image_url: String? = null
+
     override var last_chapter_number: Int? = null
 
     override fun copyFrom(other: SManga) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/ChapterQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/ChapterQueries.kt
@@ -30,6 +30,17 @@ interface ChapterQueries : DbProvider {
         )
         .prepare()
 
+    fun getChaptersByMangaId(id: Long) = db.get()
+        .listOfObjects(Chapter::class.java)
+        .withQuery(
+            Query.builder()
+                .table(ChapterTable.TABLE)
+                .where("${ChapterTable.COL_MANGA_ID} = ?")
+                .whereArgs(id)
+                .build()
+        )
+        .prepare()
+
     fun getRecentChapters(date: Date) = db.get()
         .listOfObjects(MangaChapter::class.java)
         .withQuery(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/MangaTable.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/MangaTable.kt
@@ -103,9 +103,9 @@ object MangaTable {
             $COL_RATING TEXT,
             $COL_USERS TEXT,
             $COL_MERGE_MANGA_URL TEXT,
-            $COL_MANGA_LAST_CHAPTER INTEGER,
-            $COL_FOLLOW_STATUS INTEGER,
             $COL_MERGE_MANGA_IMAGE_URL TEXT,
+            $COL_MANGA_LAST_CHAPTER INTEGER,
+            $COL_FOLLOW_STATUS INTEGER
             )"""
 
     val createUrlIndexQuery: String

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/MangaTable.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/MangaTable.kt
@@ -70,6 +70,8 @@ object MangaTable {
 
     const val COL_MANGA_LAST_CHAPTER = "manga_last_chapter"
 
+    const val COL_MERGE_MANGA_IMAGE_URL = "merge_manga_image_url"
+
     val createTableQuery: String
         get() =
             """CREATE TABLE $TABLE(
@@ -102,7 +104,8 @@ object MangaTable {
             $COL_USERS TEXT,
             $COL_MERGE_MANGA_URL TEXT,
             $COL_MANGA_LAST_CHAPTER INTEGER,
-            $COL_FOLLOW_STATUS INTEGER
+            $COL_FOLLOW_STATUS INTEGER,
+            $COL_MERGE_MANGA_IMAGE_URL TEXT,
             )"""
 
     val createUrlIndexQuery: String
@@ -156,4 +159,8 @@ object MangaTable {
 
     val addMangaLastChapter: String
         get() = "ALTER TABLE ${MangaTable.TABLE} ADD COLUMN ${MangaTable.COL_MANGA_LAST_CHAPTER} INTEGER DEFAULT NULL"
+
+    val addMergeMangaImageCol: String
+        get() = "ALTER TABLE ${MangaTable.TABLE} ADD COLUMN ${MangaTable.COL_MERGE_MANGA_IMAGE_URL} TEXT DEFAULT NULL"
+
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -302,7 +302,7 @@ class LibraryUpdateService(
             val isDexUp = sourceManager.getMangadex().checkIfUp()
 
             jobCount.andIncrement
-            if (isDexUp) {
+            if (isDexUp || preferences.useCacheSource()) {
                 val results = mangaToUpdateMap.keys.map { source ->
                     try {
                         updateMangaInSource(source, downloadNew, categoriesToDownload)
@@ -336,7 +336,7 @@ class LibraryUpdateService(
                 errorFile.getUriCompat(this)
             )
         }
-        if (isDexUp.not()) {
+        if (isDexUp.not() && !preferences.useCacheSource()) {
             notifier.showUpdateErrorNotification(
                 listOf("Skipping library update"),
                 null

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -183,9 +183,9 @@ object PreferenceKeys {
 
     const val addToLibraryAsPlannedToRead = "add_to_libray_as_planned_to_read"
 
-    const val useNewApiServer = "use_new_api_server"
-
     const val createLegacyBackup = "create_legacy_backup"
+
+    const val useCacheSource = "use_cache_source"
 
     fun sourceUsername(sourceId: Long) = "pref_source_username_$sourceId"
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -335,4 +335,6 @@ class PreferencesHelper(val context: Context) {
     fun addToLibraryAsPlannedToRead(): Boolean = prefs.getBoolean(Keys.addToLibraryAsPlannedToRead, false)
 
     fun createLegacyBackup() = flowPrefs.getBoolean(Keys.createLegacyBackup, true)
+
+    fun useCacheSource(): Boolean = prefs.getBoolean(Keys.useCacheSource, false)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
@@ -1,8 +1,11 @@
 package eu.kanade.tachiyomi.source
 
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.source.online.MangaDex
+import eu.kanade.tachiyomi.source.online.MangaDexCache
 import eu.kanade.tachiyomi.source.online.MergeSource
 import eu.kanade.tachiyomi.source.online.utils.MdLang
+import uy.kohesive.injekt.injectLazy
 import java.security.MessageDigest
 
 /**
@@ -10,8 +13,11 @@ import java.security.MessageDigest
  */
 open class SourceManager {
 
+    private val preferences: PreferencesHelper by injectLazy()
+
     // private val sourcesMap = mutableMapOf<Long, Source>()
     private val source: MangaDex = MangaDex()
+    private val sourceCache: MangaDexCache = MangaDexCache()
 
     private val mergeSource = MergeSource()
 
@@ -23,7 +29,9 @@ open class SourceManager {
         return possibleIds.contains(sourceKey)
     }
 
-    fun getMangadex() = source
+    fun getMangadex(): MangaDex {
+        return if (preferences.useCacheSource()) sourceCache else source
+    }
 
     fun getMergeSource() = mergeSource
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/model/SManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/model/SManga.kt
@@ -61,6 +61,8 @@ interface SManga : Serializable {
 
     var merge_manga_url: String?
 
+    var merge_manga_image_url: String?
+
     var last_chapter_number: Int?
 
     fun copyFrom(other: SManga) {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDex.kt
@@ -100,7 +100,7 @@ open class MangaDex() : HttpSource() {
         return FollowsHandler(clientBuilder(), headers, preferences).updateFollowStatus(mangaID, followStatus)
     }
 
-    fun fetchRandomMangaId(): Observable<String> {
+    open fun fetchRandomMangaId(): Observable<String> {
         return MangaHandler(clientBuilder(), headers, getLangsToShow()).fetchRandomMangaId()
     }
 
@@ -149,7 +149,7 @@ open class MangaDex() : HttpSource() {
         ).fetchChapterListObservable(manga)
     }
 
-    suspend fun getMangaIdFromChapterId(urlChapterId: String): Int {
+    open suspend fun getMangaIdFromChapterId(urlChapterId: String): Int {
         return MangaHandler(clientBuilder(), headers, getLangsToShow()).getMangaIdFromChapterId(urlChapterId)
     }
 
@@ -202,7 +202,7 @@ open class MangaDex() : HttpSource() {
         }
     }
 
-    fun imageRequest(page: Page): Request {
+    open fun imageRequest(page: Page): Request {
         val url = when {
             // Legacy
             page.url.isEmpty() -> page.imageUrl!!
@@ -238,11 +238,11 @@ open class MangaDex() : HttpSource() {
         return FollowsHandler(clientBuilder(), headers, preferences).fetchAllFollows(forceHd)
     }
 
-    suspend fun updateReadingProgress(track: Track): Boolean {
+    open suspend fun updateReadingProgress(track: Track): Boolean {
         return FollowsHandler(clientBuilder(), headers, preferences).updateReadingProgress(track)
     }
 
-    suspend fun updateRating(track: Track): Boolean {
+    open suspend fun updateRating(track: Track): Boolean {
         return FollowsHandler(clientBuilder(), headers, preferences).updateRating(track)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexCache.kt
@@ -13,11 +13,7 @@ import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.handlers.ApiMangaParser
-import eu.kanade.tachiyomi.source.online.handlers.FilterHandler
-import eu.kanade.tachiyomi.source.online.handlers.MangaHandler
 import eu.kanade.tachiyomi.source.online.handlers.SimilarHandler
-import eu.kanade.tachiyomi.source.online.handlers.serializers.ApiMangaSerializer
 import eu.kanade.tachiyomi.source.online.handlers.serializers.CacheApiMangaSerializer
 import eu.kanade.tachiyomi.source.online.utils.FollowStatus
 import eu.kanade.tachiyomi.source.online.utils.MdUtil
@@ -28,7 +24,6 @@ import okhttp3.Request
 import okhttp3.Response
 import rx.Observable
 import uy.kohesive.injekt.injectLazy
-import kotlin.math.floor
 
 open class MangaDexCache() : MangaDex() {
 
@@ -125,17 +120,14 @@ open class MangaDexCache() : MangaDex() {
     }
 
     override fun isLogged(): Boolean {
-        XLog.e("CACHE: isLogged() function has been called")
         return true
     }
 
     override suspend fun login(username: String, password: String, twoFactorCode: String): Boolean {
-        XLog.e("CACHE: login() function has been called")
         return true
     }
 
     override suspend fun logout(): Logout {
-        XLog.e("CACHE: logout() function has been called")
         return Logout(true, "Cache source does not have logout")
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexCache.kt
@@ -1,0 +1,196 @@
+package eu.kanade.tachiyomi.source.online
+
+import com.elvishew.xlog.XLog
+import eu.kanade.tachiyomi.data.database.DatabaseHelper
+import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.data.database.models.Track
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.data.track.TrackManager
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.asObservableSuccess
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.online.handlers.ApiMangaParser
+import eu.kanade.tachiyomi.source.online.handlers.FilterHandler
+import eu.kanade.tachiyomi.source.online.handlers.MangaHandler
+import eu.kanade.tachiyomi.source.online.handlers.SimilarHandler
+import eu.kanade.tachiyomi.source.online.handlers.serializers.ApiMangaSerializer
+import eu.kanade.tachiyomi.source.online.handlers.serializers.CacheApiMangaSerializer
+import eu.kanade.tachiyomi.source.online.utils.FollowStatus
+import eu.kanade.tachiyomi.source.online.utils.MdUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.CacheControl
+import okhttp3.Request
+import okhttp3.Response
+import rx.Observable
+import uy.kohesive.injekt.injectLazy
+import kotlin.math.floor
+
+open class MangaDexCache() : MangaDex() {
+
+    private val preferences: PreferencesHelper by injectLazy()
+    private val db: DatabaseHelper by injectLazy()
+
+    override suspend fun updateFollowStatus(mangaID: String, followStatus: FollowStatus): Boolean {
+        throw Exception("Cache source cannot update follow status")
+    }
+
+    override fun fetchRandomMangaId(): Observable<String> {
+        throw Exception("Cache source cannot get random manga")
+    }
+
+    override fun fetchPopularManga(page: Int): Observable<MangasPage> {
+        throw Exception("Cache source cannot get popular manga")
+    }
+
+    override fun fetchSearchManga(
+            page: Int,
+            query: String,
+            filters: FilterList
+    ): Observable<MangasPage> {
+        throw Exception("Cache source cannot search")
+    }
+
+    override fun fetchFollows(): Observable<MangasPage> {
+        throw Exception("Cache source cannot get follows")
+    }
+
+    override fun fetchMangaDetailsObservable(manga: SManga): Observable<SManga> {
+        return client.newCall(apiRequest(manga))
+                .asObservableSuccess()
+                .map { response ->
+                    parseMangaCacheApi(response.body!!.string())
+                }
+    }
+
+    override suspend fun fetchMangaDetails(manga: SManga): SManga {
+        return withContext(Dispatchers.IO) {
+            val response = client.newCall(apiRequest(manga)).execute()
+            parseMangaCacheApi(response.body!!.string())
+        }
+    }
+
+    override suspend fun fetchMangaAndChapterDetails(manga: SManga): Pair<SManga, List<SChapter>> {
+        val id = MdUtil.getMangaId(manga.url).toLong()
+        val dbChapters = db.getChaptersByMangaId(id).executeAsBlocking()
+        return Pair(fetchMangaDetails(manga), dbChapters)
+    }
+
+    override fun fetchChapterListObservable(manga: SManga): Observable<List<SChapter>> {
+        return Observable.just(emptyList())
+    }
+
+    override suspend fun getMangaIdFromChapterId(urlChapterId: String): Int {
+        throw Exception("Cache source cannot convert chapter id to manga id")
+    }
+
+    override suspend fun fetchChapterList(manga: SManga): List<SChapter> {
+        return emptyList()
+    }
+
+    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
+        return Observable.just(emptyList())
+    }
+
+    override fun fetchImage(page: Page): Observable<Response> {
+        throw Exception("Cache source cannot fetch images")
+    }
+
+    override fun imageRequest(page: Page): Request {
+        throw Exception("Cache source cannot request images")
+    }
+
+    override suspend fun fetchAllFollows(forceHd: Boolean): List<SManga> {
+        throw Exception("Cache source cannot fetch follows")
+    }
+
+    override suspend fun updateReadingProgress(track: Track): Boolean {
+        throw Exception("Cache source cannot update reading progress")
+    }
+
+    override suspend fun updateRating(track: Track): Boolean {
+        throw Exception("Cache source cannot update rating")
+    }
+
+    override suspend fun fetchTrackingInfo(url: String): Track {
+        return Track.create(TrackManager.MDLIST)
+    }
+
+    override fun fetchMangaSimilarObservable(manga: Manga): Observable<MangasPage> {
+        return SimilarHandler(preferences).fetchSimilar(manga)
+    }
+
+    override fun isLogged(): Boolean {
+        XLog.e("CACHE: isLogged() function has been called")
+        return true
+    }
+
+    override suspend fun login(username: String, password: String, twoFactorCode: String): Boolean {
+        XLog.e("CACHE: login() function has been called")
+        return true
+    }
+
+    override suspend fun logout(): Logout {
+        XLog.e("CACHE: logout() function has been called")
+        return Logout(true, "Cache source does not have logout")
+    }
+
+    private fun apiRequest(manga: SManga): Request {
+        val mangaId = MdUtil.getMangaId(manga.url).toLong()
+        return GET(MdUtil.apiUrlCache+mangaId.toString().padStart(5,'0')+".json", headers, CacheControl.FORCE_NETWORK)
+    }
+
+    private fun parseMangaCacheApi(jsonData : String) : SManga {
+        try {
+
+            // Serialize the api response
+            val mangaReturn = SManga.create()
+            val networkApiManga = MdUtil.jsonParser.decodeFromString(CacheApiMangaSerializer.serializer(), jsonData)
+
+            // Convert from the api format
+            mangaReturn.title = MdUtil.cleanString(networkApiManga.title)
+            mangaReturn.description = MdUtil.cleanDescription(networkApiManga.description)
+            mangaReturn.rating = networkApiManga.rating.toString()
+
+            // Get the external tracking ids for this manga
+            networkApiManga.external["al"].let {
+                mangaReturn.anilist_id = it
+            }
+            networkApiManga.external["kt"].let {
+                mangaReturn.kitsu_id = it
+            }
+            networkApiManga.external["mal"].let {
+                mangaReturn.my_anime_list_id = it
+            }
+            networkApiManga.external["mu"].let {
+                mangaReturn.manga_updates_id = it
+            }
+            networkApiManga.external["ap"].let {
+                mangaReturn.anime_planet_id = it
+            }
+            mangaReturn.status = SManga.UNKNOWN
+
+            // List the labels for this manga
+            val genres = networkApiManga.demographic.toMutableList()
+            genres += networkApiManga.content
+            genres += networkApiManga.format
+            genres += networkApiManga.genre
+            genres += networkApiManga.theme
+            if (networkApiManga.is_r18) {
+                genres.add("Hentai")
+            }
+            mangaReturn.genre = genres.joinToString(", ")
+
+            return mangaReturn
+        } catch (e: Exception) {
+            XLog.e(e)
+            throw e
+        }
+    }
+
+
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/serializers/CacheApiMangaSerializer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/serializers/CacheApiMangaSerializer.kt
@@ -1,0 +1,40 @@
+package eu.kanade.tachiyomi.source.online.handlers.serializers
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CacheApiMangaSerializer(
+    val id: Long,
+    val title: String,
+    val url: String,
+    val description: String,
+    val is_r18: Boolean,
+    val rating: Float,
+    val demographic: List<String>,
+    val content: List<String>,
+    val format: List<String>,
+    val genre: List<String>,
+    val theme: List<String>,
+    val languages: List<String>,
+    val related: List<CacheRelatedSerializer>,
+    val external: MutableMap<String,String>,
+    val last_updated: String,
+    val matches: List<CacheSimilarMatchesSerializer>,
+)
+
+@Serializable
+data class CacheRelatedSerializer(
+    val id: Long,
+    val title: String,
+    val type: String,
+    val r18: Boolean,
+)
+
+@Serializable
+data class CacheSimilarMatchesSerializer(
+    val id: Long,
+    val title: String,
+    val score: Float,
+    val r18: Boolean,
+    val languages: List<String>,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/utils/MdUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/utils/MdUtil.kt
@@ -13,6 +13,7 @@ class MdUtil {
         const val baseUrl = "https://mangadex.org"
         const val randMangaPage = "/manga/"
         const val apiUrl = "https://api.mangadex.org"
+        const val apiUrlCache = "https://raw.githubusercontent.com/goldbattle/MangadexRecomendations/master/output/api/"
         const val apiManga = "/v2/manga/"
         const val includeChapters = "?include=chapters"
         const val oldApiChapter = "/api/chapter/"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
@@ -388,6 +388,7 @@ class MangaDetailsPresenter(
 
     fun attachMergeManga(mergeManga: SManga?) {
         manga.merge_manga_url = mergeManga?.url
+        manga.merge_manga_image_url = mergeManga?.thumbnail_url
         val tempSet = filteredScanlators.toMutableSet()
         tempSet.add(MergeSource.name)
         filteredScanlators = tempSet
@@ -448,6 +449,11 @@ class MangaDetailsPresenter(
                     withContext(Dispatchers.Main) {
                         controller.clearCoverCache()
                     }
+                }
+
+                // If we don't have an image we can try to use the merge source image fallback
+                if(networkManga.thumbnail_url == null && manga.merge_manga_image_url != null) {
+                    manga.thumbnail_url = manga.merge_manga_image_url
                 }
                 db.insertManga(manga).executeOnIO()
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/merge/MergeSearchDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/merge/MergeSearchDialog.kt
@@ -3,6 +3,8 @@ package eu.kanade.tachiyomi.ui.manga.merge
 import android.app.Dialog
 import android.os.Bundle
 import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.customview.customView
 import com.jakewharton.rxbinding.widget.itemClicks
@@ -21,6 +23,7 @@ import rx.Subscription
 import rx.android.schedulers.AndroidSchedulers
 import rx.subscriptions.CompositeSubscription
 import java.util.concurrent.TimeUnit
+
 
 class MergeSearchDialog : DialogController {
 
@@ -46,9 +49,12 @@ class MergeSearchDialog : DialogController {
 
     override fun onCreateDialog(savedViewState: Bundle?): Dialog {
         val dialog = MaterialDialog(activity!!).apply {
-            customView(viewRes = R.layout.merge_search_dialog, scrollable = false)
+            customView(viewRes = R.layout.merge_search_dialog, scrollable = false, noVerticalPadding = true)
             negativeButton(android.R.string.cancel)
         }
+        val width = ViewGroup.LayoutParams.MATCH_PARENT
+        val height = ViewGroup.LayoutParams.MATCH_PARENT
+        dialog.window!!.setLayout(width, height)
 
         if (subscriptions.isUnsubscribed) {
             subscriptions = CompositeSubscription()
@@ -134,7 +140,7 @@ class MergeSearchDialog : DialogController {
         view.merge_search_list.gone()
         view.empty_view.visible()
         view.empty_view.showMedium(
-            CommunityMaterial.Icon.cmd_compass_off, view.context.getString(R.string.no_results_found)
+                CommunityMaterial.Icon.cmd_compass_off, view.context.getString(R.string.no_results_found)
         )
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsSiteController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsSiteController.kt
@@ -60,6 +60,12 @@ class SettingsSiteController :
             }
         }
 
+        switchPreference {
+            key = PreferenceKeys.useCacheSource
+            titleRes = R.string.use_cache_source
+            defaultValue = false
+        }
+
         listPreference(activity) {
             key = PreferenceKeys.showR18
             titleRes = R.string.show_r18_title

--- a/app/src/main/res/layout/merge_search_dialog.xml
+++ b/app/src/main/res/layout/merge_search_dialog.xml
@@ -12,6 +12,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
+        android:layout_marginTop="15dp"
         android:hint="@string/title">
 
         <com.google.android.material.textfield.TextInputEditText
@@ -41,7 +42,7 @@
             android:visibility="invisible"
             tools:visibility="visible" />
 
-        <ListView
+        <GridView
             android:id="@+id/merge_search_list"
             style="@style/Theme.Widget.CardView"
             android:layout_width="match_parent"
@@ -53,10 +54,10 @@
             android:footerDividersEnabled="true"
             android:headerDividersEnabled="true"
             android:listSelector="@drawable/list_item_selector"
-            android:paddingTop="4dp"
-            android:paddingBottom="4dp"
+            android:padding="0dp"
             android:scrollbars="none"
             android:visibility="invisible"
+            android:numColumns="2"
             tools:listitem="@layout/merge_search_item"
             tools:visibility="visible" />
 

--- a/app/src/main/res/layout/merge_search_item.xml
+++ b/app/src/main/res/layout/merge_search_item.xml
@@ -1,44 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView style="@style/Theme.Widget.CardView.Item"
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:padding="0dp">
+    style="@style/Theme.Widget.CardView.Item"
+    android:layout_width="180dp"
+    android:layout_height="260dp"
+    android:layout_marginBottom="10dp"
+    android:padding="15dp"
+    app:cardCornerRadius="0dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="72dp"
+        android:layout_height="match_parent"
         android:background="@drawable/list_item_selector"
         android:orientation="horizontal">
 
         <ImageView
             android:id="@+id/merge_search_cover"
-            android:layout_width="48dp"
-            android:layout_height="match_parent"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginBottom="8dp"
+            android:layout_width="170dp"
+            android:layout_height="200dp"
+            android:layout_marginTop="4dp"
             android:contentDescription="@string/cover_of_image"
             android:scaleType="centerCrop"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/merge_search_title"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0"
+            app:layout_constraintVertical_bias="1.0"
             tools:src="@mipmap/ic_launcher" />
 
         <TextView
             android:id="@+id/merge_search_title"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
+            android:layout_width="165dp"
+            android:layout_height="50dp"
+            android:layout_marginBottom="4dp"
+            android:gravity="center"
             android:maxLines="3"
+            android:padding="2dp"
             android:textAppearance="@style/Neko.Headline4"
-            android:textSize="16sp"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/merge_search_cover"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintHorizontal_bias="0.428"
+            app:layout_constraintStart_toStartOf="parent"
             tools:text="One Piece ref efe fef ef efe fef ef ef ef f fse fewfwefwf wef feef ef ef" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings_neko.xml
+++ b/app/src/main/res/values/strings_neko.xml
@@ -137,6 +137,7 @@
     <string name="show_r18_filter_in_search">Show R18 filter in search</string>
     <string name="add_favorites_as_planned_to_read">Add to library as planned to read</string>
     <string name="add_favorites_as_planned_to_read_summary">When enabled adding a manga to your library inside the manga view will add the manga as planned to read in MDList</string>
+    <string name="use_cache_source">Use cached manga api source</string>
 
 
     <!-- Advanced Settings -->


### PR DESCRIPTION
Right now this added a "cached" source which if used overwrites all the main callback functions in the main source. For viewing the manga details and tags this will query the [cache api](https://github.com/goldbattle/MangadexRecomendations/tree/master/output/api). Right now there is no good way for getting the covers of the mangas, but I might try to add this in the future to help with browsing. Additionally if you merge a source we will use that thumbnail_url if the base manga object does not have one.

Library update has been re-enabled if the cache is used as you can get updates from the merge source. Not sure if I updated the proto for backup correctly.