### PR TITLE
Related sorting update

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/MangaImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/MangaImpl.kt
@@ -70,6 +70,8 @@ open class MangaImpl : Manga {
 
     override var last_chapter_number: Int? = null
 
+    override var similar_type_string: String = ""
+
     override fun copyFrom(other: SManga) {
         if (other is MangaImpl &&
             other.title.isNotBlank() && other.title != title

--- a/app/src/main/java/eu/kanade/tachiyomi/source/model/SManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/model/SManga.kt
@@ -51,6 +51,8 @@ interface SManga : Serializable {
 
     var last_chapter_number: Int?
 
+    var similar_type_string: String
+
     fun copyFrom(other: SManga) {
         if (other.author != null) {
             author = other.author
@@ -111,6 +113,7 @@ interface SManga : Serializable {
             last_chapter_number = other.last_chapter_number
         }
 
+        similar_type_string = other.similar_type_string
         missing_chapters = other.missing_chapters
 
         status = other.status

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/dto/SimilarDto.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/dto/SimilarDto.kt
@@ -3,6 +3,12 @@ package eu.kanade.tachiyomi.source.online.dto
 import kotlinx.serialization.Serializable
 
 @Serializable
+data class SimilarMangaDatabaseDto(
+    val similarApi: SimilarMangaDto,
+    val mangadexApi: MangaListDto,
+)
+
+@Serializable
 data class SimilarMangaDto(
     val id: String,
     val title: Map<String, String>,

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt
@@ -103,6 +103,7 @@ class SimilarHandler {
         // Convert to lookup array
         // TODO: also append here the related manga?
         // TODO: filter recommended based on if they have supported lang
+        // TODO: set the next page to false, and then for page 2,3 call anilist?
         val idsToManga = hashMapOf<String, SManga>()
         similarMangaListDto.results.forEach {
             idsToManga[it.data.id] = it.toBasicManga()
@@ -110,7 +111,9 @@ class SimilarHandler {
 
         // Loop through our *sorted* related array and list in that order
         val mangaList = similarMangaDto.matches.map {
-            idsToManga[it.id]!!
+            val manga = idsToManga[it.id]!!
+            manga.similar_type_string = "Algo"
+            manga
         }
         return MangaListPage(mangaList, false)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt
@@ -7,6 +7,9 @@ import eu.kanade.tachiyomi.data.database.models.MangaSimilar
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.ProxyRetrofitQueryMap
 import eu.kanade.tachiyomi.source.model.MangaListPage
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.online.dto.MangaListDto
+import eu.kanade.tachiyomi.source.online.dto.SimilarMangaDatabaseDto
 import eu.kanade.tachiyomi.source.online.dto.SimilarMangaDto
 import eu.kanade.tachiyomi.source.online.utils.MdUtil
 import eu.kanade.tachiyomi.source.online.utils.toBasicManga
@@ -26,10 +29,11 @@ class SimilarHandler {
     suspend fun fetchSimilarManga(manga: Manga, refresh: Boolean): MangaListPage {
         val mangaDb = db.getSimilar(MdUtil.getMangaId(manga.url)).executeAsBlocking()
         if (mangaDb != null && !refresh) {
-            val similarDto = MdUtil.jsonParser.decodeFromString<SimilarMangaDto>(mangaDb.data)
-            return similarDtoToMangaListPage(similarDto)
+            try {
+                val dbDto = MdUtil.jsonParser.decodeFromString<SimilarMangaDatabaseDto>(mangaDb.data)
+                return similarDtoToMangaListPage(dbDto.similarApi, dbDto.mangadexApi)
+            } catch (e : Exception) { }
         }
-
         val response = network.similarService.getSimilarManga(MdUtil.getMangaId(manga.url))
         return similarMangaParse(manga, response)
     }
@@ -45,45 +49,69 @@ class SimilarHandler {
         if (response.isSuccessful.not() || response.code() != 200) {
             throw Exception("Error getting search manga http code: ${response.code()}")
         }
+
         // Get our page of mangaList
         val similarDto = response.body()!!
-        val mangaPages = similarDtoToMangaListPage(similarDto)
-        val similarDtoString = MdUtil.jsonParser.encodeToString(similarDto)
+        val mangaListDto = similarGetMangaList(similarDto)
+        val mangaPages = similarDtoToMangaListPage(similarDto, mangaListDto)
 
-        // Insert into our database and return
+        // Convert to a database type that has both images and similar api response
+        val similarDatabaseDto = SimilarMangaDatabaseDto(similarApi = similarDto, mangadexApi = mangaListDto)
+        val similarDatabaseDtoString = MdUtil.jsonParser.encodeToString(similarDatabaseDto)
+
+        // If we have the manga in our database, then we should update it, otherwise insert as new
         val mangaSimilar = MangaSimilar.create().apply {
             manga_id = MdUtil.getMangaId(manga.url)
-            data = similarDtoString
+            data = similarDatabaseDtoString
+        }
+        val mangaDb = db.getSimilar(MdUtil.getMangaId(manga.url)).executeAsBlocking()
+        if(mangaDb != null) {
+            mangaSimilar.id = mangaDb.id
         }
         db.insertSimilar(mangaSimilar).executeAsBlocking()
         return mangaPages
     }
 
-    private suspend fun similarDtoToMangaListPage(
+    private suspend fun similarGetMangaList(
         similarMangaDto: SimilarMangaDto,
-    ): MangaListPage {
-        // TODO: also filter based on the content rating here?
-        // TODO: also append here the related manga?
-
+    ): MangaListDto {
         val ids = similarMangaDto.matches.map {
             it.id
         }
-
         val queryMap = mutableMapOf(
             "limit" to ids.size,
             "ids[]" to ids
         )
         val response = network.service.search(ProxyRetrofitQueryMap(queryMap))
-
         if (response.isSuccessful.not()) {
             XLog.e("error ", response.errorBody()!!.string())
             throw Exception("Error getting manga http code: ${response.code()}")
         }
+        val responseBody = response.body()!!
+        if (responseBody.results.size != ids.size) {
+            XLog.e("error ", response.errorBody()!!.string())
+            throw Exception("Unable to complete response ${responseBody.results.size} of ${ids.size} returned")
+        }
+        return responseBody
+    }
 
-        val mangaList = response.body()!!.results.map {
-            it.toBasicManga()
+    private fun similarDtoToMangaListPage(
+        similarMangaDto: SimilarMangaDto,
+        similarMangaListDto: MangaListDto,
+    ): MangaListPage {
+
+        // Convert to lookup array
+        // TODO: also append here the related manga?
+        // TODO: filter recommended based on if they have supported lang
+        val idsToManga = hashMapOf<String, SManga>()
+        similarMangaListDto.results.forEach {
+            idsToManga[it.data.id] = it.toBasicManga()
         }
 
+        // Loop through our *sorted* related array and list in that order
+        val mangaList = similarMangaDto.matches.map {
+            idsToManga[it.id]!!
+        }
         return MangaListPage(mangaList, false)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryBadge.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryBadge.kt
@@ -81,12 +81,22 @@ class LibraryBadge @JvmOverloads constructor(context: Context, attrs: AttributeS
         setUnreadDownload(chapters ?: 0, 0, chapters != null)
     }
 
-    fun setInLibrary(inLibrary: Boolean) {
-        this.isVisible = inLibrary
-        binding.unreadAngle.isVisible = false
-        binding.unreadText.updatePaddingRelative(start = 5.dpToPx)
-        binding.unreadText.isVisible = inLibrary
-        binding.unreadText.text = resources.getText(R.string.in_library)
+    fun setInLibrary(inLibrary: Boolean, overrideText: String="") {
+        if(overrideText == "") {
+            this.isVisible = inLibrary
+            binding.unreadAngle.isVisible = false
+            binding.unreadText.updatePaddingRelative(start = 5.dpToPx)
+            binding.unreadText.isVisible = inLibrary
+            binding.unreadText.text = resources.getText(R.string.in_library)
+        } else {
+            this.isVisible = true
+            binding.unreadAngle.isVisible = inLibrary
+            binding.downloadText.isVisible = true
+            binding.downloadText.text = overrideText
+            binding.unreadText.updatePaddingRelative(start = 5.dpToPx)
+            binding.unreadText.isVisible = inLibrary
+            binding.unreadText.text = resources.getText(R.string.in_library)
+        }
     }
 
     fun setStatus(status: FollowStatus, inLibrary: Boolean) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/similar/SimilarPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/similar/SimilarPresenter.kt
@@ -29,6 +29,7 @@ class SimilarPresenter(
     var scope = CoroutineScope(Job() + Dispatchers.Default)
 
     override fun createPager(query: String, filters: FilterList): Pager {
+        this.isSimilar = true
         this.manga = db.getManga(mangaId).executeAsBlocking()
         return SimilarPager(this.manga!!, source)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceGridHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceGridHolder.kt
@@ -28,6 +28,7 @@ class BrowseSourceGridHolder(
     private val adapter: FlexibleAdapter<IFlexible<RecyclerView.ViewHolder>>,
     compact: Boolean,
     private val isFollows: Boolean = false,
+    private val isSimilar: Boolean = false,
 ) : BrowseSourceHolder(view, adapter) {
 
     private val binding = MangaGridItemBinding.bind(view)
@@ -56,7 +57,10 @@ class BrowseSourceGridHolder(
                 manga.follow_status!!,
                 manga.favorite
             )
-            false -> binding.unreadDownloadBadge.root.setInLibrary(manga.favorite)
+            false -> when(isSimilar) {
+                true -> binding.unreadDownloadBadge.root.setInLibrary(manga.favorite, manga.similar_type_string)
+                false -> binding.unreadDownloadBadge.root.setInLibrary(manga.favorite, "")
+            }
         }
 
         // Update the cover.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceItem.kt
@@ -23,7 +23,8 @@ class BrowseSourceItem(
     val manga: Manga,
     private val catalogueAsList: Preference<Boolean>,
     private val catalogueListType: Preference<Int>,
-    private val isFollows: Boolean = false
+    private val isFollows: Boolean = false,
+    private val isSimilar: Boolean = false
 ) :
     AbstractFlexibleItem<BrowseSourceHolder>() {
 
@@ -71,7 +72,7 @@ class BrowseSourceItem(
                     (parent.itemWidth / 3f * 3.7f).toInt()
                 )
             }
-            BrowseSourceGridHolder(view, adapter, listType == 1, isFollows = isFollows)
+            BrowseSourceGridHolder(view, adapter, listType == 1, isFollows = isFollows, isSimilar = isSimilar)
         } else {
             BrowseSourceListHolder(view, adapter)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourcePresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourcePresenter.kt
@@ -72,6 +72,8 @@ open class BrowseSourcePresenter(
 
     var isFollows = false
 
+    var isSimilar = false
+
     /**
      * Modifiable list of filters.
      */
@@ -196,7 +198,8 @@ open class BrowseSourcePresenter(
                         manga,
                         browseAsList,
                         sourceListType,
-                        isFollows
+                        isFollows,
+                        isSimilar
                     )
                 }
                     .filter { manga -> isDeepLink || isLibraryVisible || !manga.manga.favorite }
@@ -306,7 +309,7 @@ open class BrowseSourcePresenter(
             localManga.title = sManga.title
             db.insertManga(localManga).executeAsBlocking()
         }
-
+        localManga.similar_type_string = sManga.similar_type_string
         return localManga
     }
 


### PR DESCRIPTION
Sorting and cache fixes:
- Sort based on similar api score instead of the manga id order from mangadex
- Properly set the id so cache gets updated and loaded
- Cache the images also for fast loading and remove the need for an api call

Also added badge for the "source" of the recommendation.
Doesn't really look the best compared to groups like in the library.
Are we able to get the related manga from the API?
I am not sure if it is reported from the main manga endpoint currently.