### PR TITLE
Add content rating to viewChapters

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/network/services/MangaDexService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/services/MangaDexService.kt
@@ -33,6 +33,7 @@ interface MangaDexService : MangaDexImageService {
     suspend fun viewChapters(
         @Path("id") id: String,
         @Query(value = "translatedLanguage[]") translatedLanguages: List<String>,
+        @Query(value = "contentRating[]") contentRatings: List<String>,
         @Query("offset") offset: Int,
     ): Response<ChapterListDto>
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/MangaHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/MangaHandler.kt
@@ -73,9 +73,10 @@ class MangaHandler {
         return withContext(Dispatchers.IO) {
             logTimeTaken("Fetch Chapters for  ${manga.title}") {
                 val langs = MdUtil.getLangsToShow(preferencesHelper)
+                val contentRating = MdUtil.getContentRatingToShow(preferencesHelper)
 
                 val response = logTimeTaken("fetching chapters from Dex") {
-                    network.service.viewChapters(MdUtil.getMangaId(manga.url), langs, 0)
+                    network.service.viewChapters(MdUtil.getMangaId(manga.url), langs, contentRating, 0)
                 }
 
                 if (response.isSuccessful.not()) {
@@ -87,7 +88,7 @@ class MangaHandler {
                 val results = chapterListDto.results.toMutableList()
 
                 var hasMoreResults =
-                    chapterListDto.limit + chapterListDto.offset < chapterListDto.total
+                        chapterListDto.limit + chapterListDto.offset < chapterListDto.total
 
                 var offset = chapterListDto.offset
                 val limit = chapterListDto.limit
@@ -95,7 +96,7 @@ class MangaHandler {
                 while (hasMoreResults) {
                     offset += limit
                     val newResponse =
-                        network.service.viewChapters(MdUtil.getMangaId(manga.url), langs, offset)
+                            network.service.viewChapters(MdUtil.getMangaId(manga.url), langs,contentRating, offset)
 
                     hasMoreResults = if (newResponse.code() != 200) {
                         false

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/MangaHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/MangaHandler.kt
@@ -76,7 +76,8 @@ class MangaHandler {
                 val contentRating = MdUtil.getContentRatingToShow(preferencesHelper)
 
                 val response = logTimeTaken("fetching chapters from Dex") {
-                    network.service.viewChapters(MdUtil.getMangaId(manga.url), langs, contentRating, 0)
+                    network.service.viewChapters(MdUtil.getMangaId(manga.url), langs, contentRating,
+                        0)
                 }
 
                 if (response.isSuccessful.not()) {
@@ -88,7 +89,7 @@ class MangaHandler {
                 val results = chapterListDto.results.toMutableList()
 
                 var hasMoreResults =
-                        chapterListDto.limit + chapterListDto.offset < chapterListDto.total
+                    chapterListDto.limit + chapterListDto.offset < chapterListDto.total
 
                 var offset = chapterListDto.offset
                 val limit = chapterListDto.limit
@@ -96,7 +97,8 @@ class MangaHandler {
                 while (hasMoreResults) {
                     offset += limit
                     val newResponse =
-                            network.service.viewChapters(MdUtil.getMangaId(manga.url), langs,contentRating, offset)
+                        network.service.viewChapters(MdUtil.getMangaId(manga.url), langs,
+                            contentRating, offset)
 
                     hasMoreResults = if (newResponse.code() != 200) {
                         false

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/utils/MdUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/utils/MdUtil.kt
@@ -280,6 +280,6 @@ class MdUtil {
             preferences.langsToShow().get().split(",")
 
         fun getContentRatingToShow(preferences: PreferencesHelper) =
-                preferences.contentRatingSelections().toList()
+            preferences.contentRatingSelections().toList()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/utils/MdUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/utils/MdUtil.kt
@@ -278,5 +278,8 @@ class MdUtil {
 
         fun getLangsToShow(preferences: PreferencesHelper) =
             preferences.langsToShow().get().split(",")
+
+        fun getContentRatingToShow(preferences: PreferencesHelper) =
+                preferences.contentRatingSelections().toList()
     }
 }


### PR DESCRIPTION
The current implementation of viewChapter does not properly use the contentRating query from the API which defaults to exclude pornographic content.
This has lead to the following issue: [issue](https://github.com/CarlosEsco/Neko/issues/664) and fixes issue 664

This commit changes it so the the viewChapter request follows what the user has set for the content ratings preference in their settings.

This strictly follows the user setting, so if a user has pornographic content disabled in the settings even if during the browsing filter they choose to allow pornographic content while it will show the pornographic content listed it will not show any chapters. It is the same for follows, if they have a pornographic content in their follows while it will be listed if they also have pornographic content in their settings disabled it will not show any chapter. I am not sure if should be this way or if browsing and follows should override what they have in their settings. 