### PR TITLE
Update QuadStateMultiChoiceDialogAdapter.kt

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/widget/materialdialogs/QuadStateMultiChoiceDialogAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/widget/materialdialogs/QuadStateMultiChoiceDialogAdapter.kt
@@ -66,7 +66,7 @@ internal class QuadStateMultiChoiceDialogAdapter(
 
     internal inline fun <reified T> List<T>.pullIndices(indices: IntArray): List<T> {
         return mutableListOf<T>().apply {
-            for (index in indices) {
+            for (index in indices.indices) {
                 add(this@pullIndices[index])
             }
         }


### PR DESCRIPTION
pullIndices now properly returns the Index instead of the index's value. This fixes issue #634 