### PR TITLE
Use wildcard domains and A12+ auto-verify

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,14 +58,13 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:host="*.mangadex.org"/>
-                <data android:host="mangadex.org"/>
-                <data android:host="*.mangadex.cc"/>
+                <data android:host="*.mangadex.org" />
+                <data android:host="mangadex.org" />
+                <data android:host="*.mangadex.cc" />
                 <data android:host="mangadex.cc" />
 
-                <data
-                    android:pathPattern="/chapter/..*"
-                    android:scheme="https" />
+                <data android:pathPattern="/chapter/..*" />
+                <data android:scheme="https" />
             </intent-filter>
 
             <intent-filter>
@@ -124,26 +123,15 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:host="*.mangadex.org"/>
-                <data android:host="mangadex.org"/>
-                <data android:host="*.mangadex.cc"/>
-                <data android:host="mangadex.cc"/>
+                <data android:scheme="https" />
 
-                <data
-                    android:pathPattern="/manga/..*"
-                    android:scheme="https" />
+                <data android:host="*.mangadex.org" />
+                <data android:host="mangadex.org" />
+                <data android:host="*.mangadex.cc" />
+                <data android:host="mangadex.cc" />
 
-                <data android:host="*.mangadex.org"/>
-                <data android:host="mangadex.org"/>
-                <data android:host="*.mangadex.cc"/>
-                <data android:host="mangadex.cc"/>
-
-                <data android:host="*.mangodicks.org"/>
-                <data android:host="mangodicks.org"/>
-
-                <data
-                    android:pathPattern="/title/..*"
-                    android:scheme="https" />
+                <data android:pathPattern="/manga/..*" />
+                <data android:pathPattern="/title/..*" />
             </intent-filter>
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,26 +52,18 @@
         <activity
             android:name=".ui.reader.ReaderActivity"
             android:theme="@style/Theme.Splash">
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
+                <data android:host="*.mangadex.org"/>
+                <data android:host="mangadex.org"/>
+                <data android:host="*.mangadex.cc"/>
+                <data android:host="mangadex.cc" />
+
                 <data
-                    android:host="www.mangadex.org"
-                    android:pathPattern="/chapter/..*"
-                    android:scheme="https" />
-                <data
-                    android:host="mangadex.org"
-                    android:pathPattern="/chapter/..*"
-                    android:scheme="https" />
-                <data
-                    android:host="www.mangadex.cc"
-                    android:pathPattern="/chapter/..*"
-                    android:scheme="https" />
-                <data
-                    android:host="mangadex.cc"
                     android:pathPattern="/chapter/..*"
                     android:scheme="https" />
             </intent-filter>
@@ -126,43 +118,30 @@
             android:name=".ui.main.DeepLinkActivity"
             android:launchMode="singleTask"
             android:theme="@android:style/Theme.NoDisplay">
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
+                <data android:host="*.mangadex.org"/>
+                <data android:host="mangadex.org"/>
+                <data android:host="*.mangadex.cc"/>
+                <data android:host="mangadex.cc"/>
+
                 <data
-                    android:host="www.mangadex.org"
-                    android:pathPattern="/manga/..*"
-                    android:scheme="https" />
-                <data
-                    android:host="mangadex.org"
-                    android:pathPattern="/manga/..*"
-                    android:scheme="https" />
-                <data
-                    android:host="www.mangadex.cc"
-                    android:pathPattern="/manga/..*"
-                    android:scheme="https" />
-                <data
-                    android:host="www.mangadex.cc"
                     android:pathPattern="/manga/..*"
                     android:scheme="https" />
 
+                <data android:host="*.mangadex.org"/>
+                <data android:host="mangadex.org"/>
+                <data android:host="*.mangadex.cc"/>
+                <data android:host="mangadex.cc"/>
+
+                <data android:host="*.mangodicks.org"/>
+                <data android:host="mangodicks.org"/>
+
                 <data
-                    android:host="www.mangadex.org"
-                    android:pathPattern="/title/..*"
-                    android:scheme="https" />
-                <data
-                    android:host="mangadex.org"
-                    android:pathPattern="/title/..*"
-                    android:scheme="https" />
-                <data
-                    android:host="www.mangadex.cc"
-                    android:pathPattern="/title/..*"
-                    android:scheme="https" />
-                <data
-                    android:host="www.mangadex.cc"
                     android:pathPattern="/title/..*"
                     android:scheme="https" />
             </intent-filter>


### PR DESCRIPTION
I recommend buiding the apk with the keystore used for signing release keys and seeing if it shows Verified Links correctly. It shud work (as I verified it with the alternate domain and tachi mangadex extension shows up correctly)

Summary of the PR:
 - Use `android:autoVerify` to trigger verifying deeplink in A12+
 - Use wildcard domains for deeplink intents. This essentially lets us deeplink https://www.mangadex.org by only verifying for https://mangadex.org (tested and works for tachi mangadex ext)
 - **Removes** the mangadex.cc link intent. It shouldnt be in wildspread use anyways. Also its just a 301 redirect now so cant be verified. Ref: https://developer.android.com/training/app-links/verify-site-associations#publish-json