### PR TITLE
Switch Manga info to using bayesian rating

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
@@ -58,7 +58,7 @@ class ApiMangaParser {
                         this.log("trying to get rating for ${mangaDto.id}")
                     }.getOrNull()
                 statResult?.statistics?.get(mangaDto.id)?.let { stats ->
-                    val rating = stats.rating.average ?: 0.0
+                    val rating = stats.rating.bayesian ?: 0.0
                     if (rating > 0) {
                         manga.rating = rating.toString()
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FollowsHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FollowsHandler.kt
@@ -196,7 +196,7 @@ class FollowsHandler {
                     val followStatus =
                         FollowStatus.fromDex(readingStatusResponse.getOrThrow().status)
                     val rating =
-                        ratingResponse.getOrThrow().ratings.asMdMap<RatingDto>().get(mangaId)
+                        ratingResponse.getOrThrow().ratings.asMdMap<RatingDto>()[mangaId]
                     val track = Track.create(TrackManager.MDLIST).apply {
                         status = followStatus.int
                         tracking_url = "$baseUrl/title/$mangaId"

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/models/dto/StatisticsDto.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/models/dto/StatisticsDto.kt
@@ -17,4 +17,5 @@ data class StatisticsDto(
 @Serializable
 data class StatisticRatingDto(
     val average: Double?,
+    val bayesian: Double?,
 )


### PR DESCRIPTION
Sort by Rating in Browse (/manga?order[rating]=desc/asc) sorts based on Bayesian average of all Ratings for a manga
While opening a manga now shows the Average rating instead
This PR changes rating data used in manga info rating to show Bayesian ratings as well so that there's no inconsistency 

Also ft. a minor android studio suggestion/linting/sugaring