### PR TITLE
Content Type Fixes and Language Filter on Similar

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt
@@ -19,6 +19,7 @@ import eu.kanade.tachiyomi.source.online.models.dto.MangaListDto
 import eu.kanade.tachiyomi.source.online.models.dto.RelatedMangaDto
 import eu.kanade.tachiyomi.source.online.models.dto.SimilarMangaDatabaseDto
 import eu.kanade.tachiyomi.source.online.models.dto.SimilarMangaDto
+import eu.kanade.tachiyomi.source.online.utils.MdConstants
 import eu.kanade.tachiyomi.source.online.utils.MdUtil
 import eu.kanade.tachiyomi.source.online.utils.toBasicManga
 import eu.kanade.tachiyomi.util.log
@@ -59,7 +60,6 @@ class SimilarHandler {
             val mangaList = similarGetMangadexMangaList(mangaIdMap.keys.toList(), false)
 
             val thumbQuality = preferencesHelper.thumbnailQuality()
-
             val relatedMangaList = mangaList.data.map {
                 it.toRelatedMangaDto(thumbQuality, mangaIdMap[it.id] ?: "")
             }
@@ -152,23 +152,30 @@ class SimilarHandler {
         similarDto ?: return
 
         // Get our page of mangaList
-        val ids = similarDto.matches.map { it.id }
-        val scores = similarDto.matches.map { it.score }
-        val mangaListDto = similarGetMangadexMangaList(ids)
-
-        val thumbQuality = preferencesHelper.thumbnailQuality()
-        val similarMangaList = mangaListDto.data.mapIndexed { index, it ->
-            it.toRelatedMangaDto(
-                thumbQuality,
-                String.format("%.2f", 100.0 * scores[index]) + "% match",
-            )
+        // TODO: We should also remove any that have a bad language here
+        val idPairs = similarDto.matches.map {
+            val id = it.id
+            val text = String.format("%.2f", 100.0 * it.score) + "% match"
+            id to text
+        }.toMap()
+        if (idPairs.isEmpty()) {
+            return
         }
 
-        // insert the new info into the db
+        val mangaListDto = similarGetMangadexMangaList(idPairs.mapNotNull { it.key }, false)
+
+        // Convert to lookup array
+        // TODO: Also filter out manga here that are already presented
+        val thumbQuality = preferencesHelper.thumbnailQuality()
+        val mangaList = mangaListDto.data.map {
+            it.toRelatedMangaDto(thumbQuality, idPairs[it.id] ?: "")
+        }
+
+        // update db
         val mangaDb = db.getSimilar(dexId).executeAsBlocking()
         val dbDto = getDbDto(mangaDb)
         dbDto.similarApi = similarDto
-        dbDto.similarManga = similarMangaList
+        dbDto.similarManga = mangaList
         insertMangaSimilar(dexId, dbDto, mangaDb)
     }
 
@@ -193,7 +200,6 @@ class SimilarHandler {
                     this.throws(type)
                 }
             }.getOrNull()
-
             anilistRecommendationParse(dexId, response)
         }
 
@@ -221,11 +227,13 @@ class SimilarHandler {
             val text = it.node.rating.toString() + " user votes"
             id to text
         }.filterNotNull().toMap()
+        if (idPairs.isEmpty()) {
+            return
+        }
 
-        val mangaListDto = similarGetMangadexMangaList(idPairs.mapNotNull { it.key })
+        val mangaListDto = similarGetMangadexMangaList(idPairs.mapNotNull { it.key }, false)
 
         val thumbQuality = preferencesHelper.thumbnailQuality()
-
         val mangaList = mangaListDto.data.map {
             it.toRelatedMangaDto(thumbQuality, idPairs[it.id] ?: "")
         }
@@ -233,10 +241,8 @@ class SimilarHandler {
         // update db
         val mangaDb = db.getSimilar(dexId).executeAsBlocking()
         val dbDto = getDbDto(mangaDb)
-
         dbDto.aniListApi = similarDto
         dbDto.aniListManga = mangaList
-
         insertMangaSimilar(dexId, dbDto, mangaDb)
     }
 
@@ -283,22 +289,24 @@ class SimilarHandler {
             val text = it.recommendation_count.toString() + " user votes"
             id to text
         }
-        val mangaListDto = similarGetMangadexMangaList(idPairs.mapNotNull { it.key })
+        if (idPairs.isEmpty()) {
+            return
+        }
+
+        val mangaListDto = similarGetMangadexMangaList(idPairs.mapNotNull { it.key }, false)
 
         // Convert to lookup array
         // TODO: Also filter out manga here that are already presented
         val thumbQuality = preferencesHelper.thumbnailQuality()
-
         val mangaList = mangaListDto.data.map {
             it.toRelatedMangaDto(thumbQuality, idPairs[it.id] ?: "")
         }
 
+        // update db
         val mangaDb = db.getSimilar(dexId).executeAsBlocking()
         val dbDto = getDbDto(mangaDb)
-
         dbDto.myAnimelistApi = similarDto
         dbDto.myAnimeListManga = mangaList
-
         insertMangaSimilar(dexId, dbDto, mangaDb)
     }
 
@@ -352,22 +360,24 @@ class SimilarHandler {
             val text = "Similar"
             id to text
         }
-        val mangaListDto = similarGetMangadexMangaList(idPairs.mapNotNull { it.key })
+        if (idPairs.isEmpty()) {
+            return
+        }
+
+        val mangaListDto = similarGetMangadexMangaList(idPairs.mapNotNull { it.key }, false)
 
         // Convert to lookup array
         // TODO: Also filter out manga here that are already presented
         val thumbQuality = preferencesHelper.thumbnailQuality()
-
         val mangaList = mangaListDto.data.map {
             it.toRelatedMangaDto(thumbQuality, idPairs[it.id] ?: "")
         }
 
+        // update db
         val mangaDb = db.getSimilar(dexId).executeAsBlocking()
         val dbDto = getDbDto(mangaDb)
-
         dbDto.mangaUpdatesApi = similarDto
         dbDto.mangaUpdatesListManga = mangaList
-
         insertMangaSimilar(dexId, dbDto, mangaDb)
     }
 
@@ -381,6 +391,7 @@ class SimilarHandler {
         val queryMap = mutableMapOf(
             "limit" to mangaIds.size,
             "ids[]" to mangaIds,
+            "contentRating[]" to listOf(MdConstants.ContentRating.safe, MdConstants.ContentRating.suggestive, MdConstants.ContentRating.erotica, MdConstants.ContentRating.pornographic),
         )
         val responseBody = network.service.search(ProxyRetrofitQueryMap(queryMap)).onError {
             val type = "searching for manga in similar handler"

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt
@@ -153,11 +153,23 @@ class SimilarHandler {
 
         // Get our page of mangaList
         // TODO: We should also remove any that have a bad language here
+        val activeLangs = MdUtil.getLangsToShow(preferencesHelper)
         val idPairs = similarDto.matches.map {
+            if (it.languages.isNotEmpty()) {
+                var commonLang = false
+                it.languages.forEach { lang ->
+                    if (activeLangs.contains(lang)) {
+                        commonLang = true
+                    }
+                }
+                if (!commonLang) {
+                    return@map null
+                }
+            }
             val id = it.id
             val text = String.format("%.2f", 100.0 * it.score) + "% match"
             id to text
-        }.toMap()
+        }.filterNotNull().toMap()
         if (idPairs.isEmpty()) {
             return
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/models/dto/SimilarDto.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/models/dto/SimilarDto.kt
@@ -60,6 +60,7 @@ data class SimilarMangaMatchListDto(
     val title: Map<String, String>,
     val contentRating: String,
     val score: Double,
+    val languages: List<String>,
 )
 
 @Serializable


### PR DESCRIPTION
Set the content type so manga's get a response from the API.
Also changed so the API can return partial response (e.g., a manga has been deleted since the recs have been updated).
This uses the `idPair` mapping.

Also add the filtering by language for the algo similar.
The similar API returns what languages it has chapters, for each recommended manga.
It is based on the user's "Choose languages to show" and should fix issues with people opening empty manga details with no chapters (only for algo similar, AL, MU, MAL, could still do this).