### PR TITLE
Deprecate Chapter Read Markers

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/network/services/MangaDexAuthService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/services/MangaDexAuthService.kt
@@ -78,12 +78,6 @@ interface MangaDexAuthService {
         @Body markStatusDto: MarkStatusDto,
     ): ApiResponse<ResultDto>
 
-    @POST("${MdApi.chapter}/{id}/read")
-    suspend fun markChapterRead(@Path("id") chapterId: String): ApiResponse<ResultDto>
-
-    @DELETE("${MdApi.chapter}/{id}/read")
-    suspend fun markChapterUnRead(@Path("id") chapterId: String): ApiResponse<ResultDto>
-
     @POST("${MdApi.manga}/{id}/follow")
     suspend fun followManga(@Path("id") mangaId: String): ApiResponse<ResultDto>
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/StatusHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/StatusHandler.kt
@@ -56,22 +56,6 @@ class StatusHandler {
         }
     }
 
-    suspend fun markChapterRead(chapterId: String) {
-        withIOContext {
-            authService.markChapterRead(chapterId).onFailure {
-                this.log("trying to mark chapter read")
-            }
-        }
-    }
-
-    suspend fun markChapterUnRead(chapterId: String) {
-        withIOContext {
-            authService.markChapterUnRead(chapterId).onFailure {
-                this.log("trying to mark chapter unread")
-            }
-        }
-    }
-
     suspend fun getReadChapterIds(mangaId: String) = flow<Set<String>> {
         if (mangaId.isDigitsOnly()) {
             emit(emptySet())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -24,6 +24,7 @@ import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.isMergedChapter
+import eu.kanade.tachiyomi.source.model.uuid
 import eu.kanade.tachiyomi.source.online.MangaDex
 import eu.kanade.tachiyomi.source.online.handlers.StatusHandler
 import eu.kanade.tachiyomi.source.online.utils.MdUtil
@@ -499,7 +500,7 @@ class ReaderPresenter(
             if (!preferences.incognitoMode().get()) {
                 selectedChapter.chapter.read = true
                 updateTrackChapterAfterReading(selectedChapter)
-                updateReadingStatus(selectedChapter)
+                updateReadingStatus(manga ?: return, selectedChapter)
                 deleteChapterIfNeeded(selectedChapter)
             }
         }
@@ -1000,10 +1001,13 @@ class ReaderPresenter(
         class Error(val error: Throwable) : SaveImageResult()
     }
 
-    private fun updateReadingStatus(readerChapter: ReaderChapter) {
+    private fun updateReadingStatus(manga: Manga, readerChapter: ReaderChapter) {
         if (preferences.readingSync().not() && readerChapter.chapter.isMergedChapter().not()) return
         scope.launchIO {
-            statusHandler.markChapterRead(readerChapter.chapter.mangadex_chapter_id)
+            statusHandler.marksChaptersStatus(
+                mangaId = manga.uuid(),
+                chapterIds = listOf(readerChapter.chapter.mangadex_chapter_id),
+            )
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recents/RecentsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recents/RecentsController.kt
@@ -691,7 +691,7 @@ class RecentsController(bundle: Bundle? = null) :
         val pagesLeft = chapter.pages_left
         lastChapterId = chapter.id
         val wasRead = chapter.read
-        presenter.markChapterRead(chapter, !wasRead)
+        presenter.markChapterRead(manga, chapter, !wasRead)
         snack = view?.snack(
             if (wasRead) {
                 R.string.marked_as_unread
@@ -703,7 +703,7 @@ class RecentsController(bundle: Bundle? = null) :
             anchorView = activityBinding?.bottomNav
             var undoing = false
             setAction(R.string.undo) {
-                presenter.markChapterRead(chapter, wasRead, lastRead, pagesLeft)
+                presenter.markChapterRead(manga, chapter, wasRead, lastRead, pagesLeft)
                 undoing = true
             }
             addCallback(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recents/RecentsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recents/RecentsPresenter.kt
@@ -17,6 +17,7 @@ import eu.kanade.tachiyomi.data.library.LibraryUpdateService
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.model.isMergedChapter
+import eu.kanade.tachiyomi.source.model.uuid
 import eu.kanade.tachiyomi.source.online.handlers.StatusHandler
 import eu.kanade.tachiyomi.ui.base.presenter.BaseCoroutinePresenter
 import eu.kanade.tachiyomi.util.chapter.ChapterFilter
@@ -476,6 +477,7 @@ class RecentsPresenter(
      * @param read whether to mark chapters as read or unread.
      */
     fun markChapterRead(
+        manga: Manga,
         chapter: Chapter,
         read: Boolean,
         lastRead: Int? = null,
@@ -491,8 +493,15 @@ class RecentsPresenter(
             }
             if (preferences.readingSync() && chapter.isMergedChapter().not()) {
                 when (read) {
-                    true -> statusHandler.markChapterRead(chapter.mangadex_chapter_id)
-                    false -> statusHandler.markChapterUnRead(chapter.mangadex_chapter_id)
+                    true -> statusHandler.marksChaptersStatus(
+                        mangaId = manga.uuid(),
+                        chapterIds = listOf(chapter.mangadex_chapter_id),
+                    )
+                    false -> statusHandler.marksChaptersStatus(
+                        mangaId = manga.uuid(),
+                        chapterIds = listOf(chapter.mangadex_chapter_id),
+                        read = false,
+                    )
                 }
             }
             db.updateChaptersProgress(listOf(chapter)).executeAsBlocking()


### PR DESCRIPTION
As per deprecation notice in MangaDex API 5.7.1
Uses mark manga chapters as read in batch endpoint to replace all chapter read marker usage
i.e. GET/POST /manga/{id}/read instead of POST/DELETE /chapter/{id}/read

mostly made possible by matching types and bringing over (manga) stuff wherever required
could probably just have passed `manga.uuid()` instead of entire `manga` ig
marking as draft because I'll try testing it a bit