### PR TITLE
Fix number of columns grid

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/functions/NumberOfColumns.kt
+++ b/app/src/main/java/org/nekomanga/presentation/functions/NumberOfColumns.kt
@@ -14,6 +14,7 @@ import kotlin.math.roundToInt
 fun numberOfColumns(rawValue: Float): Int {
     val size = 1.5f.pow(rawValue)
     val trueSize = AutofitRecyclerView.MULTIPLE * ((size * 100 / AutofitRecyclerView.MULTIPLE).roundToInt()) / 100f
-    val math = (LocalConfiguration.current.screenWidthDp / trueSize / 100).roundToInt()
+    val dpWidth = (LocalConfiguration.current.screenWidthDp / 100f).roundToInt()
+    val math = (dpWidth / trueSize).roundToInt()
     return max(1, math)
 }


### PR DESCRIPTION
The number of columns was wrong for the screens similar, latest and follows (for example with the grid size set to 3)