### PR TITLE
1291 - Improve CI Build Performance

### DIFF
--- a/.github/runner-files/ci-gradle.properties
+++ b/.github/runner-files/ci-gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.daemon=false
-org.gradle.jvmargs=-Xmx5120m
+org.gradle.jvmargs=-Xmx5120m -XX:MaxMetaspaceSize=756M
 org.gradle.workers.max=2
 
 kotlin.incremental=false

--- a/.github/workflows/ci-draft-release.yml
+++ b/.github/workflows/ci-draft-release.yml
@@ -21,6 +21,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set Swap Space
+        if: runner.os == 'Linux'
+        # v1.0 -> 49819abfb41bd9b44fb781159c033dba90353a7c
+        uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c
+        with:
+          swap-size-gb: 7
+
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0
         with:

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -33,6 +33,11 @@ jobs:
           distribution: "zulu"
           java-version: 11
 
+      - name: Copy ci gradle.properties
+        run: |
+          mkdir -p ~/.gradle
+          cp .github/runner-files/ci-gradle.properties ~/.gradle/gradle.properties
+
       - name: Build app
         uses: eskatos/gradle-command-action@v2.3.3
         with:

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -17,6 +17,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set Swap Space
+        if: runner.os == 'Linux'
+        # v1.0 -> 49819abfb41bd9b44fb781159c033dba90353a7c
+        uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c
+        with:
+          swap-size-gb: 7
+
       - name: clone repo
         uses: actions/checkout@v3
 


### PR DESCRIPTION
An attempt to resolve OOM errors occasionally received from GH Actions, particularly in PRs. See #1291.

Bumped Swap usage from 4G to 7G.
Added JVM MaxMetaspaceSize arg due to gradle bug.
Have PR CI use the runner ci-gradle.properties.

I dropped the JVM max memory bump as the build was showing 5.2GB free to start.