### PR TITLE
Fix fatal runtime error when starting app

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
@@ -44,6 +44,7 @@ import kotlinx.serialization.json.Json
 import org.nekomanga.core.network.NetworkPreferences
 import org.nekomanga.core.security.SecurityPreferences
 import org.nekomanga.domain.library.LibraryPreferences
+import org.nekomanga.domain.details.MangaDetailsPreferences
 import tachiyomi.core.preference.AndroidPreferenceStore
 import tachiyomi.core.preference.PreferenceStore
 import uy.kohesive.injekt.api.InjektModule
@@ -83,6 +84,9 @@ class AppModule(val app: Application) : InjektModule {
                 isLenient = true
             }
         }
+
+
+
 
         addSingletonFactory { MangaMappings(app.applicationContext) }
 
@@ -172,6 +176,10 @@ class PreferenceModule(val application: Application) : InjektModule {
 
         addSingletonFactory {
             NetworkPreferences(get(), BuildConfig.DEBUG)
+        }
+
+        addSingletonFactory {
+            MangaDetailsPreferences(get())
         }
 
         addSingletonFactory {


### PR DESCRIPTION
When running the app on the latest build it gives a `no registered instance or factory for type class org.nekomanga.domain.details.MangaDetailsPreferences` fatal error. So registered the class in AppModule.