### PR TITLE
Disable Animate Page Transition for Webtoon

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/settings/ReaderPagedView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/settings/ReaderPagedView.kt
@@ -66,6 +66,8 @@ class ReaderPagedView @JvmOverloads constructor(context: Context, attrs: Attribu
             webtoonInvert.bindToPreference(readerPreferences.webtoonNavInverted())
             webtoonPageLayout.bindToPreference(readerPreferences.webtoonPageLayout())
             webtoonInvertDoublePages.bindToPreference(readerPreferences.webtoonInvertDoublePages())
+            webtoonPageTransitions.bindToPreference(readerPreferences.animatedPageTransitionsWebtoon())
+
 
             updatePagedGroup(!isWebtoonView)
         }
@@ -99,6 +101,7 @@ class ReaderPagedView @JvmOverloads constructor(context: Context, attrs: Attribu
             binding.webtoonInvert,
             binding.webtoonPageLayout,
             binding.webtoonInvertDoublePages,
+            binding.webtoonPageTransitions,
         ).forEach { it.isVisible = !show }
         val isFullFit = when (readerPreferences.imageScaleType().get()) {
             SubsamplingScaleImageView.SCALE_TYPE_FIT_HEIGHT,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -27,6 +27,9 @@ class WebtoonConfig(
     readerPreferences: ReaderPreferences = Injekt.get(),
 ) : ViewerConfig(preferences, readerPreferences, scope) {
 
+    var usePageTransitions = false
+        private set
+
     var webtoonCropBorders = false
         private set
 
@@ -48,6 +51,8 @@ class WebtoonConfig(
     var menuThreshold = PreferenceValues.ReaderHideThreshold.LOW.threshold
 
     init {
+        readerPreferences.animatedPageTransitionsWebtoon().register({ usePageTransitions = it })
+
         readerPreferences.navigationModeWebtoon()
             .register({ navigationMode = it }, { updateNavigation(it) })
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -273,14 +273,24 @@ class WebtoonViewer(val activity: ReaderActivity, val hasMargins: Boolean = fals
      * Scrolls up by [scrollDistance].
      */
     override fun moveToPrevious() {
-        recycler.smoothScrollBy(0, -scrollDistance)
+        if (config.usePageTransitions) {
+            recycler.smoothScrollBy(0, -scrollDistance)
+        }
+        else {
+            recycler.scrollBy(0, -scrollDistance)
+        }
     }
 
     /**
      * Scrolls down by [scrollDistance].
      */
     override fun moveToNext() {
-        recycler.smoothScrollBy(0, scrollDistance)
+        if (config.usePageTransitions) {
+            recycler.smoothScrollBy(0, scrollDistance)
+        }
+        else {
+            recycler.scrollBy(0, scrollDistance)
+        }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
@@ -46,11 +46,6 @@ class SettingsReaderController : SettingsController() {
                 // min is 1
                 defaultValue = 500
             }
-            switchPreference {
-                key = readerPreferences.animatedPageTransitions().key()
-                titleRes = R.string.animate_page_transitions
-                defaultValue = true
-            }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 switchPreference {
                     key = readerPreferences.trueColor().key()
@@ -259,6 +254,11 @@ class SettingsReaderController : SettingsController() {
                 defaultValue = false
             }
             switchPreference {
+                key = readerPreferences.animatedPageTransitions().key()
+                titleRes = R.string.animate_page_transitions
+                defaultValue = true
+            }
+            switchPreference {
                 bindTo(readerPreferences.navigateToPan())
                 titleRes = R.string.navigate_pan
             }
@@ -389,6 +389,12 @@ class SettingsReaderController : SettingsController() {
                 key = readerPreferences.webtoonInvertDoublePages().key()
                 titleRes = R.string.invert_double_pages
                 defaultValue = false
+            }
+
+            switchPreference {
+                key = readerPreferences.animatedPageTransitionsWebtoon().key()
+                titleRes = R.string.animate_page_transitions_webtoon
+                defaultValue = true
             }
 
             switchPreference {

--- a/app/src/main/java/org/nekomanga/domain/reader/ReaderPreferences.kt
+++ b/app/src/main/java/org/nekomanga/domain/reader/ReaderPreferences.kt
@@ -13,6 +13,8 @@ class ReaderPreferences(private val preferenceStore: PreferenceStore) {
 
     fun animatedPageTransitions() = this.preferenceStore.getBoolean("pref_enable_transitions_key", true)
 
+    fun animatedPageTransitionsWebtoon() = this.preferenceStore.getBoolean("pref_enable_transitions_webtoon_key", true)
+
     fun pagerCutoutBehavior() = this.preferenceStore.getInt("pager_cutout_behavior")
 
     fun doubleTapAnimSpeed() = this.preferenceStore.getInt("pref_double_tap_anim_speed", 500)

--- a/app/src/main/res/layout/reader_paged_layout.xml
+++ b/app/src/main/res/layout/reader_paged_layout.xml
@@ -163,7 +163,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <com.google.android.material.materialswitch.MaterialSwitch
-            android:id="@+id/page_transitions_webtoon"
+            android:id="@+id/webtoon_page_transitions"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"

--- a/app/src/main/res/layout/reader_paged_layout.xml
+++ b/app/src/main/res/layout/reader_paged_layout.xml
@@ -163,6 +163,14 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/page_transitions_webtoon"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/animate_page_transitions_webtoon"
+            android:textColor="?attr/colorOnBackground" />
+
+        <com.google.android.material.materialswitch.MaterialSwitch
             android:id="@+id/webtoon_enable_zoom_out"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/constants/src/main/res/values/strings.xml
+++ b/constants/src/main/res/values/strings.xml
@@ -487,6 +487,7 @@
     <string name="if_disabled_transition_will_skip">If disabled, the transition page will be
         skipped if the next chapter is loaded</string>
     <string name="pref_webtoon_side_padding">Side padding</string>
+    <string name="animate_page_transitions_webtoon">Animate page transitions</string>
     <string name="webtoon_side_padding_0">None</string>
     <string name="webtoon_side_padding_5">5%</string>
     <string name="webtoon_side_padding_10">10%</string>


### PR DESCRIPTION
Hello,

I've been using Neko for a while in conjuction of TachiyomiSY for sources other than Mangadex. The latter can disable page transition for Webtoon that is really useful for e-ink devices. 

Because Neko didn't have it, I've added the option to disable it in the settings, in the Webtoon category. I've also moved the original "Animate Page" settings in the Paged category for better readilibity. 

If there are some correction in naming please feel free to tell me.

Have a great day !