### PR TITLE
chore: only match "fix" at the beginning of line

### DIFF
--- a/.github/scripts/commit_log_generation.sh
+++ b/.github/scripts/commit_log_generation.sh
@@ -12,7 +12,7 @@ OUTPUT=$(curl -H "Accept: application/vnd.github.v3+json" \
       | sub("^fix\\(deps\\)"; "chore(deps)")  # 1. fix(deps) -> chore(deps)
       | sub("^feature/"; "feat:")           # 2. feature/ -> feat:
       | sub("^fix/"; "fix:")                 # 3. fix/ -> fix:
-      | sub("fix "; "fix: ")                 # 4. fix -> fix:
+      | sub("^fix "; "fix: ")                 # 4. fix -> fix:
       | sub("^chore/"; "chore:")             # 5. chore/ -> chore:
       | sub("^chore\\(deps\\):"; "chore:");   # 6. chore(deps): -> chore:
 


### PR DESCRIPTION
See the 2.21.4 release:

<img width="248" height="128" alt="image" src="https://github.com/user-attachments/assets/18aadaea-0955-4083-88a3-49f301d6d881" />
