### PR TITLE
fix: Center ButtonGroup in Feed and Browse Screens

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/screens/BrowseScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/BrowseScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -344,8 +343,7 @@ fun BrowseScreen(
 
                             ButtonGroup(
                                 modifier =
-                                    Modifier.align(Alignment.BottomStart)
-                                        .fillMaxWidth()
+                                    Modifier.align(Alignment.BottomCenter)
                                         .padding(horizontal = Size.tiny),
                                 items = items,
                                 selectedItem = selectedItem,

--- a/app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -361,8 +360,7 @@ fun FeedScreen(
 
                                 ButtonGroup(
                                     modifier =
-                                        Modifier.align(Alignment.BottomStart)
-                                            .fillMaxWidth()
+                                        Modifier.align(Alignment.BottomCenter)
                                             .padding(horizontal = Size.tiny),
                                     items = items,
                                     selectedItem = selectedItem,


### PR DESCRIPTION
This change centers the ButtonGroup at the bottom of the Feed and Browse screens. The `fillMaxWidth()` modifier was removed to allow the ButtonGroup to wrap its content, and the alignment was set to `Alignment.BottomCenter` to correctly position it.