### PR TITLE
feat: Speed up initial loading of LibraryPresenter

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedPresenter.kt
@@ -168,8 +168,7 @@ class FeedPresenter(
         lastHistoryFeedMangaList = _historyScreenPagingState.value.historyFeedMangaList
         lastSummaryUpdatesFeedMangaList = _summaryScreenPagingState.value.updatesFeedMangaList
         lastContinueReadingList = _summaryScreenPagingState.value.continueReadingList
-        lastSummaryNewlyAddedFeedMangaList =
-            _summaryScreenPagingState.value.newlyAddedFeedMangaList
+        lastSummaryNewlyAddedFeedMangaList = _summaryScreenPagingState.value.newlyAddedFeedMangaList
     }
 
     override fun onPause() {


### PR DESCRIPTION
Introduced a "fast path" for the initial loading of the library to improve user experience.

- When the library is loaded for the first time, it now quickly displays a preview of the manga list.
- This preview is grouped according to the user's preferences but is not sorted or filtered, allowing for a near-instant display.
- The full data processing, including sorting and filtering, now runs in the background.
- Once the full processing is complete, the UI is updated with the fully-featured list.
- For the `ByTrackStatus` grouping, which requires network calls, the fast path temporarily falls back to an `Ungrouped` view to avoid delays.