### PR TITLE
fix(ui): Resolve toolbar race condition during navigation

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -89,7 +89,14 @@ class MainActivity : ComponentActivity() {
 
             var screenBars by remember { mutableStateOf(ScreenBars()) }
 
-            val updateScreenBars: (ScreenBars) -> Unit = { newBars -> screenBars = newBars }
+            val updateScreenBars: (ScreenBars) -> Unit = { newBars ->
+                if (newBars.id == screenBars.id && newBars.topBar == null) {
+                    // This is a screen being disposed, only clear if it is the current screen
+                    screenBars = ScreenBars()
+                } else if (newBars.topBar != null) {
+                    screenBars = newBars
+                }
+            }
 
             var pullRefreshState by remember { mutableStateOf(PullRefreshState()) }
             val updateRefreshScreenBars: (PullRefreshState) -> Unit = { newPullRefreshState ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/ScreenBars.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/ScreenBars.kt
@@ -3,10 +3,12 @@ package eu.kanade.tachiyomi.ui.main
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
+import java.util.UUID
 
 data class ScreenBars(
     val topBar: (@Composable () -> Unit)? = null,
     val scrollBehavior: TopAppBarScrollBehavior? = null,
+    val id: UUID = UUID.randomUUID(),
 )
 
 val LocalBarUpdater =

--- a/app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt
@@ -229,8 +229,8 @@ private fun FeedWrapper(
         }
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
 
-        DisposableEffect(Unit) {
-            updateTopBar(
+        val screenBars =
+            remember {
                 ScreenBars(
                     topBar = {
                         FeedScreenTopBar(
@@ -243,8 +243,11 @@ private fun FeedWrapper(
                     },
                     scrollBehavior = scrollBehavior,
                 )
-            )
-            onDispose { updateTopBar(ScreenBars()) }
+            }
+
+        DisposableEffect(Unit) {
+            updateTopBar(screenBars)
+            onDispose { updateTopBar(ScreenBars(id = screenBars.id, topBar = null)) }
         }
 
         DisposableEffect(

--- a/app/src/main/java/org/nekomanga/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/LibraryScreen.kt
@@ -234,8 +234,8 @@ private fun LibraryWrapper(
 
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
 
-        DisposableEffect(Unit) {
-            updateTopBar(
+        val screenBars =
+            remember {
                 ScreenBars(
                     topBar = {
                         LibraryScreenTopBar(
@@ -263,8 +263,10 @@ private fun LibraryWrapper(
                     },
                     scrollBehavior = scrollBehavior,
                 )
-            )
-            onDispose { updateTopBar(ScreenBars()) }
+            }
+        DisposableEffect(Unit) {
+            updateTopBar(screenBars)
+            onDispose { updateTopBar(ScreenBars(id = screenBars.id, topBar = null)) }
         }
 
         DisposableEffect(libraryScreenState.isRefreshing, libraryScreenActions.updateLibrary) {


### PR DESCRIPTION
Correctly handles the toolbar state when navigating between screens in Jetpack Compose.

- Added a unique ID to the `ScreenBars` object to track the current toolbar owner.
- Modified `MainActivity` to only clear the toolbar if the `onDispose` call comes from the currently active screen.
- Updated `LibraryScreen` and `FeedScreen` to use the new lifecycle-aware toolbar logic.

This prevents a race condition where the outgoing screen's `onDispose` would clear the toolbar after the incoming screen had already set it up.