### PR TITLE
fix: use smart `smart_order` instead of `source_order`

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackService.kt
@@ -173,6 +173,6 @@ suspend fun TrackService.getCompletedDate(track: Track, allRead: Boolean): Long 
 
 suspend fun TrackService.getLastChapterRead(track: Track): Float {
     val chapters = db.getChapters(track.manga_id).executeOnIO()
-    val lastChapterRead = chapters.filter { it.read }.minByOrNull { it.source_order }
+    val lastChapterRead = chapters.filter { it.read }.minByOrNull { it.smart_order }
     return lastChapterRead?.takeIf { it.isRecognizedNumber }?.chapter_number ?: 0f
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedRepository.kt
@@ -263,7 +263,7 @@ class FeedRepository(
                         val simpleChapter =
                             chapters
                                 .filter { it.isAvailable(downloadManager, manga) }
-                                .maxByOrNull { it.source_order }
+                                .maxByOrNull { it.smart_order }
                                 ?.toSimpleChapter() ?: return@mapNotNull null
 
                         val displayManga = manga.toDisplayManga()


### PR DESCRIPTION
Fix for the unstarted summary and for adding a tracker, order got reversed a while back.