### PR TITLE
opt: slight library view model tweaks

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -231,6 +231,15 @@ class DownloadManager(val context: Context) {
         return cache.getDownloadCounts(manga.mapNotNull { it.id })
     }
 
+    /**
+     * Returns the amount of downloaded chapters for a list of manga IDs.
+     *
+     * @param mangaIds the list of manga IDs to check.
+     */
+    fun getDownloadCountsById(mangaIds: List<Long>): Map<Long, Int> {
+        return cache.getDownloadCounts(mangaIds)
+    }
+
     /** Returns the list of downloaded file names */
     fun getAllDownloads(manga: Manga): List<UniFile> {
         return cache.getAllDownloadFiles(manga)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -70,7 +70,6 @@ import org.nekomanga.domain.manga.LibraryMangaItem
 import org.nekomanga.domain.site.MangaDexPreferences
 import org.nekomanga.logging.TimberKt
 import org.nekomanga.usecases.chapters.ChapterUseCases
-import org.nekomanga.util.system.filterAsync
 import org.nekomanga.util.system.mapAsync
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -317,8 +316,8 @@ class LibraryViewModel() : ViewModel() {
                     val removeArticles = libraryPreferences.removeArticles().get()
 
                     val downloadCountMapAsync = async {
-                        downloadManager.getDownloadCounts(
-                            filteredMangaList.map { it.displayManga.toDbManga() }
+                        downloadManager.getDownloadCountsById(
+                            filteredMangaList.map { it.displayManga.mangaId }
                         )
                     }
 
@@ -383,8 +382,7 @@ class LibraryViewModel() : ViewModel() {
                                 val sortedMangaList =
                                     libraryCategoryItem.libraryItems
                                         .distinctBy { it.displayManga.mangaId }
-                                        .sortedWith(comparator)
-                                        .mapAsync { item ->
+                                        .map { item ->
                                             item.copy(
                                                 downloadCount =
                                                     downloadCountMap[item.displayManga.mangaId]
@@ -394,6 +392,7 @@ class LibraryViewModel() : ViewModel() {
                                             )
                                         }
                                         .applyFilters(libraryFilters, trackMap)
+                                        .sortedWith(comparator)
                                         .toPersistentList()
 
                                 val isRefreshing =
@@ -537,7 +536,7 @@ class LibraryViewModel() : ViewModel() {
         libraryFilters: LibraryFilters,
         trackMap: Map<Long, List<String>>,
     ): List<LibraryMangaItem> {
-        return this.filterAsync { libraryMangaItem ->
+        return this.filter { libraryMangaItem ->
             val displayManga = libraryMangaItem.displayManga
             val bookmarkedCondition = libraryFilters.filterBookmarked.matches(libraryMangaItem)
             val completedCondition = libraryFilters.filterCompleted.matches(libraryMangaItem)


### PR DESCRIPTION
This commit improves the performance of the library view, especially for large libraries (4k+ entries), by:

1.  Optimizing `DownloadManager.getDownloadCounts`: Added `getDownloadCountsById` to accept a list of IDs, avoiding the creation of thousands of `DbManga` objects during library refreshes.
2.  Removing `mapAsync` and `filterAsync`: Replaced parallel stream operations with standard `map` and `filter`. The overhead of creating thousands of coroutines for lightweight operations was causing significant performance degradation.
3.  Correcting Operation Order: Reordered the library item processing pipeline to `Enrich -> Filter -> Sort`. This ensures that sorting uses up-to-date data (fixing a potential bug where sorting by download count relied on stale values) and improves performance by sorting a potentially smaller, filtered list.