### PR TITLE
Fix library sort not updating when returning from reader

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
@@ -16,6 +16,7 @@ import eu.kanade.tachiyomi.data.database.resolvers.MangaScanlatorFilterFlagsPutR
 import eu.kanade.tachiyomi.data.database.resolvers.MangaTitlePutResolver
 import eu.kanade.tachiyomi.data.database.tables.CategoryTable
 import eu.kanade.tachiyomi.data.database.tables.ChapterTable
+import eu.kanade.tachiyomi.data.database.tables.HistoryTable
 import eu.kanade.tachiyomi.data.database.tables.MangaCategoryTable
 import eu.kanade.tachiyomi.data.database.tables.MangaTable
 
@@ -196,7 +197,7 @@ interface MangaQueries : DbProvider {
             .withQuery(
                 RawQuery.builder()
                     .query(getLastReadMangaQuery())
-                    .observesTables(MangaTable.TABLE)
+                    .observesTables(MangaTable.TABLE, ChapterTable.TABLE, HistoryTable.TABLE)
                     .build()
             )
             .prepare()
@@ -207,7 +208,7 @@ interface MangaQueries : DbProvider {
             .withQuery(
                 RawQuery.builder()
                     .query(getLastFetchedMangaQuery())
-                    .observesTables(MangaTable.TABLE)
+                    .observesTables(MangaTable.TABLE, ChapterTable.TABLE)
                     .build()
             )
             .prepare()
@@ -218,7 +219,7 @@ interface MangaQueries : DbProvider {
             .withQuery(
                 RawQuery.builder()
                     .query(getTotalChapterMangaQuery())
-                    .observesTables(MangaTable.TABLE)
+                    .observesTables(MangaTable.TABLE, ChapterTable.TABLE)
                     .build()
             )
             .prepare()


### PR DESCRIPTION
The library list was not re-sorting when `HistoryTable` (reading progress) or `ChapterTable` (new/updated chapters) changed, because the reactive database queries for `getLastReadManga`, `getLastFetchedManga`, and `getTotalChapterManga` were only observing `MangaTable`.

This commit adds `HistoryTable` and `ChapterTable` to the observed tables list in these raw queries. This ensures that changes such as reading a chapter or adding a new one trigger a re-emission of the flow, causing the `LibraryViewModel` to re-sort the list with the latest data.