### PR TITLE
🎨 Palette: Accessibility polish for Empty States and Feed Flags

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/screens/EmptyScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/EmptyScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import jp.wasabeef.gap.Gap
@@ -91,6 +92,7 @@ fun EmptyScreen(
             style = MaterialTheme.typography.displayMedium,
             color =
                 MaterialTheme.colorScheme.onSurface.copy(alpha = NekoColors.mediumAlphaLowContrast),
+            modifier = Modifier.clearAndSetSemantics {},
         )
         Gap(Size.large)
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedPage.kt
@@ -160,7 +160,8 @@ fun FeedChapterTitleLine(
             Gap(Size.extraTiny)
         }
         if (language.isNotEmpty() && !language.equals("en", true)) {
-            val iconRes = MdLang.fromIsoCode(language)?.iconResId
+            val lang = MdLang.fromIsoCode(language)
+            val iconRes = lang?.iconResId
 
             when (iconRes == null) {
                 true -> {
@@ -177,7 +178,7 @@ fun FeedChapterTitleLine(
                             Modifier.height(Size.medium)
                                 .clip(RoundedCornerShape(Size.tiny))
                                 .align(Alignment.CenterVertically),
-                        contentDescription = "flag",
+                        contentDescription = lang!!.prettyPrint,
                     )
                     Gap(Size.extraTiny)
                 }


### PR DESCRIPTION
This PR implements two micro-UX improvements focused on accessibility:
1.  **Empty States:** The ASCII art faces (Kaomoji) used in `EmptyScreen` are now hidden from accessibility services. Previously, screen readers would read out every character (e.g., "Left parenthesis, dot, underscore..."), which was confusing and annoying. Now, the decorative art is ignored, allowing focus to land on the helpful text message.
2.  **Language Flags:** In the Feed, language flags now use the full language name (e.g., "Japanese", "English") as their `contentDescription` instead of the generic "flag". This provides context to users relying on screen readers.

---
*PR created automatically by Jules for task [1584333080718496107](https://jules.google.com/task/1584333080718496107) started by @nonproto*