### PR TITLE
🎨 Palette: Add accessibility label to 'In Library' icon

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/InLibrary.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/InLibrary.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.nekomanga.R
@@ -25,7 +27,14 @@ import org.nekomanga.presentation.theme.Size
 
 @Composable
 fun InLibraryIcon(offset: Dp, outline: Boolean) {
-    Box(modifier = Modifier.offset(x = offset, y = offset), contentAlignment = Alignment.Center) {
+    val inLibraryDescription = stringResource(id = R.string.in_library)
+    Box(
+        modifier =
+            Modifier.offset(x = offset, y = offset).semantics {
+                contentDescription = inLibraryDescription
+            },
+        contentAlignment = Alignment.Center,
+    ) {
         if (outline) {
             Icon(
                 imageVector = Icons.Outlined.Favorite,


### PR DESCRIPTION
💡 **What:** Added `contentDescription` to the `InLibraryIcon` composable using the existing "In library" string resource.
🎯 **Why:** In the manga list view (`MangaListView`), the "In Library" heart icon was purely decorative (`contentDescription = null`). This meant screen reader users had no audio feedback indicating a manga was in their library.
♿ **Accessibility:** TalkBack will now announce "In library" along with the manga title and subtitle when focusing on a list row, providing parity with the grid view (which uses a text badge).


---
*PR created automatically by Jules for task [15635600873665644799](https://jules.google.com/task/15635600873665644799) started by @nonproto*