### PR TITLE
🎨 Palette: Improve accessibility of manga stats

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/screens/manga/InformationBlock.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/manga/InformationBlock.kt
@@ -193,6 +193,7 @@ fun InformationBlock(
                         text = formattedRating,
                         icon = Icons.Filled.HotelClass,
                         color = mediumAlpha,
+                        contentDescription = stringResource(id = R.string.rating),
                     )
                 }
                 it.follows.toIntOrNull()?.let { follows ->
@@ -200,6 +201,7 @@ fun InformationBlock(
                         text = numberFormat.format(follows),
                         icon = Icons.Filled.Bookmarks,
                         color = mediumAlpha,
+                        contentDescription = stringResource(id = R.string.bookmarked),
                     )
                 }
                 it.repliesCount.toIntOrNull()?.let { replies ->
@@ -207,12 +209,18 @@ fun InformationBlock(
                         text = numberFormat.format(replies),
                         icon = Icons.AutoMirrored.Filled.Comment,
                         color = mediumAlpha,
+                        contentDescription = stringResource(id = R.string.comments),
                     )
                 }
             }
 
             if (showMergedIcon) {
-                StatItem(text = "", icon = MergeCheckIcon, color = mediumAlpha)
+                StatItem(
+                    text = "",
+                    icon = MergeCheckIcon,
+                    color = mediumAlpha,
+                    contentDescription = stringResource(id = R.string.merged),
+                )
             }
         }
 
@@ -254,9 +262,14 @@ private fun StatItem(text: String, color: Color, icon: @Composable () -> Unit) {
 
 // Overloaded version for standard Material Icons
 @Composable
-private fun StatItem(text: String, icon: ImageVector, color: Color) {
+private fun StatItem(
+    text: String,
+    icon: ImageVector,
+    color: Color,
+    contentDescription: String? = null,
+) {
     StatItem(text = text, color = color) {
-        Icon(imageVector = icon, contentDescription = null, tint = color)
+        Icon(imageVector = icon, contentDescription = contentDescription, tint = color)
     }
 }
 


### PR DESCRIPTION
This PR improves the accessibility of the manga details screen by adding content descriptions to the statistics icons in the `InformationBlock`.

**Changes:**
- Modified `StatItem` composable to accept an optional `contentDescription`.
- Updated `StatItem` usages to pass `stringResource` IDs for:
  - Rating (`R.string.rating`)
  - Follows (`R.string.bookmarked`)
  - Comments (`R.string.comments`)
  - Merged status (`R.string.merged`)

**Why:**
Previously, these icons lacked content descriptions, making them invisible or confusing to screen reader users. This change ensures that all users can understand the manga statistics.

**Screenshots:**
(Visuals remain unchanged, but accessibility tools will now announce these items)

---
*PR created automatically by Jules for task [4695892932573106667](https://jules.google.com/task/4695892932573106667) started by @nonproto*