### PR TITLE
Fix delayed rendering of library item badges and outline

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -98,6 +98,15 @@ class LibraryViewModel() : ViewModel() {
             isFirstLoad = lastLibraryCategoryItems == null,
             rawColumnCount = libraryPreferences.gridSize().get(),
             libraryDisplayMode = libraryPreferences.layout().get(),
+            outlineCovers = libraryPreferences.outlineOnCovers().get(),
+            showUnreadBadges = libraryPreferences.showUnreadBadge().get(),
+            showDownloadBadges = libraryPreferences.showDownloadBadge().get(),
+            showStartReadingButton = libraryPreferences.showStartReadingButton().get(),
+            horizontalCategories = libraryPreferences.libraryHorizontalCategories().get(),
+            showLibraryButtonBar = libraryPreferences.showLibraryButtonBar().get(),
+            incognitoMode = securityPreferences.incognitoMode().get(),
+            showUnavailableFilter = mangadexPreferences.includeUnavailableChapters().get(),
+            useVividColorHeaders = preferences.useVividColorHeaders().get(),
         )
 
     private val _internalLibraryScreenState = MutableStateFlow(initialState)


### PR DESCRIPTION
Updated `initialState` initialization in `LibraryViewModel.kt` to explicitly fetch user preferences for UI toggles (`outlineOnCovers`, `showUnreadBadge`, `showDownloadBadge`, etc.) using `.get()`. Previously, these fields defaulted to `false` (or other defaults) and were only updated after an asynchronous flow emission, causing a visual pop-in effect.

---
*PR created automatically by Jules for task [687734892871213617](https://jules.google.com/task/687734892871213617) started by @nonproto*