### PR TITLE
🎨 Palette: Accessibility improvements for StartReadingButton

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/StartReadingButton.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/StartReadingButton.kt
@@ -15,11 +15,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import org.nekomanga.R
 import org.nekomanga.presentation.theme.Shapes
 import org.nekomanga.presentation.theme.Size
 
 @Composable
 fun StartReadingButton(modifier: Modifier = Modifier, onStartReadingClick: () -> Unit) {
+    val contentDescriptionString = stringResource(id = R.string.start_reading)
     Box(
         modifier =
             modifier
@@ -33,7 +39,8 @@ fun StartReadingButton(modifier: Modifier = Modifier, onStartReadingClick: () ->
                             topEnd = Shapes.coverRadius,
                         )
                 )
-                .clickable(onClick = onStartReadingClick)
+                .clickable(onClick = onStartReadingClick, role = Role.Button)
+                .semantics { contentDescription = contentDescriptionString }
                 .border(
                     width = Outline.thickness,
                     color = Outline.color,


### PR DESCRIPTION
💡 What: Added role="Button" and contentDescription="Start Reading" to the StartReadingButton component.
🎯 Why: Screen readers previously announced this button as "Unlabelled button" or just "clickable", making it difficult for visually impaired users to understand its function.
♿ Accessibility: The button is now correctly announced as a "Start Reading, Button".

---
*PR created automatically by Jules for task [2674429256749916995](https://jules.google.com/task/2674429256749916995) started by @nonproto*