### PR TITLE
feat(security): harden WebView settings in external source handlers

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/external/ComikeyHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/external/ComikeyHandler.kt
@@ -63,6 +63,10 @@ class ComikeyHandler {
             innerWv.settings.domStorageEnabled = true
             innerWv.settings.javaScriptEnabled = true
             innerWv.settings.blockNetworkImage = true
+            // Security: Disable file and content access to prevent potential local file
+            // exfiltration
+            innerWv.settings.allowFileAccess = false
+            innerWv.settings.allowContentAccess = false
             innerWv.settings.userAgentString = headers["User-Agent"]
             innerWv.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
             innerWv.addJavascriptInterface(jsInterface, interfaceName)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/kagane/Kagane.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/kagane/Kagane.kt
@@ -335,6 +335,10 @@ class Kagane : ReducedHttpSource() {
             innerWv.settings.domStorageEnabled = true
             innerWv.settings.javaScriptEnabled = true
             innerWv.settings.blockNetworkImage = true
+            // Security: Disable file and content access to prevent potential local file
+            // exfiltration
+            innerWv.settings.allowFileAccess = false
+            innerWv.settings.allowContentAccess = false
             innerWv.settings.userAgentString = headers["User-Agent"]
             innerWv.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
             innerWv.addJavascriptInterface(jsInterface, interfaceName)


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix WebView configuration security

**Vulnerability:**
The `WebView` instances created in `ComikeyHandler.kt` and `Kagane.kt` relied on default settings for `allowFileAccess` and `allowContentAccess`. While `allowFileAccess` defaults to `false` on modern Android (API 30+), `allowContentAccess` defaults to `true`, potentially allowing access to content providers.

**Impact:**
If a malicious page or compromised source were loaded, it could potentially attempt to access local content providers or files (if defaults changed or on older devices/configs).

**Fix:**
Explicitly set `allowFileAccess = false` and `allowContentAccess = false` in both handlers. Added comments explaining the security rationale.

**Verification:**
- Verified code changes via `read_file`.
- Ran `ktfmtFormatMain` to ensure code style.
- Tests failed due to missing Android SDK licenses in the environment, but code changes are isolated to property setters and verified manually.

---
*PR created automatically by Jules for task [16072145898576952651](https://jules.google.com/task/16072145898576952651) started by @nonproto*