### PR TITLE
🛡️ Sentinel: [HIGH] Fix exported activity vulnerability

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,12 +89,12 @@
         </activity>
         <activity
             android:name="eu.kanade.tachiyomi.ui.webview.WebViewActivity"
-            android:exported="true"
+            android:exported="false"
             android:configChanges="uiMode|orientation|screenSize" />
 
         <activity
             android:name="eu.kanade.tachiyomi.ui.security.BiometricActivity"
-            android:exported="true" />
+            android:exported="false" />
         <activity
             android:name="eu.kanade.tachiyomi.ui.setting.logins.MyAnimeListLoginActivity"
             android:label="MyAnimeList"


### PR DESCRIPTION
This PR addresses a security vulnerability where `WebViewActivity` and `BiometricActivity` were inadvertently exported, allowing any application on the device to launch them. This could be exploited to perform open redirects or phishing attacks via the WebView, or to interfere with the authentication flow.

By setting `android:exported="false"`, these activities are restricted to be launched only by the application itself, significantly reducing the attack surface.

This change aligns with Android security best practices and ensures that internal components remain internal.

---
*PR created automatically by Jules for task [13971309609281919555](https://jules.google.com/task/13971309609281919555) started by @nonproto*