### PR TITLE
🏗️ Architect: Move BackupUtil to data.backup

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupRestorer.kt
@@ -16,7 +16,6 @@ import eu.kanade.tachiyomi.data.track.TrackManager
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.online.utils.MdLang
 import eu.kanade.tachiyomi.source.online.utils.MdUtil
-import eu.kanade.tachiyomi.util.BackupUtil
 import eu.kanade.tachiyomi.util.manga.MangaCoverMetadata
 import eu.kanade.tachiyomi.util.system.executeOnIO
 import eu.kanade.tachiyomi.util.system.notificationManager

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupUtil.kt
@@ -1,9 +1,8 @@
-package eu.kanade.tachiyomi.util
+package eu.kanade.tachiyomi.data.backup
 
 import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
-import eu.kanade.tachiyomi.data.backup.BackupCreator
 import eu.kanade.tachiyomi.data.backup.models.Backup
 import okio.buffer
 import okio.gzip


### PR DESCRIPTION
Moved `BackupUtil.kt` to `eu.kanade.tachiyomi.data.backup` to improve package cohesion.

---
*PR created automatically by Jules for task [14352582792968906234](https://jules.google.com/task/14352582792968906234) started by @nonproto*