### PR TITLE
💅 Stylist: Extract 16.dp to Size.medium

### DIFF
--- a/.jules/stylist.md
+++ b/.jules/stylist.md
@@ -1,0 +1,1 @@
+## 2024-05-23 - [Found Size.medium for 16.dp] **Learning:** The project defines dimension constants in `org.nekomanga.presentation.theme.Constants.kt` under `object Size`. `Size.medium` corresponds to `16.dp`. **Action:** When encountering hardcoded `16.dp`, replace it with `Size.medium`.

--- a/app/src/main/java/org/nekomanga/presentation/screens/stats/DetailedStats.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/stats/DetailedStats.kt
@@ -490,12 +490,12 @@ private fun DefaultView(
         if (viewType == ViewType.Split) {
             item {
                 Row(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = Size.medium),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     graph(Modifier, chartWidth)
-                    Column(Modifier.fillMaxWidth(.9f).padding(16.dp)) {
+                    Column(Modifier.fillMaxWidth(.9f).padding(Size.medium)) {
                         sortedSeries.forEach { entry ->
                             StatCard(
                                 header = entry.key,
@@ -649,7 +649,7 @@ private fun LazyListWrapper(
 @Composable
 private fun SortChip(sortType: Sort, onClick: () -> Unit) {
     Box(
-        modifier = Modifier.fillMaxWidth().padding(end = 16.dp),
+        modifier = Modifier.fillMaxWidth().padding(end = Size.medium),
         contentAlignment = Alignment.CenterEnd,
     ) {
         AssistChip(
@@ -684,7 +684,7 @@ private fun LazyListScope.CustomChip(
 
 @Composable
 private fun DetailedCard(manga: StatsConstants.DetailedStatManga, modifier: Modifier) {
-    ElevatedCard(modifier = modifier.padding(horizontal = 16.dp, vertical = Size.small)) {
+    ElevatedCard(modifier = modifier.padding(horizontal = Size.medium, vertical = Size.small)) {
         Column(
             modifier =
                 Modifier.fillMaxWidth().padding(horizontal = Size.small, vertical = Size.tiny)
@@ -760,7 +760,7 @@ private fun Line(label: String, value: String) {
 
 @Composable
 private fun Pie(pieData: List<PieData>, chartWidth: Float, modifier: Modifier = Modifier) {
-    Box(modifier = modifier.padding(16.dp), contentAlignment = Alignment.Center) {
+    Box(modifier = modifier.padding(Size.medium), contentAlignment = Alignment.Center) {
         if (pieData.isNotEmpty()) {
             PieChart(
                 modifier = Modifier.fillMaxWidth(chartWidth),
@@ -787,7 +787,8 @@ private fun Line(
 ) {
     Box(
         modifier =
-            Modifier.padding(horizontal = 16.dp, vertical = Size.none).fillMaxWidth(chartWidth),
+            Modifier.padding(horizontal = Size.medium, vertical = Size.none)
+                .fillMaxWidth(chartWidth),
         contentAlignment = Alignment.Center,
     ) {
         if (lineData.isNotEmpty()) {
@@ -796,7 +797,7 @@ private fun Line(
             LineChart(
                 lineData = lineData,
                 color = color,
-                modifier = Modifier.fillMaxWidth().height(height.dp).padding(16.dp),
+                modifier = Modifier.fillMaxWidth().height(height.dp).padding(Size.medium),
                 chartDimens = ChartDimens(Size.small),
                 axisConfig =
                     AxisConfig(
@@ -832,7 +833,7 @@ private fun StatCard(
     totalReadDuration: Long,
 ) {
     ElevatedCard(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = Size.small)
+        modifier = Modifier.fillMaxWidth().padding(horizontal = Size.medium, vertical = Size.small)
     ) {
         val labelStyle =
             MaterialTheme.typography.labelSmall.copy(


### PR DESCRIPTION
This PR extracts hardcoded `16.dp` values in `DetailedStats.kt` and replaces them with `Size.medium` as part of the "Stylist" design system enforcement.

**Changes:**
- Replaced `16.dp` with `Size.medium` in `app/src/main/java/org/nekomanga/presentation/screens/stats/DetailedStats.kt`.
- Created `.jules/stylist.md` with a journal entry documenting the convention.

**Verification:**
- Verified `Size.medium` is defined as `16.dp` in `Constants.kt`.
- Verified `Size` is imported in `DetailedStats.kt`.
- Ran `ktfmtFormatMain` to ensure code style.
- Manual verification of code changes.

---
*PR created automatically by Jules for task [7053796783227841310](https://jules.google.com/task/7053796783227841310) started by @nonproto*