### PR TITLE
⚰️ Undertaker: Remove unused private function startAppUpdate

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -303,13 +303,6 @@ class NotificationReceiver : BroadcastReceiver() {
         dismissNotification(context, Notifications.ID_UPDATER)
     }
 
-    private fun startAppUpdate(context: Context, intent: Intent) {
-        val url = intent.getStringExtra(AppDownloadInstallJob.EXTRA_DOWNLOAD_URL) ?: return
-        val notifyOnInstall =
-            intent.getBooleanExtra(AppDownloadInstallJob.EXTRA_NOTIFY_ON_INSTALL, false)
-        AppDownloadInstallJob.start(context, url, notifyOnInstall)
-    }
-
     /**
      * Method called when user wants to download chapters
      *


### PR DESCRIPTION
Removed `private fun startAppUpdate` from `NotificationReceiver.kt`.
This function was private and not called within the class.
The corresponding intent action `ACTION_START_APP_UPDATE` is not handled in `onReceive`, rendering this function unreachable even if an intent was broadcasted.

💡 What: Removed `startAppUpdate` function.
🎯 Why: Dead code cleanup / Unused private function.
📉 Stats: 7 lines of code removed.

---
*PR created automatically by Jules for task [2352741112759159405](https://jules.google.com/task/2352741112759159405) started by @nonproto*