### PR TITLE
Fix Reader layout under navigation bar

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -878,18 +878,11 @@ class ReaderActivity : BaseActivity<ReaderActivityBinding>() {
                 leftMargin = 12.dpToPx + systemInsets.left
                 rightMargin = 12.dpToPx + systemInsets.right
             }
+            binding.pageNumber.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                bottomMargin = 12.dpToPx + systemInsets.bottom
+            }
             binding.chaptersSheet.root.sheetBehavior?.peekHeight =
-                peek +
-                    if (fullscreen) {
-                        insets.getBottomGestureInsets()
-                    } else {
-                        val rootInsets = binding.root.rootWindowInsetsCompat ?: insets
-                        max(
-                            0,
-                            (rootInsets.getBottomGestureInsets()) -
-                                rootInsets.getInsetsIgnoringVisibility(systemBars()).bottom,
-                        )
-                    }
+                peek + insets.getBottomGestureInsets()
             binding.chaptersSheet.chapterRecycler.updatePaddingRelative(
                 bottom = systemInsets.bottom
             )


### PR DESCRIPTION
Resolved issue #2649 where page number and gallery controls were positioned under the navigation bar when fullscreen was disabled. This was caused by the edge-to-edge enforcement on newer Android versions combined with a custom `OnApplyWindowInsetsListener` that disabled automatic framework padding. The fix involves manually applying bottom insets to the affected views.

---
*PR created automatically by Jules for task [3469163188173157661](https://jules.google.com/task/3469163188173157661) started by @nonproto*