### PR TITLE
perf: Optimize library sorting by pre-calculating title without articles

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryMangaItemComparator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryMangaItemComparator.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.ui.library
 
-import eu.kanade.tachiyomi.util.lang.removeArticles
 import org.nekomanga.domain.manga.LibraryMangaItem
 
 fun libraryMangaItemComparator(
@@ -76,7 +75,7 @@ fun libraryMangaItemComparator(
 private fun compareByTitle(removeArticles: Boolean): Comparator<LibraryMangaItem> {
     return compareBy {
         when (removeArticles) {
-            true -> it.displayManga.getTitle().removeArticles()
+            true -> it.titleWithoutArticles
             false -> it.displayManga.getTitle()
         }
     }

--- a/app/src/main/java/org/nekomanga/domain/manga/Manga.kt
+++ b/app/src/main/java/org/nekomanga/domain/manga/Manga.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.util.fastAny
 import eu.kanade.tachiyomi.data.database.models.Manga as DbManga
 import eu.kanade.tachiyomi.data.database.models.MergeType
 import eu.kanade.tachiyomi.ui.library.filter.FilterMangaType
+import eu.kanade.tachiyomi.util.lang.removeArticles
 import org.nekomanga.domain.category.CategoryItem
 
 data class SimpleManga(val title: String, val id: Long)
@@ -42,6 +43,7 @@ data class LibraryMangaItem(
     val status: List<String> = emptyList(),
     val seriesType: FilterMangaType = FilterMangaType.Manga,
     val rating: Double = (-1).toDouble(),
+    val titleWithoutArticles: String = displayManga.getTitle().removeArticles(),
 ) {
     val totalChapterCount
         get() = readCount + unreadCount


### PR DESCRIPTION
💡 What:
I optimized the library sorting logic by pre-calculating the "title without articles" (e.g., "Manga" for "The Manga") when the `LibraryMangaItem` is created, rather than calculating it every time two items are compared during the sort.

🎯 Why:
The `removeArticles()` function involves string manipulation (substrings) and is relatively expensive. When sorting a list of N items, the comparator is called O(N log N) times. If "Ignore articles" is enabled, this caused redundant recalculations. By caching the value in the data class, we shift the complexity to O(N) (once per item creation) and make the sort comparisons O(1) (simple string comparison).

📊 Impact:
Significantly reduces CPU overhead and object allocation during library sorting, especially for large libraries (e.g., 1000+ items). This leads to smoother UI updates when changing sort orders or refreshing the library.

🔬 Measurement:
Code inspection confirms `removeArticles()` is now called only once per item instantiation instead of multiple times per item during sorting.


---
*PR created automatically by Jules for task [11798609832974651950](https://jules.google.com/task/11798609832974651950) started by @nonproto*