### PR TITLE
chore: Improve accessibility for language flags

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
@@ -346,13 +346,13 @@ private fun ChapterSubtitle(subtitleText: String, language: String, textColor: C
 private fun LanguageIcon(language: String, textColor: Color) {
     if (language.equals(MdLang.ENGLISH.lang, true)) return
 
-    val iconRes = remember(language) { MdLang.fromIsoCode(language)?.iconResId }
+    val mdLang = remember(language) { MdLang.fromIsoCode(language) }
 
-    if (iconRes != null) {
+    if (mdLang?.iconResId != null) {
         Image(
-            painter = painterResource(id = iconRes),
+            painter = painterResource(id = mdLang.iconResId),
             modifier = Modifier.height(Size.medium).clip(RoundedCornerShape(Size.tiny)),
-            contentDescription = "Language flag",
+            contentDescription = mdLang.prettyPrint,
         )
         Spacer(modifier = Modifier.size(Size.tiny))
     } else {

--- a/app/src/main/java/org/nekomanga/presentation/screens/manga/InformationBlock.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/manga/InformationBlock.kt
@@ -276,13 +276,15 @@ private fun StatItem(
 @Composable
 private fun LanguageFlag(langFlag: String) {
     val context = LocalContext.current
-    val flag = remember(langFlag) { MdLang.fromIsoCode(langFlag.lowercase(Locale.US))?.iconResId }
-    if (flag != null) {
+    val mdLang = remember(langFlag) { MdLang.fromIsoCode(langFlag.lowercase(Locale.US)) }
+    if (mdLang?.iconResId != null) {
         Image(
             painter =
-                rememberDrawablePainter(drawable = AppCompatResources.getDrawable(context, flag)),
+                rememberDrawablePainter(
+                    drawable = AppCompatResources.getDrawable(context, mdLang.iconResId)
+                ),
             modifier = Modifier.height(Size.large).clip(RoundedCornerShape(Size.tiny)),
-            contentDescription = "Language flag",
+            contentDescription = mdLang.prettyPrint,
         )
     }
 }


### PR DESCRIPTION
💡 **What:** Replaced the hardcoded "Language flag" content description with the actual language name (e.g., "English", "Japanese") in `ChapterRow.kt` and `InformationBlock.kt`.

🎯 **Why:** To improve accessibility for screen reader users. Hearing "Language flag" repeatedly provides no useful information. Hearing the actual language name allows users to understand the content's language without needing to infer it from other context.

📸 **Before/After:**
*   **Before:** Screen reader announces "Language flag".
*   **After:** Screen reader announces "English", "Japanese", "Spanish (LATAM)", etc.

♿ **Accessibility:**
*   Added dynamic `contentDescription` using `MdLang.prettyPrint`.
*   Ensured consistent behavior across chapter lists and manga information blocks.

---
*PR created automatically by Jules for task [12515200533437696474](https://jules.google.com/task/12515200533437696474) started by @nonproto*