### PR TITLE
chore(security): Do not export CrashActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -137,10 +137,15 @@
                 <data android:host="${mangadexAuthRedirectUri}" />
             </intent-filter>
         </activity>
+        <!--
+         This activity should not be exported as it is intended to be used only internally
+         by the global exception handler. Exporting it would allow other apps to trigger
+         fake crash screens (phishing risk).
+        -->
         <activity
             android:process=":error_handler"
             android:name="eu.kanade.tachiyomi.crash.CrashActivity"
-            android:exported="true" />
+            android:exported="false" />
         <activity
             android:name="eu.kanade.tachiyomi.ui.main.DeepLinkActivity"
             android:launchMode="singleTask"


### PR DESCRIPTION
**Vulnerability:** `CrashActivity` was exported in `AndroidManifest.xml`.
**Impact:** Malicious apps could trigger a fake crash screen to phish users or disrupt usage.
**Fix:** Set `android:exported="false"` in `app/src/main/AndroidManifest.xml`.
**Verification:**
- Verified `CrashActivity` is now `exported="false"`.
- Ran `./gradlew app:compileStandardDebugKotlin` to ensure build passes.

---
*PR created automatically by Jules for task [17783607456304035474](https://jules.google.com/task/17783607456304035474) started by @nonproto*