### PR TITLE
chore: Extract 16.dp padding to Size.medium

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/dialog/TrackingChapterDialog.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/dialog/TrackingChapterDialog.kt
@@ -19,11 +19,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import org.nekomanga.R
 import org.nekomanga.domain.track.TrackItem
 import org.nekomanga.presentation.components.ExpressivePicker
 import org.nekomanga.presentation.components.theme.ThemeColorState
+import org.nekomanga.presentation.theme.Size
 
 @Composable
 fun TrackingChapterDialog(
@@ -55,7 +55,7 @@ fun TrackingChapterDialog(
             text = {
                 Box(
                     contentAlignment = Alignment.Center,
-                    modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                    modifier = Modifier.padding(Size.medium).fillMaxWidth(),
                 ) {
                     ExpressivePicker(
                         value = currentChapter,

--- a/app/src/main/java/org/nekomanga/presentation/components/dialog/TrackingScoreDialog.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/dialog/TrackingScoreDialog.kt
@@ -19,11 +19,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import eu.kanade.tachiyomi.ui.manga.TrackingConstants
 import org.nekomanga.R
 import org.nekomanga.presentation.components.ExpressivePicker
 import org.nekomanga.presentation.components.theme.ThemeColorState
+import org.nekomanga.presentation.theme.Size
 
 @Composable
 fun TrackingScoreDialog(
@@ -58,7 +58,7 @@ fun TrackingScoreDialog(
             text = {
                 Box(
                     contentAlignment = Alignment.Center,
-                    modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                    modifier = Modifier.padding(Size.medium).fillMaxWidth(),
                 ) {
                     ExpressivePicker(
                         modifier = Modifier.fillMaxWidth(.4f),

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/BasePreferenceWidget.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/BasePreferenceWidget.kt
@@ -29,9 +29,9 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
+import org.nekomanga.presentation.theme.Size
 
 @Composable
 internal fun BasePreferenceWidget(
@@ -55,7 +55,7 @@ internal fun BasePreferenceWidget(
     ) {
         if (icon != null) {
             Box(
-                modifier = Modifier.padding(start = PrefsHorizontalPadding, end = 8.dp),
+                modifier = Modifier.padding(start = PrefsHorizontalPadding, end = Size.small),
                 content = { icon() },
             )
         }
@@ -112,6 +112,6 @@ internal fun Modifier.highlightBackground(highlighted: Boolean): Modifier = comp
     Modifier.background(color = highlight)
 }
 
-internal val TrailingWidgetBuffer = 16.dp
-internal val PrefsHorizontalPadding = 16.dp
-internal val PrefsVerticalPadding = 16.dp
+internal val TrailingWidgetBuffer = Size.medium
+internal val PrefsHorizontalPadding = Size.medium
+internal val PrefsVerticalPadding = Size.medium


### PR DESCRIPTION
Extracted hardcoded `16.dp` and `8.dp` values to `Size.medium` and `Size.small` respectively in `TrackingChapterDialog`, `TrackingScoreDialog`, and `BasePreferenceWidget`. This improves consistency with the design system and centralized resource definitions.

---
*PR created automatically by Jules for task [11308649163888748110](https://jules.google.com/task/11308649163888748110) started by @nonproto*