### PR TITLE
chore: add accessibility label to header close button

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/ColumnHeader.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ColumnHeader.kt
@@ -12,9 +12,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import jp.wasabeef.gap.Gap
+import org.nekomanga.R
 import org.nekomanga.presentation.components.Divider
 import org.nekomanga.presentation.theme.Size
 
@@ -25,7 +27,7 @@ fun ColumnScope.Header(text: String, cancelClick: () -> Unit) {
         IconButton(onClick = { cancelClick() }) {
             Icon(
                 imageVector = Icons.Default.Close,
-                contentDescription = null,
+                contentDescription = stringResource(id = R.string.close),
                 modifier = Modifier.size(28.dp),
                 tint = MaterialTheme.colorScheme.onSurface,
             )


### PR DESCRIPTION
💡 What: Added `contentDescription` to the close icon button in `ColumnHeader.kt`.
🎯 Why: The close button was previously unlabelled (`contentDescription = null`), making it inaccessible to screen reader users who wouldn't know what the button does.
♿ Accessibility: Screen readers will now announce "Close" (localized) when focusing on this button.

---
*PR created automatically by Jules for task [7202658492308708973](https://jules.google.com/task/7202658492308708973) started by @nonproto*