### PR TITLE
chore: Add Preview for MangaGridItem

### DIFF
--- a/.jules/propmaster.md
+++ b/.jules/propmaster.md
@@ -1,3 +1,7 @@
 ## 2025-02-17 - NekoTheme Preview Wrapper
 **Learning:** `NekoTheme` (in `org.nekomanga.presentation.theme`) requires `Injekt` (dependency injection) for preferences. To use it in `@Preview` without crashing, manually pass a `colorScheme` parameter (e.g., `NekoColorScheme.lightScheme`).
 **Action:** Always wrap previews in `NekoTheme(colorScheme = ...)` or mock `Injekt`.
+
+## 2025-05-15 - Preview Wrappers and Image Mocks
+**Learning:** This app uses `ThemedPreviews` (composable) to render components across all themes. For Coil images in previews, use `AsyncImagePreviewHandler` provided via `LocalAsyncImagePreviewHandler`.
+**Action:** Wrap previews in `ThemedPreviews { ... }` and provide `LocalAsyncImagePreviewHandler` with a dummy `ColorImage`.

--- a/app/src/main/java/org/nekomanga/presentation/components/MangaGridItemPreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/MangaGridItemPreview.kt
@@ -1,0 +1,91 @@
+package org.nekomanga.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import coil3.ColorImage
+import coil3.compose.AsyncImagePreviewHandler
+import coil3.compose.LocalAsyncImagePreviewHandler
+import org.nekomanga.domain.manga.Artwork
+import org.nekomanga.domain.manga.DisplayManga
+import org.nekomanga.ui.theme.ThemedPreviews
+
+@Preview(widthDp = 400, showBackground = true)
+@Composable
+private fun MangaGridItemPreview(
+    @PreviewParameter(DisplayMangaProvider::class) displayManga: DisplayManga
+) {
+    val previewHandler = AsyncImagePreviewHandler { ColorImage(Color.Red.toArgb()) }
+    CompositionLocalProvider(LocalAsyncImagePreviewHandler provides previewHandler) {
+        ThemedPreviews {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                // Comfortable Item
+                MangaGridItem(
+                    displayManga = displayManga,
+                    shouldOutlineCover = true,
+                    isComfortable = true,
+                    showUnreadBadge = true,
+                    unreadCount = 12,
+                    showDownloadBadge = true,
+                    downloadCount = 5,
+                )
+
+                // Compact Item
+                MangaGridItem(
+                    displayManga = displayManga,
+                    shouldOutlineCover = true,
+                    isComfortable = false,
+                    showUnreadBadge = false,
+                    unreadCount = 0,
+                    showDownloadBadge = false,
+                    downloadCount = 0,
+                )
+            }
+        }
+    }
+}
+
+private class DisplayMangaProvider : PreviewParameterProvider<DisplayManga> {
+    override val values: Sequence<DisplayManga> =
+        sequenceOf(
+            DisplayManga(
+                mangaId = 1L,
+                inLibrary = true,
+                currentArtwork = Artwork(mangaId = 1L, inLibrary = true),
+                url = "",
+                originalTitle = "One Piece",
+                userTitle = "One Piece",
+                displayText = "Eiichiro Oda",
+            ),
+            DisplayManga(
+                mangaId = 2L,
+                inLibrary = false,
+                currentArtwork = Artwork(mangaId = 2L, inLibrary = false),
+                url = "",
+                originalTitle = "Detailed Long Title: The Adventure of a Lifetime in Another World",
+                userTitle = "",
+                displayText = "Author Name • Artist Name",
+            ),
+            DisplayManga(
+                mangaId = 3L,
+                inLibrary = true,
+                currentArtwork = Artwork(mangaId = 3L, inLibrary = true),
+                url = "",
+                originalTitle = "No Subtitle",
+                userTitle = "No Subtitle",
+                displayText = "",
+            ),
+        )
+}


### PR DESCRIPTION
Added `MangaGridItemPreview.kt` containing a `@Preview` composable and a `PreviewParameterProvider` for `DisplayManga`.
This preview allows for isolated development of the `MangaGridItem` component, covering various states including:
- Different title lengths
- Presence/absence of subtitles
- In-library status
- Comfortable vs Compact modes
- Theme variations (Light/Dark and all app themes via `ThemedPreviews`)

Mocking of Coil images is handled via `LocalAsyncImagePreviewHandler` to ensure previews render without network errors.

---
*PR created automatically by Jules for task [7724451632010195932](https://jules.google.com/task/7724451632010195932) started by @nonproto*