### PR TITLE
ref: Deduplicate ImageUtil logic and fix test configuration

### DIFF
--- a/.jules/groundskeeper.md
+++ b/.jules/groundskeeper.md
@@ -1,0 +1,4 @@
+
+## 2026-02-20 - [Test Configuration] **Learning:** The `app` module relies on JUnit 4 (via `libs.junit`) but the project root forces `useJUnitPlatform()`. To successfully run unit tests (e.g., `./gradlew app:testStandardDebugUnitTest`), the `app/build.gradle.kts` must explicitly configure `tasks.withType<Test> { useJUnit() }` to use the legacy runner. **Action:** Check parent build configurations for conflicting test runner settings when tests fail to launch.
+
+## 2026-02-20 - [Testing Internal Libraries] **Learning:** Classes in external libraries with `internal` constructors (like `tachiyomi.decoder.ImageType`) cannot be instantiated directly in tests and require MockK (e.g., `mockk<ImageType>()`) to simulate behavior. **Action:** Use mocking frameworks to bypass visibility restrictions when testing extension functions on external types.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -179,3 +179,5 @@ dependencies {
     testImplementation(libs.kotest.assertions)
     testImplementation(libs.mockk) { exclude(group = "junit", module = "junit") }
 }
+
+tasks.withType<Test> { useJUnit() }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -62,16 +62,7 @@ object ImageUtil {
 
     fun findImageType(stream: InputStream): ImageType? {
         return try {
-            when (getImageType(stream)?.format) {
-                Format.Avif -> ImageType.AVIF
-                Format.Gif -> ImageType.GIF
-                Format.Heif -> ImageType.HEIF
-                Format.Jpeg -> ImageType.JPEG
-                Format.Jxl -> ImageType.JXL
-                Format.Png -> ImageType.PNG
-                Format.Webp -> ImageType.WEBP
-                else -> null
-            }
+            getImageType(stream)?.toImageUtilType()
         } catch (e: Exception) {
             TimberKt.e(e) { "Error getting image type from stream" }
             null
@@ -80,16 +71,7 @@ object ImageUtil {
 
     fun findImageType(stream: BufferedSource): ImageType? {
         return try {
-            when (getImageType(stream)?.format) {
-                Format.Avif -> ImageType.AVIF
-                Format.Gif -> ImageType.GIF
-                Format.Heif -> ImageType.HEIF
-                Format.Jpeg -> ImageType.JPEG
-                Format.Jxl -> ImageType.JXL
-                Format.Png -> ImageType.PNG
-                Format.Webp -> ImageType.WEBP
-                else -> null
-            }
+            getImageType(stream)?.toImageUtilType()
         } catch (e: Exception) {
             TimberKt.e(e) { "Error getting image type from stream" }
             null
@@ -105,15 +87,7 @@ object ImageUtil {
     fun isAnimatedAndSupported(stream: InputStream): Boolean {
         try {
             val type = getImageType(stream) ?: return false
-            return when (type.format) {
-                Format.Gif -> true
-                // https://coil-kt.github.io/coil/getting_started/#supported-image-formats
-                // Animated WebP support on Android 9+
-                Format.Webp -> type.isAnimated && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
-                // Animated HEIF support on Android 11+
-                Format.Heif -> type.isAnimated && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
-                else -> false
-            }
+            return type.isAnimatedAndSupported()
         } catch (e: Exception) {
             TimberKt.e(e) { "Error is animated image type" }
         }
@@ -123,19 +97,38 @@ object ImageUtil {
     fun isAnimatedAndSupported(stream: BufferedSource): Boolean {
         try {
             val type = getImageType(stream) ?: return false
-            return when (type.format) {
-                Format.Gif -> true
-                // https://coil-kt.github.io/coil/getting_started/#supported-image-formats
-                // Animated WebP support on Android 9+
-                Format.Webp -> type.isAnimated && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
-                // Animated HEIF support on Android 11+
-                Format.Heif -> type.isAnimated && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
-                else -> false
-            }
+            return type.isAnimatedAndSupported()
         } catch (e: Exception) {
             TimberKt.e(e) { "Error is animated image type" }
         }
         return false
+    }
+
+    internal fun tachiyomi.decoder.ImageType.toImageUtilType(): ImageType? {
+        return when (format) {
+            Format.Avif -> ImageType.AVIF
+            Format.Gif -> ImageType.GIF
+            Format.Heif -> ImageType.HEIF
+            Format.Jpeg -> ImageType.JPEG
+            Format.Jxl -> ImageType.JXL
+            Format.Png -> ImageType.PNG
+            Format.Webp -> ImageType.WEBP
+            else -> null
+        }
+    }
+
+    internal fun tachiyomi.decoder.ImageType.isAnimatedAndSupported(
+        sdkInt: Int = Build.VERSION.SDK_INT
+    ): Boolean {
+        return when (format) {
+            Format.Gif -> true
+            // https://coil-kt.github.io/coil/getting_started/#supported-image-formats
+            // Animated WebP support on Android 9+
+            Format.Webp -> isAnimated && sdkInt >= Build.VERSION_CODES.P
+            // Animated HEIF support on Android 11+
+            Format.Heif -> isAnimated && sdkInt >= Build.VERSION_CODES.R
+            else -> false
+        }
     }
 
     enum class ImageType(val mime: String, val extension: String) {

--- a/app/src/test/java/eu/kanade/tachiyomi/util/system/ImageUtilTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/util/system/ImageUtilTest.kt
@@ -1,0 +1,65 @@
+package eu.kanade.tachiyomi.util.system
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tachiyomi.decoder.Format
+import tachiyomi.decoder.ImageType
+
+class ImageUtilTest {
+
+    @Test
+    fun testToImageUtilType() {
+        with(ImageUtil) {
+            fun mockType(fmt: Format): ImageType {
+                val m = mockk<ImageType>()
+                every { m.format } returns fmt
+                return m
+            }
+
+            assertEquals(ImageUtil.ImageType.AVIF, mockType(Format.Avif).toImageUtilType())
+            assertEquals(ImageUtil.ImageType.GIF, mockType(Format.Gif).toImageUtilType())
+            assertEquals(ImageUtil.ImageType.HEIF, mockType(Format.Heif).toImageUtilType())
+            assertEquals(ImageUtil.ImageType.JPEG, mockType(Format.Jpeg).toImageUtilType())
+            assertEquals(ImageUtil.ImageType.JXL, mockType(Format.Jxl).toImageUtilType())
+            assertEquals(ImageUtil.ImageType.PNG, mockType(Format.Png).toImageUtilType())
+            assertEquals(ImageUtil.ImageType.WEBP, mockType(Format.Webp).toImageUtilType())
+        }
+    }
+
+    @Test
+    fun testIsAnimatedAndSupported() {
+        with(ImageUtil) {
+            fun mockType(fmt: Format, animated: Boolean): ImageType {
+                val m = mockk<ImageType>()
+                every { m.format } returns fmt
+                every { m.isAnimated } returns animated
+                return m
+            }
+
+            // Gif is always supported
+            assertTrue(mockType(Format.Gif, true).isAnimatedAndSupported(sdkInt = 21))
+            assertTrue(mockType(Format.Gif, true).isAnimatedAndSupported(sdkInt = 30))
+
+            // WebP supported on P (28) +
+            assertTrue(mockType(Format.Webp, true).isAnimatedAndSupported(sdkInt = 28))
+            assertTrue(mockType(Format.Webp, true).isAnimatedAndSupported(sdkInt = 29))
+            assertFalse(mockType(Format.Webp, true).isAnimatedAndSupported(sdkInt = 27))
+            // Non animated WebP is false
+            assertFalse(mockType(Format.Webp, false).isAnimatedAndSupported(sdkInt = 28))
+
+            // Heif supported on R (30) +
+            assertTrue(mockType(Format.Heif, true).isAnimatedAndSupported(sdkInt = 30))
+            assertTrue(mockType(Format.Heif, true).isAnimatedAndSupported(sdkInt = 31))
+            assertFalse(mockType(Format.Heif, true).isAnimatedAndSupported(sdkInt = 29))
+            assertFalse(mockType(Format.Heif, false).isAnimatedAndSupported(sdkInt = 30))
+
+            // Others false
+            assertFalse(mockType(Format.Jpeg, true).isAnimatedAndSupported(sdkInt = 30))
+            assertFalse(mockType(Format.Png, true).isAnimatedAndSupported(sdkInt = 30))
+        }
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/util/system/ImageUtilTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/util/system/ImageUtilTest.kt
@@ -20,13 +20,19 @@ class ImageUtilTest {
                 return m
             }
 
-            assertEquals(ImageUtil.ImageType.AVIF, mockType(Format.Avif).toImageUtilType())
-            assertEquals(ImageUtil.ImageType.GIF, mockType(Format.Gif).toImageUtilType())
-            assertEquals(ImageUtil.ImageType.HEIF, mockType(Format.Heif).toImageUtilType())
-            assertEquals(ImageUtil.ImageType.JPEG, mockType(Format.Jpeg).toImageUtilType())
-            assertEquals(ImageUtil.ImageType.JXL, mockType(Format.Jxl).toImageUtilType())
-            assertEquals(ImageUtil.ImageType.PNG, mockType(Format.Png).toImageUtilType())
-            assertEquals(ImageUtil.ImageType.WEBP, mockType(Format.Webp).toImageUtilType())
+            val typeMappings = mapOf(
+                Format.Avif to ImageUtil.ImageType.AVIF,
+                Format.Gif to ImageUtil.ImageType.GIF,
+                Format.Heif to ImageUtil.ImageType.HEIF,
+                Format.Jpeg to ImageUtil.ImageType.JPEG,
+                Format.Jxl to ImageUtil.ImageType.JXL,
+                Format.Png to ImageUtil.ImageType.PNG,
+                Format.Webp to ImageUtil.ImageType.WEBP,
+            )
+
+            typeMappings.forEach { (format, expectedType) ->
+                assertEquals(expectedType, mockType(format).toImageUtilType())
+            }
         }
     }
 


### PR DESCRIPTION
- Extracted image type mapping and animation support check logic into `toImageUtilType` and `isAnimatedAndSupported` extension functions in `ImageUtil.kt`.
- Added `ImageUtilTest.kt` to verify the logic.
- Configured `app/build.gradle.kts` to use JUnit 4 runner for tests, resolving `TestSuiteExecutionException`.

---
*PR created automatically by Jules for task [18079236834105961490](https://jules.google.com/task/18079236834105961490) started by @nonproto*