### PR TITLE
Refactor @Preview methods to separate files

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/InfoScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/InfoScreen.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Newspaper
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -30,7 +28,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.zIndex
 import org.nekomanga.presentation.components.LauncherIcon
@@ -135,21 +132,5 @@ fun InfoScreen(
 
             content()
         }
-    }
-}
-
-@Preview
-@Composable
-private fun InfoScaffoldPreview() {
-    InfoScreen(
-        icon = Icons.Outlined.Newspaper,
-        headingText = "Heading",
-        subtitleText = "Subtitle",
-        acceptText = "Accept",
-        onAcceptClick = {},
-        rejectText = "Reject",
-        onRejectClick = {},
-    ) {
-        Text("Hello world")
     }
 }

--- a/app/src/main/java/org/nekomanga/presentation/InfoScreenPreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/InfoScreenPreview.kt
@@ -1,0 +1,23 @@
+package org.nekomanga.presentation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Newspaper
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview
+@Composable
+private fun InfoScaffoldPreview() {
+    InfoScreen(
+        icon = Icons.Outlined.Newspaper,
+        headingText = "Heading",
+        subtitleText = "Subtitle",
+        acceptText = "Accept",
+        onAcceptClick = {},
+        rejectText = "Reject",
+        onRejectClick = {},
+    ) {
+        Text("Hello world")
+    }
+}

--- a/app/src/main/java/org/nekomanga/presentation/components/DownloadUnreadBadge.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/DownloadUnreadBadge.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -20,7 +19,6 @@ import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
@@ -281,46 +279,4 @@ private class SlashedRoundedShape(
                 }
         )
     }
-}
-
-@Preview(showBackground = true, apiLevel = 32)
-@Composable
-private fun DownloadUnreadBadgePreview() {
-    Surface { DownloadUnreadBadge(true, true, 100, true, 100, 0.dp) }
-}
-
-@Preview(showBackground = true, apiLevel = 32)
-@Composable
-private fun DownloadUnreadBadgePreview10() {
-    Surface { DownloadUnreadBadge(true, true, 10, true, 1, 0.dp) }
-}
-
-@Preview(showBackground = true, apiLevel = 32)
-@Composable
-private fun DownloadUnreadBadgePreviewSmall() {
-    Surface { DownloadUnreadBadge(true, true, 1, true, 1, 0.dp) }
-}
-
-@Preview(showBackground = true, apiLevel = 32)
-@Composable
-private fun DownloadUnreadBadgePreview2() {
-    Surface { DownloadUnreadBadge(false, true, 100, true, 100, 0.dp) }
-}
-
-@Preview(showBackground = true, apiLevel = 32)
-@Composable
-private fun DownloadUnreadBadgePreview3() {
-    Surface { DownloadUnreadBadge(true, false, 100, true, 100, 0.dp) }
-}
-
-@Preview(showBackground = true, apiLevel = 32)
-@Composable
-private fun DownloadUnreadBadgePreview4() {
-    Surface { DownloadUnreadBadge(false, true, 100, false, 100, 0.dp) }
-}
-
-@Preview(showBackground = true, apiLevel = 32)
-@Composable
-private fun DownloadUnreadBadgePreview5() {
-    Surface { DownloadUnreadBadge(false, true, 1, false, 100, 0.dp) }
 }

--- a/app/src/main/java/org/nekomanga/presentation/components/DownloadUnreadBadgePreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/DownloadUnreadBadgePreview.kt
@@ -1,0 +1,48 @@
+package org.nekomanga.presentation.components
+
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Preview(showBackground = true, apiLevel = 32)
+@Composable
+private fun DownloadUnreadBadgePreview() {
+    Surface { DownloadUnreadBadge(true, true, 100, true, 100, 0.dp) }
+}
+
+@Preview(showBackground = true, apiLevel = 32)
+@Composable
+private fun DownloadUnreadBadgePreview10() {
+    Surface { DownloadUnreadBadge(true, true, 10, true, 1, 0.dp) }
+}
+
+@Preview(showBackground = true, apiLevel = 32)
+@Composable
+private fun DownloadUnreadBadgePreviewSmall() {
+    Surface { DownloadUnreadBadge(true, true, 1, true, 1, 0.dp) }
+}
+
+@Preview(showBackground = true, apiLevel = 32)
+@Composable
+private fun DownloadUnreadBadgePreview2() {
+    Surface { DownloadUnreadBadge(false, true, 100, true, 100, 0.dp) }
+}
+
+@Preview(showBackground = true, apiLevel = 32)
+@Composable
+private fun DownloadUnreadBadgePreview3() {
+    Surface { DownloadUnreadBadge(true, false, 100, true, 100, 0.dp) }
+}
+
+@Preview(showBackground = true, apiLevel = 32)
+@Composable
+private fun DownloadUnreadBadgePreview4() {
+    Surface { DownloadUnreadBadge(false, true, 100, false, 100, 0.dp) }
+}
+
+@Preview(showBackground = true, apiLevel = 32)
+@Composable
+private fun DownloadUnreadBadgePreview5() {
+    Surface { DownloadUnreadBadge(false, true, 1, false, 100, 0.dp) }
+}

--- a/app/src/main/java/org/nekomanga/presentation/components/HeaderCard.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/HeaderCard.kt
@@ -1,9 +1,7 @@
 package org.nekomanga.presentation.components
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
@@ -12,7 +10,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.nekomanga.presentation.theme.Shapes
 import org.nekomanga.presentation.theme.Size
@@ -38,12 +35,4 @@ fun DefaultHeaderText(text: String) {
         color = MaterialTheme.colorScheme.onSecondary,
         modifier = Modifier.fillMaxWidth().padding(12.dp),
     )
-}
-
-@Preview
-@Composable
-private fun HeaderCardPreview() {
-    Box(modifier = Modifier.statusBarsPadding()) {
-        HeaderCard { DefaultHeaderText(text = "My Test Header") }
-    }
 }

--- a/app/src/main/java/org/nekomanga/presentation/components/HeaderCardPreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/HeaderCardPreview.kt
@@ -1,0 +1,15 @@
+package org.nekomanga.presentation.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview
+@Composable
+private fun HeaderCardPreview() {
+    Box(modifier = Modifier.statusBarsPadding()) {
+        HeaderCard { DefaultHeaderText(text = "My Test Header") }
+    }
+}

--- a/app/src/main/java/org/nekomanga/presentation/components/MangaGridView.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/MangaGridView.kt
@@ -76,8 +76,8 @@ fun MangaGridWithHeader(
             }
 
             itemsIndexed(items = chunks, key = { index, _ -> "grid-row-$stringRes-$index" }) {
-                    _,
-                    rowItems ->
+                _,
+                rowItems ->
                 VerticalGrid(
                     columns = SimpleGridCells.Fixed(columns),
                     modifier = modifier.fillMaxWidth().padding(horizontal = Size.small),

--- a/app/src/main/java/org/nekomanga/presentation/components/theme/ThemeItem.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/theme/ThemeItem.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import eu.kanade.tachiyomi.util.system.isInNightMode
 import org.nekomanga.R
@@ -201,10 +200,4 @@ fun AppThemePreviewItem(
             }
         }
     }
-}
-
-@Preview
-@Composable
-private fun PreviewThemeItem() {
-    Surface() { ThemeItem(theme = Themes.Pink, isDarkTheme = false, selected = false) {} }
 }

--- a/app/src/main/java/org/nekomanga/presentation/components/theme/ThemeItemPreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/theme/ThemeItemPreview.kt
@@ -1,0 +1,12 @@
+package org.nekomanga.presentation.components.theme
+
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import org.nekomanga.presentation.theme.Themes
+
+@Preview
+@Composable
+private fun PreviewThemeItem() {
+    Surface() { ThemeItem(theme = Themes.Pink, isDarkTheme = false, selected = false) {} }
+}

--- a/app/src/main/java/org/nekomanga/presentation/screens/EmptyScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/EmptyScreen.kt
@@ -15,11 +15,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import jp.wasabeef.gap.Gap
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
-import org.nekomanga.R
 import org.nekomanga.presentation.components.NekoColors
 import org.nekomanga.presentation.components.UiText
 import org.nekomanga.presentation.theme.Size
@@ -111,15 +109,6 @@ fun EmptyScreen(
             Gap(Size.small)
         }
     }
-}
-
-@Preview
-@Composable
-private fun EmptyViewPreview() {
-    EmptyScreen(
-        message = UiText.StringResource(R.string.no_results_found),
-        actions = persistentListOf(Action(UiText.StringResource(R.string.retry))),
-    )
 }
 
 data class Action(val text: UiText, val onClick: () -> Unit = {})

--- a/app/src/main/java/org/nekomanga/presentation/screens/EmptyScreenPreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/EmptyScreenPreview.kt
@@ -1,0 +1,16 @@
+package org.nekomanga.presentation.screens
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import kotlinx.collections.immutable.persistentListOf
+import org.nekomanga.R
+import org.nekomanga.presentation.components.UiText
+
+@Preview
+@Composable
+private fun EmptyViewPreview() {
+    EmptyScreen(
+        message = UiText.StringResource(R.string.no_results_found),
+        actions = persistentListOf(Action(UiText.StringResource(R.string.retry))),
+    )
+}

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/widgets/InfoWidget.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/widgets/InfoWidget.kt
@@ -7,18 +7,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.PreviewLightDark
 import jp.wasabeef.gap.Gap
-import org.nekomanga.R
 import org.nekomanga.presentation.components.NekoColors
-import org.nekomanga.presentation.theme.NekoTheme
 import org.nekomanga.presentation.theme.Size
 
 @Composable
@@ -36,10 +31,4 @@ internal fun InfoWidget(text: String) {
             style = MaterialTheme.typography.bodyMedium,
         )
     }
-}
-
-@PreviewLightDark
-@Composable
-private fun InfoWidgetPreview() {
-    NekoTheme { Surface { InfoWidget(text = stringResource(R.string.download_ahead_info)) } }
 }

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/widgets/InfoWidgetPreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/widgets/InfoWidgetPreview.kt
@@ -1,0 +1,14 @@
+package org.nekomanga.presentation.screens.settings.widgets
+
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import org.nekomanga.R
+import org.nekomanga.presentation.theme.NekoTheme
+
+@PreviewLightDark
+@Composable
+private fun InfoWidgetPreview() {
+    NekoTheme { Surface { InfoWidget(text = stringResource(R.string.download_ahead_info)) } }
+}

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/widgets/SwitchPreferenceWidget.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/widgets/SwitchPreferenceWidget.kt
@@ -1,17 +1,11 @@
 package org.nekomanga.presentation.screens.settings.widgets
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Preview
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.tooling.preview.PreviewLightDark
 import org.nekomanga.presentation.screens.settings.TrailingWidgetBuffer
-import org.nekomanga.presentation.theme.NekoTheme
 
 @Composable
 fun SwitchPreferenceWidget(
@@ -36,38 +30,4 @@ fun SwitchPreferenceWidget(
         },
         onPreferenceClick = { onCheckedChanged(!checked) },
     )
-}
-
-@PreviewLightDark
-@Composable
-private fun SwitchPreferenceWidgetPreview() {
-    NekoTheme {
-        Surface {
-            Column {
-                SwitchPreferenceWidget(
-                    title = "Text preference with icon",
-                    subtitle = "Text preference summary",
-                    icon = Icons.Filled.Preview,
-                    checked = true,
-                    onCheckedChanged = {},
-                )
-                SwitchPreferenceWidget(
-                    title = "Text preference",
-                    subtitle = "Text preference summary",
-                    checked = false,
-                    onCheckedChanged = {},
-                )
-                SwitchPreferenceWidget(
-                    title = "Text preference no summary",
-                    checked = false,
-                    onCheckedChanged = {},
-                )
-                SwitchPreferenceWidget(
-                    title = "Another text preference no summary",
-                    checked = false,
-                    onCheckedChanged = {},
-                )
-            }
-        }
-    }
 }

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/widgets/SwitchPreferenceWidgetPreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/widgets/SwitchPreferenceWidgetPreview.kt
@@ -1,0 +1,43 @@
+package org.nekomanga.presentation.screens.settings.widgets
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Preview
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import org.nekomanga.presentation.theme.NekoTheme
+
+@PreviewLightDark
+@Composable
+private fun SwitchPreferenceWidgetPreview() {
+    NekoTheme {
+        Surface {
+            Column {
+                SwitchPreferenceWidget(
+                    title = "Text preference with icon",
+                    subtitle = "Text preference summary",
+                    icon = Icons.Filled.Preview,
+                    checked = true,
+                    onCheckedChanged = {},
+                )
+                SwitchPreferenceWidget(
+                    title = "Text preference",
+                    subtitle = "Text preference summary",
+                    checked = false,
+                    onCheckedChanged = {},
+                )
+                SwitchPreferenceWidget(
+                    title = "Text preference no summary",
+                    checked = false,
+                    onCheckedChanged = {},
+                )
+                SwitchPreferenceWidget(
+                    title = "Another text preference no summary",
+                    checked = false,
+                    onCheckedChanged = {},
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/widgets/TextPreferenceWidget.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/widgets/TextPreferenceWidget.kt
@@ -2,21 +2,16 @@ package org.nekomanga.presentation.screens.settings.widgets
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Preview
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.tooling.preview.PreviewLightDark
 import org.nekomanga.presentation.components.NekoColors
 import org.nekomanga.presentation.screens.settings.BasePreferenceWidget
-import org.nekomanga.presentation.theme.NekoTheme
 import org.nekomanga.presentation.theme.Size
 
 @Composable
@@ -67,26 +62,4 @@ fun TextPreferenceWidget(
         onClick = onPreferenceClick,
         widget = widget,
     )
-}
-
-@PreviewLightDark
-@Composable
-private fun TextPreferenceWidgetPreview() {
-    NekoTheme {
-        Surface {
-            Column {
-                TextPreferenceWidget(
-                    title = "Text preference with icon",
-                    subtitle = "Text preference summary",
-                    icon = Icons.Filled.Preview,
-                    onPreferenceClick = {},
-                )
-                TextPreferenceWidget(
-                    title = "Text preference",
-                    subtitle = "Text preference summary",
-                    onPreferenceClick = {},
-                )
-            }
-        }
-    }
 }

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/widgets/TextPreferenceWidgetPreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/widgets/TextPreferenceWidgetPreview.kt
@@ -1,0 +1,31 @@
+package org.nekomanga.presentation.screens.settings.widgets
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Preview
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import org.nekomanga.presentation.theme.NekoTheme
+
+@PreviewLightDark
+@Composable
+private fun TextPreferenceWidgetPreview() {
+    NekoTheme {
+        Surface {
+            Column {
+                TextPreferenceWidget(
+                    title = "Text preference with icon",
+                    subtitle = "Text preference summary",
+                    icon = Icons.Filled.Preview,
+                    onPreferenceClick = {},
+                )
+                TextPreferenceWidget(
+                    title = "Text preference",
+                    subtitle = "Text preference summary",
+                    onPreferenceClick = {},
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Moved `@Preview` annotated composables from their original files to new files suffixed with `Preview.kt` (e.g., `ThemeItemPreview.kt`). This refactoring cleans up the production code files and keeps preview logic separate.
The new preview files are placed in the same package as the original components to allow access to `internal` members where necessary.
Ran `ktfmt` to ensure code style compliance.
Verified compilation.

---
*PR created automatically by Jules for task [7775993887029895248](https://jules.google.com/task/7775993887029895248) started by @nonproto*