### PR TITLE
opt: Fix Chapter ID mapping in Recents query

### DIFF
--- a/.jules/oracle.md
+++ b/.jules/oracle.md
@@ -1,0 +1,1 @@
+## 2024-05-22 - StorIO Column Mapping Bug **Learning:** `SELECT *` in JOINs with duplicate column names (like `_id`) causes StorIO `GetResolver` to map the wrong ID if relying on `getColumnIndex(colName)` which returns the first occurrence. **Action:** Always alias ID columns in JOIN queries (e.g., `chapter._id AS chapter_id`) to ensure correct mapping.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
@@ -76,7 +76,7 @@ fun getRecentsQuery(offset: Int, limit: Int, sortByDateFetched: Boolean): String
         }
 
     return """
-    SELECT ${Manga.TABLE}.${Manga.COL_URL} as mangaUrl, * FROM ${Manga.TABLE} JOIN ${Chapter.TABLE}
+    SELECT ${Manga.TABLE}.${Manga.COL_URL} as mangaUrl, ${Chapter.TABLE}.${Chapter.COL_ID} as chapter_id, * FROM ${Manga.TABLE} JOIN ${Chapter.TABLE}
     ON ${Manga.TABLE}.${Manga.COL_ID} = ${Chapter.TABLE}.${Chapter.COL_MANGA_ID}
     WHERE ${Manga.COL_FAVORITE} = 1
     AND ${Chapter.COL_DATE_FETCH} > ${Manga.COL_DATE_ADDED}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/resolvers/MangaChapterGetResolver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/resolvers/MangaChapterGetResolver.kt
@@ -22,6 +22,11 @@ class MangaChapterGetResolver : DefaultGetResolver<MangaChapter>() {
         manga.id = chapter.manga_id
         manga.url = cursor.getString(cursor.getColumnIndex("mangaUrl"))
 
+        val chapterIdIndex = cursor.getColumnIndex("chapter_id")
+        if (chapterIdIndex != -1) {
+            chapter.id = cursor.getLong(chapterIdIndex)
+        }
+
         return MangaChapter(manga, chapter)
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/data/database/resolvers/MangaChapterGetResolverTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/database/resolvers/MangaChapterGetResolverTest.kt
@@ -1,0 +1,55 @@
+package eu.kanade.tachiyomi.data.database.resolvers
+
+import android.database.Cursor
+import eu.kanade.tachiyomi.data.database.tables.ChapterTable
+import eu.kanade.tachiyomi.data.database.tables.MangaTable
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MangaChapterGetResolverTest {
+
+    @Test
+    fun `test chapter id resolution with duplicate _id column`() {
+        val cursor = mockk<Cursor>(relaxed = true)
+        val resolver = MangaChapterGetResolver()
+
+        val mangaId = 100L
+        val chapterId = 200L // This is what we WANT, but won't get if not fixed
+
+        // Simulate the query result where _id appears twice but getColumnIndex returns the first
+        // one
+        every { cursor.getColumnIndex("_id") } returns 0
+        every { cursor.getLong(0) } returns mangaId
+
+        // Mock other required columns to avoid NPE or errors in resolvers
+        // Manga columns
+        every { cursor.getColumnIndex(MangaTable.COL_SOURCE) } returns 1
+        every { cursor.getLong(1) } returns 1L
+        every { cursor.getColumnIndex(MangaTable.COL_URL) } returns 2
+        every { cursor.getString(2) } returns "manga_url"
+        every { cursor.getColumnIndex("mangaUrl") } returns 3
+        every { cursor.getString(3) } returns "manga_url_alias"
+
+        // Chapter columns
+        // Note: ChapterGetResolver also looks for _id and gets index 0 -> mangaId
+
+        // Mocking chapter specific columns that don't clash
+        every { cursor.getColumnIndex(ChapterTable.COL_MANGA_ID) } returns 4
+        every { cursor.getLong(4) } returns mangaId // Correctly linked
+
+        // New column alias
+        every { cursor.getColumnIndex("chapter_id") } returns 5
+        every { cursor.getLong(5) } returns chapterId
+
+        // Execute
+        val result = resolver.mapFromCursor(cursor)
+
+        // Assert
+        assertEquals(mangaId, result.manga.id)
+
+        // After fix: it should pick up chapterId from the alias
+        assertEquals(chapterId, result.chapter.id)
+    }
+}


### PR DESCRIPTION
The `getRecentsQuery` was using `SELECT *` on a JOIN between `Manga` and `Chapter` tables. Both tables have an `_id` column.
StorIO's `GetResolver` uses `cursor.getColumnIndex(colName)` which returns the index of the *first* matching column.
Since `Manga` table comes first in the JOIN, `getColumnIndex("_id")` returned the index of `Manga._id`.
Consequently, `MangaChapterGetResolver` (via `ChapterGetResolver`) was populating `chapter.id` with the Manga's ID instead of the Chapter's ID.

This change:
1.  Modifies `getRecentsQuery` to explicitly include `${Chapter.TABLE}.${Chapter.COL_ID} as chapter_id`.
2.  Updates `MangaChapterGetResolver` to check for `chapter_id` column and use it if present.
3.  Adds a unit test `MangaChapterGetResolverTest` to reproduce the collision and verify the fix.
4.  Adds a learning to `.jules/oracle.md` regarding this pattern.


---
*PR created automatically by Jules for task [13506743415430066785](https://jules.google.com/task/13506743415430066785) started by @nonproto*