### PR TITLE
opt: remove redundant FrameLayout in reader_activity.xml

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -874,10 +874,10 @@ class ReaderActivity : BaseActivity<ReaderActivityBinding>() {
                 rightMargin = systemInsets.right
                 height = 280.dpToPx + systemInsets.bottom
             }
-            binding.navLayout.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+            binding.readerNav.root.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                 leftMargin = 12.dpToPx + systemInsets.left
                 rightMargin = 12.dpToPx + systemInsets.right
-                bottomMargin = systemInsets.bottom
+                bottomMargin = systemInsets.bottom + 6.dpToPx
             }
 
             binding.pageNumber.updateLayoutParams<ViewGroup.MarginLayoutParams> {

--- a/app/src/main/res/layout/reader_activity.xml
+++ b/app/src/main/res/layout/reader_activity.xml
@@ -73,21 +73,17 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <FrameLayout
-        android:id="@+id/nav_layout"
+    <include
+        layout="@layout/reader_nav"
+        android:id="@+id/reader_nav"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="6dp"
         android:layout_marginEnd="6dp"
-        android:paddingBottom="6dp"
+        android:layout_marginBottom="6dp"
         app:layout_anchorGravity="top"
         android:layout_gravity="top"
-        app:layout_anchor="@id/chapters_sheet">
-
-        <include
-            layout="@layout/reader_nav"
-            android:id="@+id/reader_nav" />
-    </FrameLayout>
+        app:layout_anchor="@id/chapters_sheet" />
 
     <include
         layout="@layout/reader_chapters_sheet"


### PR DESCRIPTION
Removed a redundant `FrameLayout` (`@+id/nav_layout`) in `app/src/main/res/layout/reader_activity.xml` to flatten the view hierarchy. This `FrameLayout` served only as a container for the `reader_nav` include and provided margins/padding.

Changes:
- Removed `FrameLayout` with ID `nav_layout`.
- Promoted `<include layout="@layout/reader_nav" ... />` to be a direct child of `CoordinatorLayout`.
- Migrated attributes (`layout_anchor`, `layout_gravity`, margins) to the `<include>` tag.
- Replaced `paddingBottom="6dp"` on the FrameLayout with `layout_marginBottom="6dp"` on the include to maintain the visual gap.
- Updated `ReaderActivity.kt` to reference `binding.readerNav.root` instead of the removed `binding.navLayout`.
- Adjusted margin calculations in `ReaderActivity.kt` to include the 6dp gap explicitly since the container padding is gone.

This optimization reduces the layout depth by 1 level for the reader navigation overlay, slightly improving layout performance.

---
*PR created automatically by Jules for task [2163779109899429453](https://jules.google.com/task/2163779109899429453) started by @nonproto*