### PR TITLE
ref(detektor): neutralize UnusedPrivateMember in MangaViewModel.kt

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -27,7 +27,6 @@ import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.track.TrackManager
 import eu.kanade.tachiyomi.data.track.matchingTrack
 import eu.kanade.tachiyomi.source.SourceManager
-import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.isMergedChapterOfType
 import eu.kanade.tachiyomi.source.online.MangaDexLoginHelper
 import eu.kanade.tachiyomi.source.online.handlers.StatusHandler
@@ -47,10 +46,7 @@ import eu.kanade.tachiyomi.util.chapter.ChapterItemFilter
 import eu.kanade.tachiyomi.util.chapter.ChapterItemSort
 import eu.kanade.tachiyomi.util.chapter.ChapterUtil
 import eu.kanade.tachiyomi.util.chapter.MissingChapterHolder
-import eu.kanade.tachiyomi.util.chapter.getChapterNum
 import eu.kanade.tachiyomi.util.chapter.getMissingChapters
-import eu.kanade.tachiyomi.util.chapter.getVolumeNum
-import eu.kanade.tachiyomi.util.chapter.isAvailable
 import eu.kanade.tachiyomi.util.chapter.updateTrackChapterMarkedAsRead
 import eu.kanade.tachiyomi.util.manga.MangaCoverMetadata
 import eu.kanade.tachiyomi.util.system.ImageUtil
@@ -1210,35 +1206,6 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                 simpleChapter = chapter,
             )
         } ?: NextUnreadChapter()
-    }
-
-    private fun isMangaStatusCompleted(
-        mangaItem: MangaItem,
-        missingChapterCount: String,
-        allChapters: List<ChapterItem>,
-    ): Boolean {
-        val cancelledOrCompleted =
-            mangaItem.status == SManga.PUBLICATION_COMPLETE || mangaItem.status == SManga.CANCELLED
-        if (
-            cancelledOrCompleted && missingChapterCount == "" && mangaItem.lastChapterNumber != null
-        ) {
-            val final =
-                allChapters
-                    .filter { it.isAvailable() }
-                    .filter {
-                        getChapterNum(it.chapter.toSChapter())?.toInt() ==
-                            mangaItem.lastChapterNumber
-                    }
-                    .filter {
-                        getVolumeNum(it.chapter.toSChapter()) == mangaItem.lastVolumeNumber ||
-                            getVolumeNum(it.chapter.toSChapter()) == null ||
-                            mangaItem.lastVolumeNumber == null
-                    }
-            if (final.isNotEmpty()) {
-                return true
-            }
-        }
-        return false
     }
 
     fun onSearch(searchQuery: String?) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
     alias(kotlinx.plugins.serialization) apply false
     alias(libs.plugins.firebase) apply false
     alias(libs.plugins.ktfmt)
+    alias(libs.plugins.detekt)
 }
 
 subprojects {
@@ -57,12 +58,24 @@ subprojects {
         }
     }
 
+    plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
+        tasks.withType<io.gitlab.arturbosch.detekt.Detekt> {
+            reports {
+                html.required.set(true)
+                xml.required.set(true)
+                txt.required.set(true)
+                sarif.required.set(true)
+            }
+        }
+    }
+
     plugins.withType<BasePlugin> {
         plugins.apply(libs.plugins.ktfmt.get().pluginId)
         ktfmt {
             kotlinLangStyle()
             removeUnusedImports = true
         }
+        plugins.apply(libs.plugins.detekt.get().pluginId)
 
         configure<BaseExtension> {
             compileSdkVersion(AndroidConfig.compileSdkVersion)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ firebasePluginVersion = "3.0.6"
 googleServicesPluginVersion = "4.4.4"
 injektCoreVersion = "1.16.1"
 kotlinResultVersion = "2.1.0"
+detektVersion = "1.23.5"
 ktfmtVersion = "0.25.0"
 okhttpVersion = "5.3.2"
 photoViewVersion = "2.3.0"
@@ -108,6 +109,7 @@ about-libraries = { id = "com.mikepenz.aboutlibraries.plugin.android", version.r
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServicesPluginVersion" }
 firebase = { id = "com.google.firebase.crashlytics", version.ref = "firebasePluginVersion" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmtVersion" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektVersion" }
 
 [bundles]
 coil = [ "coil3", "coil3-compose", "coil3-svg", "coil3-gif", "coil3-okhttp" ]


### PR DESCRIPTION
* 💡 Detection: `UnusedPrivateMember` rule triggered for `isMangaStatusCompleted` in `app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt`.
* 🎯 Neutralization: Removed the unused private function `isMangaStatusCompleted`.
* 🛠️ Config: Added Detekt configuration to `libs.versions.toml` and `build.gradle.kts` to enable the scan.
* 📊 Status: Violation cleared; Build successful; Tests passed.

---
*PR created automatically by Jules for task [13820631882330551257](https://jules.google.com/task/13820631882330551257) started by @nonproto*