### PR TITLE
perf: Hoist event callbacks in Compose lists

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Hoist Event Callbacks in Compose Lists/Grids
+**Learning:** Inline lambdas inside `items` / `itemsIndexed` blocks create new function instances on every recomposition, breaking skippability of item composables even if their data is unchanged. By hoisting the callback signature to accept the item ID/Model and passing a stable function reference (or a lambda that doesn't capture unstable state), we allow Compose to skip recomposition of individual items.
+**Action:** Always prefer passing `(Id) -> Unit` or `(Item) -> Unit` to list item composables instead of `() -> Unit` that captures the item.

--- a/app/src/main/java/org/nekomanga/presentation/components/MangaGridView.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/MangaGridView.kt
@@ -88,8 +88,8 @@ fun MangaGridWithHeader(
                             displayManga = displayManga,
                             shouldOutlineCover = shouldOutlineCover,
                             isComfortable = isComfortable,
-                            onClick = { onClick(displayManga.mangaId) },
-                            onLongClick = { onLongClick(displayManga) },
+                            onClick = onClick,
+                            onLongClick = onLongClick,
                         )
                     }
                 }
@@ -145,8 +145,8 @@ fun MangaGrid(
                 displayManga = displayManga,
                 shouldOutlineCover = shouldOutlineCover,
                 isComfortable = isComfortable,
-                onClick = { onClick(displayManga.mangaId) },
-                onLongClick = { onLongClick(displayManga) },
+                onClick = onClick,
+                onLongClick = onLongClick,
             )
         }
     }
@@ -165,8 +165,9 @@ fun MangaGridItem(
     isSelected: Boolean = false,
     showStartReadingButton: Boolean = false,
     onStartReadingClick: () -> Unit = {},
-    onClick: () -> Unit = {},
-    onLongClick: () -> Unit = {},
+    // Optimize: Use stable function references to allow skipping recomposition
+    onClick: (Long) -> Unit = {},
+    onLongClick: (DisplayManga) -> Unit = {},
 ) {
     val subtitleText =
         when (displayManga.displayTextRes) {
@@ -205,7 +206,10 @@ fun MangaGridItem(
             Box(
                 modifier =
                     Modifier.clip(RoundedCornerShape(Shapes.coverRadius))
-                        .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+                        .combinedClickable(
+                            onClick = { onClick(displayManga.mangaId) },
+                            onLongClick = { onLongClick(displayManga) },
+                        )
                         .padding(Size.extraTiny)
                         .semantics { this.contentDescription = contentDescription }
             ) {

--- a/app/src/main/java/org/nekomanga/presentation/components/MangaListView.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/MangaListView.kt
@@ -80,22 +80,13 @@ fun MangaList(
                     mangaList.size == 1 -> ListCardType.Single
                     else -> ListCardType.Center
                 }
-            ExpressiveListCard(
-                modifier = Modifier.padding(horizontal = Size.small),
+            MangaListItem(
+                displayManga = displayManga,
                 listCardType = listCardType,
-            ) {
-                MangaRow(
-                    displayManga = displayManga,
-                    shouldOutlineCover = shouldOutlineCover,
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .wrapContentHeight()
-                            .combinedClickable(
-                                onClick = { onClick(displayManga.mangaId) },
-                                onLongClick = { onLongClick(displayManga) },
-                            ),
-                )
-            }
+                shouldOutlineCover = shouldOutlineCover,
+                onClick = onClick,
+                onLongClick = onLongClick,
+            )
         }
     }
 }
@@ -137,24 +128,42 @@ fun MangaListWithHeader(
                         mangaList.size == 1 -> ListCardType.Single
                         else -> ListCardType.Center
                     }
-                ExpressiveListCard(
-                    modifier = Modifier.padding(horizontal = Size.small),
+                MangaListItem(
+                    displayManga = displayManga,
                     listCardType = listCardType,
-                ) {
-                    MangaRow(
-                        displayManga = displayManga,
-                        shouldOutlineCover = shouldOutlineCover,
-                        modifier =
-                            Modifier.fillMaxWidth()
-                                .wrapContentHeight()
-                                .combinedClickable(
-                                    onClick = { onClick(displayManga.mangaId) },
-                                    onLongClick = { onLongClick(displayManga) },
-                                ),
-                    )
-                }
+                    shouldOutlineCover = shouldOutlineCover,
+                    onClick = onClick,
+                    onLongClick = onLongClick,
+                )
             }
         }
+    }
+}
+
+@Composable
+private fun MangaListItem(
+    displayManga: DisplayManga,
+    listCardType: ListCardType,
+    shouldOutlineCover: Boolean,
+    // Optimize: Use stable function references to allow skipping recomposition
+    onClick: (Long) -> Unit,
+    onLongClick: (DisplayManga) -> Unit,
+) {
+    ExpressiveListCard(
+        modifier = Modifier.padding(horizontal = Size.small),
+        listCardType = listCardType,
+    ) {
+        MangaRow(
+            displayManga = displayManga,
+            shouldOutlineCover = shouldOutlineCover,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .wrapContentHeight()
+                    .combinedClickable(
+                        onClick = { onClick(displayManga.mangaId) },
+                        onLongClick = { onLongClick(displayManga) },
+                    ),
+        )
     }
 }
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/library/HorizontalCategoriesPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/library/HorizontalCategoriesPage.kt
@@ -358,14 +358,14 @@ private fun GridItem(
         onStartReadingClick = {
             libraryScreenActions.mangaStartReadingClick(libraryItem.displayManga.mangaId)
         },
-        onClick = {
+        onClick = { _ ->
             if (libraryScreenState.selectedItems.isNotEmpty()) {
                 libraryScreenActions.mangaLongClick(libraryItem)
             } else {
                 libraryScreenActions.mangaClick(libraryItem.displayManga.mangaId)
             }
         },
-        onLongClick = { libraryScreenActions.mangaLongClick(libraryItem) },
+        onLongClick = { _ -> libraryScreenActions.mangaLongClick(libraryItem) },
     )
 }
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/library/VerticalCategoriesPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/library/VerticalCategoriesPage.kt
@@ -218,14 +218,14 @@ private fun RowGrid(
                 onStartReadingClick = {
                     libraryScreenActions.mangaStartReadingClick(libraryItem.displayManga.mangaId)
                 },
-                onClick = {
+                onClick = { _ ->
                     if (selectedIds.isNotEmpty()) {
                         libraryScreenActions.mangaLongClick(libraryItem)
                     } else {
                         libraryScreenActions.mangaClick(libraryItem.displayManga.mangaId)
                     }
                 },
-                onLongClick = { libraryScreenActions.mangaLongClick(libraryItem) },
+                onLongClick = { _ -> libraryScreenActions.mangaLongClick(libraryItem) },
             )
         }
     }


### PR DESCRIPTION
💡 What: Updated `MangaGridItem` (and created `MangaListItem`) to accept `onClick: (Long) -> Unit` and `onLongClick: (DisplayManga) -> Unit` instead of parameterless lambdas that capture the item.
🎯 Why: Previously, inline lambdas created new function instances for every item on every recomposition of the parent list/grid. This prevented Compose from skipping recomposition of individual items even if their data (`DisplayManga`) hadn't changed.
📊 Impact: Reduces unnecessary recomposition of heavy `MangaGridItem` and `MangaRow` components during scrolling or parent state updates.
🔬 Measurement: Verified with lint and manual code inspection. The optimization follows standard Compose performance best practices.

---
*PR created automatically by Jules for task [15239308395933500101](https://jules.google.com/task/15239308395933500101) started by @nonproto*