### PR TITLE
Redact Cookie and Set-Cookie headers in network logs

### DIFF
--- a/core/src/main/kotlin/org/nekomanga/core/network/interceptor/LoggingInterceptor.kt
+++ b/core/src/main/kotlin/org/nekomanga/core/network/interceptor/LoggingInterceptor.kt
@@ -29,5 +29,7 @@ fun loggingInterceptor(verboseLoggingProvider: () -> Boolean, json: Json): HttpL
                 false -> HttpLoggingInterceptor.Level.BASIC
             }
         redactHeader(HttpHeaders.AUTHORIZATION)
+        redactHeader(HttpHeaders.COOKIE)
+        redactHeader(HttpHeaders.SET_COOKIE)
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: Redacted sensitive Cookie headers from network logs

**Vulnerability:** Session cookies were being logged in plain text by `HttpLoggingInterceptor`, exposing potential session hijacking risks if logs are shared or leaked.
**Fix:** Explicitly redacted `Cookie` and `Set-Cookie` headers in `LoggingInterceptor.kt`, similar to how `Authorization` is already handled.
**Verification:**
- Verified code changes in `core/src/main/kotlin/org/nekomanga/core/network/interceptor/LoggingInterceptor.kt`.
- Ran `lintDebug` and `app:testStandardDebugUnitTest` to ensure no regressions.

---
*PR created automatically by Jules for task [12150505319566129018](https://jules.google.com/task/12150505319566129018) started by @nonproto*