### PR TITLE
chore: Add accessibility labels to tracking icons

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/sheets/TrackingSearchSheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/sheets/TrackingSearchSheet.kt
@@ -228,7 +228,7 @@ private fun TrackSearchItem(
                 ) {
                     Icon(
                         imageVector = Icons.Default.OpenInBrowser,
-                        contentDescription = null,
+                        contentDescription = stringResource(id = R.string.open_in_browser),
                         modifier = Modifier.size(24.dp),
                         tint = MaterialTheme.colorScheme.onSurface,
                     )
@@ -319,7 +319,7 @@ private fun TrackSearchItem(
                 ) {
                     Icon(
                         imageVector = Icons.Default.Check,
-                        contentDescription = null,
+                        contentDescription = stringResource(id = R.string.selected),
                         modifier = Modifier.size(20.dp),
                         tint = MaterialTheme.colorScheme.surface,
                     )

--- a/app/src/main/java/org/nekomanga/presentation/components/sheets/TrackingSheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/sheets/TrackingSheet.kt
@@ -325,7 +325,7 @@ private fun TrackRowOne(
             IconButton(onClick = onRemoveClick) {
                 Icon(
                     imageVector = Icons.Default.Cancel,
-                    contentDescription = null,
+                    contentDescription = stringResource(id = R.string.remove),
                     modifier = Modifier.padding(end = Size.small).size(24.dp),
                     tint = themeColor.primaryColor,
                 )
@@ -477,7 +477,7 @@ private fun Logo(service: TrackServiceItem, track: TrackItem?, onClick: (String,
     ) {
         Image(
             painter = painterResource(id = service.logoRes),
-            contentDescription = null,
+            contentDescription = stringResource(id = service.nameRes),
             modifier = Modifier.align(Alignment.Center),
         )
     }


### PR DESCRIPTION
💡 What: Added `contentDescription` to icon-only buttons and informative images in `TrackingSearchSheet` and `TrackingSheet`.

🎯 Why: To make the tracking feature accessible to screen reader users. Previously, these buttons were announced as "unlabelled" or ignored.

♿ Accessibility:
- Added `R.string.open_in_browser` description to the external link button.
- Added `R.string.selected` description to the selection indicator.
- Added `service.nameRes` description to the service logo.
- Added `R.string.remove` description to the remove tracking button.

---
*PR created automatically by Jules for task [7010546842543368633](https://jules.google.com/task/7010546842543368633) started by @nonproto*