### PR TITLE
chore: Improve ChapterRow accessibility with role and click label

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -211,6 +212,8 @@ private fun ChapterRowContent(
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         isDropdownExpanded = true
                     },
+                    role = Role.Button,
+                    onClickLabel = stringResource(id = R.string.start_reading),
                 )
                 .padding(start = Size.small, top = Size.small, bottom = Size.small),
         horizontalArrangement = Arrangement.SpaceBetween,


### PR DESCRIPTION
🎨 **Palette's Touch:**

Added semantic information to the `ChapterRow` component to make it more accessible for screen reader users.

**Changes:**
- Added `role = Role.Button` to the `combinedClickable` modifier. This ensures TalkBack announces the row as a button, indicating interactivity.
- Added `onClickLabel = stringResource(id = R.string.start_reading)` to the `combinedClickable` modifier. This provides a clear action description ("Double tap to Start Reading") instead of a generic "activate".

**Why:**
Users relying on screen readers need clear indications of what interactive elements do. A generic "double tap to activate" on a list item is less helpful than "double tap to start reading". This small change improves the navigation experience significantly.

**Verification:**
- Verified `R.string.start_reading` exists in `constants/src/main/res/values/strings.xml`.
- Verified imports in `ChapterRow.kt`.
- Ran `ktfmt` to ensure code style compliance.


---
*PR created automatically by Jules for task [275986641778589855](https://jules.google.com/task/275986641778589855) started by @nonproto*