### PR TITLE
ref: use TypedArray.use extension for resource safety

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
@@ -29,6 +29,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
+import androidx.core.content.res.use
 import androidx.core.net.toUri
 import androidx.work.CoroutineWorker
 import androidx.work.WorkInfo
@@ -121,17 +122,11 @@ fun Context.hasPermission(permission: String) =
  */
 @ColorInt
 fun Context.getResourceColor(@AttrRes resource: Int): Int {
-    val typedArray = obtainStyledAttributes(intArrayOf(resource))
-    val attrValue = typedArray.getColor(0, 0)
-    typedArray.recycle()
-    return attrValue
+    return obtainStyledAttributes(intArrayOf(resource)).use { it.getColor(0, 0) }
 }
 
 fun Context.getResourceDrawable(@AttrRes resource: Int): Drawable? {
-    val typedArray = obtainStyledAttributes(intArrayOf(resource))
-    val attrValue = typedArray.getDrawable(0)
-    typedArray.recycle()
-    return attrValue
+    return obtainStyledAttributes(intArrayOf(resource)).use { it.getDrawable(0) }
 }
 
 /**


### PR DESCRIPTION
Refactored `obtainStyledAttributes` usage in `ContextExtensions.kt` and `ReaderActivity.kt` to use `androidx.core.content.res.use`. This ensures `TypedArray.recycle()` is always called, improving resource safety and code readability.

---
*PR created automatically by Jules for task [4747683636813214413](https://jules.google.com/task/4747683636813214413) started by @nonproto*