### PR TITLE
ref: Move MangaExtensions to util.manga

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadStore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadStore.kt
@@ -7,8 +7,8 @@ import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.model.getHttpSource
+import eu.kanade.tachiyomi.util.manga.toSimpleManga
 import eu.kanade.tachiyomi.util.system.executeOnIO
-import eu.kanade.tachiyomi.util.toSimpleManga
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.nekomanga.domain.chapter.toSimpleChapter

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -14,11 +14,11 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.source.online.MangaDex
 import eu.kanade.tachiyomi.util.chapter.ChapterItemSort
+import eu.kanade.tachiyomi.util.manga.toSimpleManga
 import eu.kanade.tachiyomi.util.storage.saveTo
 import eu.kanade.tachiyomi.util.system.ImageUtil
 import eu.kanade.tachiyomi.util.system.launchIO
 import eu.kanade.tachiyomi.util.system.withIOContext
-import eu.kanade.tachiyomi.util.toSimpleManga
 import java.io.BufferedOutputStream
 import java.io.File
 import java.util.Locale

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/model/Download.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/model/Download.kt
@@ -5,8 +5,8 @@ import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.getHttpSource
 import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.util.manga.toSimpleManga
 import eu.kanade.tachiyomi.util.system.executeOnIO
-import eu.kanade.tachiyomi.util.toSimpleManga
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -51,7 +51,8 @@ import eu.kanade.tachiyomi.util.chapter.ChapterUtil
 import eu.kanade.tachiyomi.util.chapter.getChapterNum
 import eu.kanade.tachiyomi.util.chapter.mergeSorted
 import eu.kanade.tachiyomi.util.chapter.syncChaptersWithSource
-import eu.kanade.tachiyomi.util.shouldDownloadNewChapters
+import eu.kanade.tachiyomi.util.manga.shouldDownloadNewChapters
+import eu.kanade.tachiyomi.util.manga.toDisplayManga
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.createFileInCacheDir
 import eu.kanade.tachiyomi.util.system.executeOnIO
@@ -61,7 +62,6 @@ import eu.kanade.tachiyomi.util.system.launchIO
 import eu.kanade.tachiyomi.util.system.saveTimeTaken
 import eu.kanade.tachiyomi.util.system.tryToSetForeground
 import eu.kanade.tachiyomi.util.system.withIOContext
-import eu.kanade.tachiyomi.util.toDisplayManga
 import java.io.File
 import java.lang.ref.WeakReference
 import java.util.Collections

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
@@ -26,10 +26,10 @@ import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.ui.main.DeepLinks
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.util.lang.chop
+import eu.kanade.tachiyomi.util.manga.toDisplayManga
 import eu.kanade.tachiyomi.util.system.notification
 import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.notificationManager
-import eu.kanade.tachiyomi.util.toDisplayManga
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedRepository.kt
@@ -13,8 +13,8 @@ import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.ui.manga.MangaConstants
 import eu.kanade.tachiyomi.util.chapter.ChapterItemSort
 import eu.kanade.tachiyomi.util.chapter.isAvailable
+import eu.kanade.tachiyomi.util.manga.toDisplayManga
 import eu.kanade.tachiyomi.util.system.executeOnIO
-import eu.kanade.tachiyomi.util.toDisplayManga
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -32,12 +32,12 @@ import eu.kanade.tachiyomi.ui.manga.MangaConstants.DownloadAction
 import eu.kanade.tachiyomi.util.chapter.ChapterItemFilter
 import eu.kanade.tachiyomi.util.chapter.ChapterItemSort
 import eu.kanade.tachiyomi.util.chapter.isAvailable
+import eu.kanade.tachiyomi.util.manga.toLibraryMangaItem
 import eu.kanade.tachiyomi.util.system.asFlow
 import eu.kanade.tachiyomi.util.system.combine
 import eu.kanade.tachiyomi.util.system.executeOnIO
 import eu.kanade.tachiyomi.util.system.launchIO
 import eu.kanade.tachiyomi.util.system.launchNonCancellable
-import eu.kanade.tachiyomi.util.toLibraryMangaItem
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaUpdateCoordinator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaUpdateCoordinator.kt
@@ -15,7 +15,7 @@ import eu.kanade.tachiyomi.source.model.isMergedChapter
 import eu.kanade.tachiyomi.util.chapter.getChapterNum
 import eu.kanade.tachiyomi.util.chapter.syncChaptersWithSource
 import eu.kanade.tachiyomi.util.manga.MangaShortcutManager
-import eu.kanade.tachiyomi.util.shouldDownloadNewChapters
+import eu.kanade.tachiyomi.util.manga.shouldDownloadNewChapters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/similar/SimilarRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/similar/SimilarRepository.kt
@@ -5,8 +5,8 @@ import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.online.MangaDex
 import eu.kanade.tachiyomi.source.online.handlers.SimilarHandler
+import eu.kanade.tachiyomi.util.manga.toDisplayManga
 import eu.kanade.tachiyomi.util.system.logTimeTaken
-import eu.kanade.tachiyomi.util.toDisplayManga
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseRepository.kt
@@ -9,8 +9,8 @@ import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.online.MangaDex
 import eu.kanade.tachiyomi.source.online.MangaDexLoginHelper
+import eu.kanade.tachiyomi.util.manga.toDisplayManga
 import eu.kanade.tachiyomi.util.system.executeOnIO
-import eu.kanade.tachiyomi.util.toDisplayManga
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.domain.filter.DexFilters

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseViewModel.kt
@@ -13,11 +13,11 @@ import eu.kanade.tachiyomi.source.online.utils.MdSort
 import eu.kanade.tachiyomi.ui.library.LibraryDisplayMode
 import eu.kanade.tachiyomi.ui.source.latest.DisplayScreenType
 import eu.kanade.tachiyomi.util.category.CategoryUtil
-import eu.kanade.tachiyomi.util.filterVisibility
-import eu.kanade.tachiyomi.util.resync
+import eu.kanade.tachiyomi.util.manga.filterVisibility
+import eu.kanade.tachiyomi.util.manga.resync
+import eu.kanade.tachiyomi.util.manga.unique
+import eu.kanade.tachiyomi.util.manga.updateVisibility
 import eu.kanade.tachiyomi.util.system.launchIO
-import eu.kanade.tachiyomi.util.unique
-import eu.kanade.tachiyomi.util.updateVisibility
 import java.util.Date
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayRepository.kt
@@ -10,8 +10,8 @@ import com.github.michaelbull.result.onSuccess
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.online.MangaDex
+import eu.kanade.tachiyomi.util.manga.toDisplayManga
 import eu.kanade.tachiyomi.util.system.executeOnIO
-import eu.kanade.tachiyomi.util.toDisplayManga
 import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.domain.filter.DexFilters
 import org.nekomanga.domain.filter.Filter

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayViewModel.kt
@@ -10,10 +10,10 @@ import eu.kanade.tachiyomi.data.database.models.MangaCategory
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.ui.library.LibraryDisplayMode
 import eu.kanade.tachiyomi.util.category.CategoryUtil
-import eu.kanade.tachiyomi.util.filterVisibility
-import eu.kanade.tachiyomi.util.resync
+import eu.kanade.tachiyomi.util.manga.filterVisibility
+import eu.kanade.tachiyomi.util.manga.resync
+import eu.kanade.tachiyomi.util.manga.unique
 import eu.kanade.tachiyomi.util.system.launchIO
-import eu.kanade.tachiyomi.util.unique
 import java.util.Date
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.util
+package eu.kanade.tachiyomi.util.manga
 
 import androidx.annotation.StringRes
 import eu.kanade.tachiyomi.data.database.DatabaseHelper

--- a/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaShortcutManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaShortcutManager.kt
@@ -16,7 +16,6 @@ import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.ui.feed.FeedRepository
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.util.system.launchIO
-import eu.kanade.tachiyomi.util.toDisplayManga
 import kotlin.math.min
 import kotlinx.coroutines.GlobalScope
 import org.nekomanga.R

--- a/app/src/main/java/org/nekomanga/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/LibraryScreen.kt
@@ -43,7 +43,7 @@ import eu.kanade.tachiyomi.ui.library.LibraryViewModel
 import eu.kanade.tachiyomi.ui.main.states.RefreshState
 import eu.kanade.tachiyomi.ui.manga.MangaConstants
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
-import eu.kanade.tachiyomi.util.toLibraryManga
+import eu.kanade.tachiyomi.util.manga.toLibraryManga
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.nekomanga.R

--- a/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
@@ -61,7 +61,7 @@ import eu.kanade.tachiyomi.ui.manga.MangaViewModel
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.ui.source.latest.DisplayScreenType
 import eu.kanade.tachiyomi.util.chapter.isAvailable
-import eu.kanade.tachiyomi.util.getSlug
+import eu.kanade.tachiyomi.util.manga.getSlug
 import eu.kanade.tachiyomi.util.storage.getUriWithAuthority
 import eu.kanade.tachiyomi.util.system.getBestColor
 import eu.kanade.tachiyomi.util.system.openInBrowser

--- a/app/src/main/java/org/nekomanga/presentation/screens/deepLink/DeepLinkViewModel.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/deepLink/DeepLinkViewModel.kt
@@ -17,7 +17,7 @@ import eu.kanade.tachiyomi.ui.source.latest.DisplayScreenType
 import eu.kanade.tachiyomi.ui.source.latest.SerializableDisplayScreenType
 import eu.kanade.tachiyomi.ui.source.latest.toSerializable
 import eu.kanade.tachiyomi.util.manga.MangaMappings
-import eu.kanade.tachiyomi.util.toDisplayManga
+import eu.kanade.tachiyomi.util.manga.toDisplayManga
 import java.math.BigInteger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow


### PR DESCRIPTION
Moves `MangaExtensions.kt` from `eu.kanade.tachiyomi.util` to `eu.kanade.tachiyomi.util.manga`.

This change:
- Consolidates manga-related utility functions into the `util.manga` package.
- Updates the package declaration in `MangaExtensions.kt`.
- Updates imports in all files using these extensions (e.g., `toDisplayManga`, `shouldDownloadNewChapters`, `unique`, etc.).
- Removes redundant imports in files within `util.manga` (e.g., `MangaShortcutManager.kt`).

Verified by running `app:testStandardDebugUnitTest`.

---
*PR created automatically by Jules for task [4299667697761215306](https://jules.google.com/task/4299667697761215306) started by @nonproto*