### PR TITLE
chore: Improve logging in App.kt

### DIFF
--- a/app/src/main/java/org/nekomanga/App.kt
+++ b/app/src/main/java/org/nekomanga/App.kt
@@ -183,7 +183,9 @@ open class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.F
                 }
 
             if (isChromiumCall) return WebViewUtil.spoofedPackageName(applicationContext)
-        } catch (_: Exception) {}
+        } catch (e: Exception) {
+            TimberKt.e(e) { "Failed to spoof package name" }
+        }
 
         return super.getPackageName()
     }


### PR DESCRIPTION
Improved diagnostics by logging swallowed exceptions in `App.getPackageName()`. This method uses reflection to inspect stack traces and spoof the package name for WebView requests. Previously, if this logic failed, it would silently fall back to the default package name, potentially hiding issues. Now, any exception during this process is logged to Timber/Crashlytics.

---
*PR created automatically by Jules for task [15123275955466388346](https://jules.google.com/task/15123275955466388346) started by @nonproto*