### PR TITLE
chore: Update deprecated PreferenceManager usage in AndroidPreferenceStore

### DIFF
--- a/core/src/main/kotlin/tachiyomi/core/preference/AndroidPreferenceStore.kt
+++ b/core/src/main/kotlin/tachiyomi/core/preference/AndroidPreferenceStore.kt
@@ -2,7 +2,6 @@ package tachiyomi.core.preference
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.preference.PreferenceManager
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import tachiyomi.core.preference.AndroidPreference.BooleanPrimitive
@@ -14,7 +13,8 @@ import tachiyomi.core.preference.AndroidPreference.StringSetPrimitive
 
 class AndroidPreferenceStore(context: Context) : PreferenceStore {
 
-    private val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+    private val sharedPreferences =
+        context.getSharedPreferences("${context.packageName}_preferences", Context.MODE_PRIVATE)
 
     private val keyFlow = sharedPreferences.keyFlow
 


### PR DESCRIPTION
💡 What: Replaced `PreferenceManager.getDefaultSharedPreferences(context)` with `context.getSharedPreferences("${context.packageName}_preferences", Context.MODE_PRIVATE)` in `AndroidPreferenceStore.kt`.

🎯 Why: The `PreferenceManager.getDefaultSharedPreferences` method is deprecated in API 29 and should be replaced with explicit `SharedPreferences` creation.

⚠️ Compatibility: No version checks needed as `getSharedPreferences` is available since API 1. The implementation mimics the default shared preferences file name and mode to ensure data persistence.

---
*PR created automatically by Jules for task [13196719859850490759](https://jules.google.com/task/13196719859850490759) started by @nonproto*