### PR TITLE
chore: Extract 16.dp to Size.medium

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/sheets/FilterBrowseSheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/sheets/FilterBrowseSheet.kt
@@ -92,7 +92,7 @@ fun FilterBrowseSheet(
     filterChanged: (Filter) -> Unit,
     defaultContentRatings: ImmutableSet<String>,
     savedFilters: PersistentList<BrowseFilterImpl>,
-    bottomContentPadding: Dp = 16.dp,
+    bottomContentPadding: Dp = Size.medium,
     themeColorState: ThemeColorState = defaultThemeColorState(),
 ) {
     CompositionLocalProvider(
@@ -146,7 +146,7 @@ fun FilterBrowseSheet(
         BaseSheet(themeColor = themeColorState, bottomPaddingAroundContent = 0.dp) {
             val paddingModifier = Modifier.padding(horizontal = Size.small)
 
-            Gap(16.dp)
+            Gap(Size.medium)
 
             val titleRes =
                 when (filters.queryMode) {

--- a/app/src/main/java/org/nekomanga/presentation/components/sheets/FilterChapterSheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/sheets/FilterChapterSheet.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.state.ToggleableState
-import androidx.compose.ui.unit.dp
 import eu.kanade.tachiyomi.source.online.utils.MdLang
 import eu.kanade.tachiyomi.ui.manga.MangaConstants
 import eu.kanade.tachiyomi.ui.manga.MangaConstants.SortOption
@@ -84,7 +83,7 @@ private fun Sort(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                modifier = Modifier.padding(vertical = 16.dp),
+                modifier = Modifier.padding(vertical = Size.medium),
                 text = stringResource(id = R.string.sort),
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.onSurface,
@@ -158,7 +157,7 @@ private fun Filter(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                modifier = Modifier.padding(vertical = 16.dp),
+                modifier = Modifier.padding(vertical = Size.medium),
                 text = stringResource(id = R.string.filter_and_display),
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.onSurface,
@@ -303,7 +302,7 @@ private fun Scanlator(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                modifier = Modifier.padding(vertical = 16.dp),
+                modifier = Modifier.padding(vertical = Size.medium),
                 text =
                     stringResource(
                         id =
@@ -369,7 +368,7 @@ private fun Language(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                modifier = Modifier.padding(vertical = 16.dp),
+                modifier = Modifier.padding(vertical = Size.medium),
                 text = stringResource(id = R.string.filter_languages),
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/org/nekomanga/presentation/components/sheets/MergeSheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/sheets/MergeSheet.kt
@@ -239,7 +239,7 @@ private fun SuccessResults(
         modifier = Modifier.fillMaxWidth(),
         contentPadding =
             PaddingValues(
-                top = 16.dp,
+                top = Size.medium,
                 bottom = Size.huge * 2,
                 start = Size.small,
                 end = Size.small,
@@ -309,7 +309,7 @@ private fun BoxScope.NonSuccessResultsAndChips(
         modifier = Modifier.fillMaxWidth().align(Alignment.BottomStart),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Gap(16.dp)
+        Gap(Size.medium)
         when (searchResults) {
             is MergeSearchResult.Loading ->
                 CircularProgressIndicator(
@@ -321,7 +321,7 @@ private fun BoxScope.NonSuccessResultsAndChips(
             is MergeSearchResult.Error -> Text(text = searchResults.errorMessage)
             else -> Unit
         }
-        Gap(16.dp)
+        Gap(Size.medium)
         if (altTitles.isNotEmpty()) {
             val allTitles = listOf(title) + altTitles.sorted()
             val partitioned =

--- a/app/src/main/java/org/nekomanga/presentation/components/sheets/TrackingSheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/sheets/TrackingSheet.kt
@@ -488,7 +488,7 @@ private fun RowScope.TrackingBox(clickable: () -> Unit, content: @Composable () 
     Box(
         Modifier.weight(1f)
             .clickable { clickable() }
-            .padding(horizontal = Size.small, vertical = 16.dp),
+            .padding(horizontal = Size.small, vertical = Size.medium),
         contentAlignment = Alignment.Center,
     ) {
         content()


### PR DESCRIPTION
Extracted hardcoded `16.dp` values to `Size.medium` in `FilterChapterSheet`, `FilterBrowseSheet`, `MergeSheet`, and `TrackingSheet` to improve design system consistency. Verified that the `Size` object is correctly imported and the project compiles.

---
*PR created automatically by Jules for task [11861844348973836455](https://jules.google.com/task/11861844348973836455) started by @nonproto*