### PR TITLE
chore: Secure Manifest Removed unused INSTALL_SHORTCUT

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,6 @@
     <uses-permission android:name="android.permission.UPDATE_PACKAGES_WITHOUT_USER_ACTION" />
 
 
-    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 


### PR DESCRIPTION
Removed `com.android.launcher.permission.INSTALL_SHORTCUT` from `app/src/main/AndroidManifest.xml` as it is a legacy permission replaced by `ShortcutManager` (API 26+) and is unused in the codebase.
This improves manifest hygiene and adheres to the principle of least privilege.
Verified that the app targets minSdk 26, making the legacy broadcast permission obsolete.

---
*PR created automatically by Jules for task [5010667838805423642](https://jules.google.com/task/5010667838805423642) started by @nonproto*