### PR TITLE
chore: Add Preview for ToolTipButton

### DIFF
--- a/.jules/propmaster.md
+++ b/.jules/propmaster.md
@@ -5,3 +5,7 @@
 ## 2025-05-15 - Preview Wrappers and Image Mocks
 **Learning:** This app uses `ThemedPreviews` (composable) to render components across all themes. For Coil images in previews, use `AsyncImagePreviewHandler` provided via `LocalAsyncImagePreviewHandler`.
 **Action:** Wrap previews in `ThemedPreviews { ... }` and provide `LocalAsyncImagePreviewHandler` with a dummy `ColorImage`.
+
+## 2025-05-24 - ThemedPreviews Annotation vs Composable
+**Learning:** The `@ThemePreviews` annotation exists but its usage is discouraged in favor of the `ThemedPreviews` composable within a standard `@Preview`. This provides more control and avoids dependency issues with custom annotations.
+**Action:** Use standard `@Preview` and wrap content with `ThemedPreviews { ... }`.

--- a/app/src/main/java/org/nekomanga/presentation/components/ToolTipComponentsPreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ToolTipComponentsPreview.kt
@@ -1,0 +1,48 @@
+package org.nekomanga.presentation.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import org.nekomanga.ui.theme.ThemedPreviews
+
+private data class ToolTipButtonData(
+    val label: String,
+    val isEnabled: Boolean,
+    val icon: ImageVector,
+)
+
+private class ToolTipButtonProvider : PreviewParameterProvider<ToolTipButtonData> {
+    override val values =
+        sequenceOf(
+            ToolTipButtonData("Enabled Action", true, Icons.Default.Favorite),
+            ToolTipButtonData("Disabled Action", false, Icons.Default.Delete),
+            ToolTipButtonData("Long Label Action", true, Icons.Default.Share),
+        )
+}
+
+@Preview(name = "ToolTipButton Variants", showBackground = true, widthDp = 720)
+@Composable
+private fun ToolTipButtonPreview(
+    @PreviewParameter(ToolTipButtonProvider::class) data: ToolTipButtonData
+) {
+    ThemedPreviews {
+        Box(modifier = Modifier.padding(16.dp)) {
+            ToolTipButton(
+                toolTipLabel = data.label,
+                isEnabled = data.isEnabled,
+                icon = data.icon,
+                onClick = {},
+            )
+        }
+    }
+}


### PR DESCRIPTION
💡 What: Added @Preview and ParameterProvider for ToolTipButton.
🎯 Why: Enabling isolated UI iteration for this reusable component.
📸 Snapshot: Covers Enabled, Disabled, and Long Label variants using ThemedPreviews wrapper.

---
*PR created automatically by Jules for task [4884069379049258443](https://jules.google.com/task/4884069379049258443) started by @nonproto*