### PR TITLE
chore: [UX improvement] Add contentDescription to ActionButton for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - [Accessibility in Dynamic Button Blocks]
+**Learning:** In `ButtonBlock.kt`, buttons can have their text labels hidden via `hideText` or be initialized with empty text (like the Favorite button). This creates icon-only buttons that are inaccessible to screen readers.
+**Action:** When designing data-driven button components, always include an optional `contentDescription` field in the data model (e.g., `ActionButtonData`) to provide a fallback accessible label when the visual text is hidden or empty.

--- a/app/src/main/java/org/nekomanga/presentation/components/ExpressivePicker.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ExpressivePicker.kt
@@ -223,7 +223,6 @@ private fun PreviewNumberPicker(
             modifier = Modifier.width(150.dp).padding(bottom = 16.dp),
             visibleItemsCount = 5,
         )
-
     }
 }
 
@@ -248,7 +247,5 @@ private fun PreviewWeekPicker(
             modifier = Modifier.width(150.dp),
             visibleItemsCount = 5,
         )
-
     }
 }
-

--- a/app/src/main/java/org/nekomanga/presentation/screens/manga/ButtonBlock.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/manga/ButtonBlock.kt
@@ -115,6 +115,9 @@ fun ButtonBlock(
                                 if (inLibrary) Icons.Filled.Favorite
                                 else Icons.Filled.FavoriteBorder,
                             text = UiText.String(""),
+                            contentDescription =
+                                if (inLibrary) UiText.StringResource(R.string.remove_from_library)
+                                else UiText.StringResource(R.string.add_to_library),
                             isChecked = inLibrary,
                             onClick = toggleFavorite,
                             dropdownItems =
@@ -273,7 +276,9 @@ private fun ActionButton(
             Row {
                 Icon(
                     imageVector = data.icon,
-                    contentDescription = null,
+                    contentDescription =
+                        if (hideText) data.contentDescription?.asString() ?: data.text.asString()
+                        else null,
                     modifier = Modifier.size(Size.large),
                 )
                 if (!hideText) {
@@ -324,4 +329,5 @@ private data class ActionButtonData(
     val onClick: () -> Unit,
     val isChecked: Boolean = false,
     val dropdownItems: ImmutableList<SimpleDropDownItem>? = null,
+    val contentDescription: UiText? = null,
 )


### PR DESCRIPTION
This PR improves accessibility for the action buttons in the Manga Details screen, specifically fixing the missing content description for the "Favorite" (Add to Library) button.

## Changes
- Modified `ActionButtonData` to include an optional `contentDescription: UiText?`.
- Updated `ActionButton` composable to use `contentDescription` on the `Icon` when `hideText` is true.
- Provided explicit "Add to Library" / "Remove from Library" descriptions for the Favorite button.

## Accessibility
- **Before:** The Favorite button was announced as "Unlabeled button" or nothing by TalkBack.
- **After:** The Favorite button is announced as "Add to Library" or "Remove from Library" depending on the state.


---
*PR created automatically by Jules for task [8584840211367901865](https://jules.google.com/task/8584840211367901865) started by @nonproto*