### PR TITLE
ref(detektor): neutralize UnusedPrivateProperty in DownloadPageLoader.kt

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -66,8 +66,7 @@ class ChapterLoader(
         val isDownloaded = downloadManager.isChapterDownloaded(chapter.chapter, manga, true)
         val source = chapter.chapter.getHttpSource(sourceManager)
         return when {
-            isDownloaded ->
-                DownloadPageLoader(chapter, manga, source, downloadManager, downloadProvider)
+            isDownloaded -> DownloadPageLoader(chapter, manga, downloadManager, downloadProvider)
             else -> HttpPageLoader(chapter, source)
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
@@ -6,7 +6,6 @@ import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
-import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
@@ -17,7 +16,6 @@ import uy.kohesive.injekt.injectLazy
 class DownloadPageLoader(
     private val chapter: ReaderChapter,
     private val manga: Manga,
-    private val source: Source,
     private val downloadManager: DownloadManager,
     private val downloadProvider: DownloadProvider,
 ) : PageLoader() {


### PR DESCRIPTION
* 💡 Detection: `Private property source is unused. [UnusedPrivateProperty]` in `app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt`.
* 🎯 Neutralization: Removed the unused `source` property from `DownloadPageLoader` constructor and updated `ChapterLoader` to remove the argument from the instantiation.
* 📊 Status: Violation cleared; Build successful.

---
*PR created automatically by Jules for task [6681495116709082501](https://jules.google.com/task/6681495116709082501) started by @nonproto*