### PR TITLE
perf: hoist callbacks in ChapterRow to reduce recomposition

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
@@ -71,14 +71,14 @@ fun ChapterRow(
     themeColor: ThemeColorState,
     chapterItem: ChapterItem,
     shouldHideChapterTitles: Boolean = false,
-    onClick: () -> Unit,
-    onBookmark: () -> Unit,
-    onRead: () -> Unit,
-    onWebView: () -> Unit,
-    onComment: () -> Unit,
-    onDownload: (MangaConstants.DownloadAction) -> Unit,
+    onClick: (ChapterItem) -> Unit,
+    onBookmark: (ChapterItem) -> Unit,
+    onRead: (ChapterItem) -> Unit,
+    onWebView: (ChapterItem) -> Unit,
+    onComment: (String) -> Unit,
+    onDownload: (List<ChapterItem>, MangaConstants.DownloadAction) -> Unit,
     blockScanlator: (MangaConstants.BlockType, String) -> Unit,
-    markPrevious: (Boolean) -> Unit,
+    markPrevious: (ChapterItem, Boolean) -> Unit,
 ) {
     CompositionLocalProvider(LocalRippleConfiguration provides themeColor.rippleConfiguration) {
         val (readIcon, readTextRes) =
@@ -105,7 +105,7 @@ fun ChapterRow(
                     )
                 },
                 background = swipeActionBackgroundColor,
-                onSwipe = onRead,
+                onSwipe = { onRead(chapterItem) },
             )
 
         val markBookmarkAction =
@@ -118,7 +118,7 @@ fun ChapterRow(
                     )
                 },
                 background = swipeActionBackgroundColor,
-                onSwipe = onBookmark,
+                onSwipe = { onBookmark(chapterItem) },
             )
 
         ChapterSwipe(
@@ -145,11 +145,11 @@ private fun ChapterRowContent(
     themeColorState: ThemeColorState,
     shouldHideChapterTitles: Boolean,
     chapterItem: ChapterItem,
-    onClick: () -> Unit,
-    onWebView: () -> Unit,
-    onComment: () -> Unit,
-    onDownload: (MangaConstants.DownloadAction) -> Unit,
-    markPrevious: (Boolean) -> Unit,
+    onClick: (ChapterItem) -> Unit,
+    onWebView: (ChapterItem) -> Unit,
+    onComment: (String) -> Unit,
+    onDownload: (List<ChapterItem>, MangaConstants.DownloadAction) -> Unit,
+    markPrevious: (ChapterItem, Boolean) -> Unit,
     blockScanlator: (MangaConstants.BlockType, String) -> Unit,
 ) {
     var isDropdownExpanded by remember { mutableStateOf(false) }
@@ -184,9 +184,9 @@ private fun ChapterRowContent(
                 isMerged = chapterItem.chapter.isMergedChapter(),
                 scanlator = chapterItem.chapter.scanlator,
                 uploader = chapterItem.chapter.uploader,
-                onWebView = onWebView,
-                onComment = onComment,
-                markPrevious = markPrevious,
+                onWebView = { onWebView(chapterItem) },
+                onComment = { onComment(chapterItem.chapter.mangaDexChapterId) },
+                markPrevious = { read -> markPrevious(chapterItem, read) },
                 blockScanlator = blockScanlator,
             )
         }
@@ -207,7 +207,7 @@ private fun ChapterRowContent(
                     background(themeColorState.rippleColor.copy(alpha = 0.2f))
                 }
                 .combinedClickable(
-                    onClick = onClick,
+                    onClick = { onClick(chapterItem) },
                     onLongClick = {
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         isDropdownExpanded = true
@@ -285,7 +285,7 @@ private fun ChapterRowContent(
             scanlator = chapterItem.chapter.scanlator,
             downloadState = chapterItem.downloadState,
             downloadProgress = chapterItem.downloadProgress,
-            onDownload = onDownload,
+            onDownload = { action -> onDownload(listOf(chapterItem), action) },
             themeColorState = themeColorState,
         )
     }

--- a/app/src/main/java/org/nekomanga/presentation/components/ChapterRowPreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ChapterRowPreview.kt
@@ -30,9 +30,9 @@ private fun ChapterRowPreviewContent(chapterItem: ChapterItem) {
             onRead = {},
             onWebView = {},
             onComment = {},
-            onDownload = {},
+            onDownload = { _, _ -> },
             blockScanlator = { _, _ -> },
-            markPrevious = {},
+            markPrevious = { _, _ -> },
         )
     }
 }

--- a/app/src/main/java/org/nekomanga/presentation/screens/manga/MangaChapterListItem.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/manga/MangaChapterListItem.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import eu.kanade.tachiyomi.ui.manga.MangaConstants.ChapterActions
 import org.nekomanga.domain.chapter.ChapterItem
@@ -36,34 +37,40 @@ fun MangaChapterListItem(
         listCardType = listCardType,
         themeColorState = themeColorState,
     ) {
+        val onBookmark: (ChapterItem) -> Unit =
+            remember(chapterActions) {
+                { item ->
+                    chapterActions.mark(
+                        listOf(item),
+                        if (item.chapter.bookmark) ChapterMarkActions.UnBookmark(true)
+                        else ChapterMarkActions.Bookmark(true),
+                    )
+                }
+            }
+
+        val onRead: (ChapterItem) -> Unit =
+            remember(chapterActions) {
+                { item ->
+                    chapterActions.mark(
+                        listOf(item),
+                        if (item.chapter.read) ChapterMarkActions.Unread(true)
+                        else ChapterMarkActions.Read(true),
+                    )
+                }
+            }
+
         ChapterRow(
             themeColor = themeColorState,
             chapterItem = chapterItem,
             shouldHideChapterTitles = shouldHideChapterTitles,
-            onClick = { chapterActions.open(chapterItem) },
-            onBookmark = {
-                chapterActions.mark(
-                    listOf(chapterItem),
-                    if (chapterItem.chapter.bookmark) ChapterMarkActions.UnBookmark(true)
-                    else ChapterMarkActions.Bookmark(true),
-                )
-            },
-            onRead = {
-                chapterActions.mark(
-                    listOf(chapterItem),
-                    if (chapterItem.chapter.read) ChapterMarkActions.Unread(true)
-                    else ChapterMarkActions.Read(true),
-                )
-            },
-            onWebView = { chapterActions.openInBrowser(chapterItem) },
-            onComment = { chapterActions.openComment(chapterItem.chapter.mangaDexChapterId) },
-            onDownload = { downloadAction ->
-                chapterActions.download(listOf(chapterItem), downloadAction)
-            },
-            markPrevious = { read -> chapterActions.markPrevious(chapterItem, read) },
-            blockScanlator = { blockType, blocked ->
-                chapterActions.blockScanlator(blockType, blocked)
-            },
+            onClick = chapterActions.open,
+            onBookmark = onBookmark,
+            onRead = onRead,
+            onWebView = chapterActions.openInBrowser,
+            onComment = chapterActions.openComment,
+            onDownload = chapterActions.download,
+            markPrevious = chapterActions.markPrevious,
+            blockScanlator = chapterActions.blockScanlator,
         )
     }
     if (listCardType != ListCardType.Bottom) {


### PR DESCRIPTION
💡 What:
- Updated `ChapterRow` and `ChapterRowContent` to accept callbacks that take `ChapterItem` as an argument (e.g., `onClick: (ChapterItem) -> Unit`) instead of `() -> Unit` closures.
- Updated `MangaChapterListItem` to pass stable function references (like `chapterActions.open`) or stable `remember`ed lambdas to `ChapterRow`.
- Memoized `ChapterActions` in `MangaScreen` using `remember` to ensure stability across recompositions.

🎯 Why:
- The previous implementation created new lambda instances for every item in the chapter list on every recomposition (because they captured the loop variable `chapterItem`).
- This caused `ChapterRow` (and its children) to recompose unnecessarily even when the data hadn't changed, degrading scroll performance in long lists.
- By hoisting the item parameter to the callback signature, we can pass stable function references that do not change per-item or per-recomposition.

📊 Impact:
- Reduces unnecessary recompositions of `ChapterRow` components in the chapter list.
- Improves scrolling performance on the Manga Details screen, especially for manga with many chapters.

🔬 Measurement:
- Verified that the code compiles successfully.
- While specific recomposition counts were not measured with Layout Inspector in this session, this is a standard Compose performance pattern (lambda hoisting) that guarantees skippability when inputs are stable.

---
*PR created automatically by Jules for task [3080682972127365581](https://jules.google.com/task/3080682972127365581) started by @nonproto*