### PR TITLE
perf: memoize LibraryScreen actions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-18 - Hoist Event Callbacks in Compose Lists/Grids
 **Learning:** Inline lambdas inside `items` / `itemsIndexed` blocks create new function instances on every recomposition, breaking skippability of item composables even if their data is unchanged. By hoisting the callback signature to accept the item ID/Model and passing a stable function reference (or a lambda that doesn't capture unstable state), we allow Compose to skip recomposition of individual items.
 **Action:** Always prefer passing `(Id) -> Unit` or `(Item) -> Unit` to list item composables instead of `() -> Unit` that captures the item.
+
+## 2025-02-18 - Stabilizing Data Classes with Function Properties
+**Learning:** Data classes containing function types (e.g., event handlers like `LibraryScreenActions`) are recreated on every recomposition if initialized with unstable method references (e.g., `viewModel::method`) or capturing lambdas. This forces downstream recomposition of all children accepting these objects. Using `remember` to memoize the data class instance stabilizes the object across recompositions where dependencies (ViewModel, Context) remain unchanged.
+**Action:** When passing a bag of callbacks to a composable, memoize the data class creation using `remember` with appropriate keys (e.g., `remember(viewModel) { Actions(...) }`).

--- a/app/src/main/java/org/nekomanga/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/LibraryScreen.kt
@@ -74,14 +74,10 @@ fun LibraryScreen(
 ) {
     val context = LocalContext.current
 
-    LibraryWrapper(
-        navigationRail = navigationRail,
-        bottomBar = bottomBar,
-        mainDropdown = mainDropdown,
-        mainDropdownShowing = mainDropdownShowing,
-        libraryStateFlow = libraryViewModel.libraryScreenState,
-        onSearchLoaded = libraryViewModel::clearInitialSearch,
-        libraryScreenActions =
+    // Optimize: Remember the action objects to prevent unnecessary recompositions of child composables
+    // when LibraryScreen recomposes but these actions (and their dependencies) haven't changed.
+    val libraryScreenActions =
+        remember(libraryViewModel, openManga, onSearchMangaDex, context) {
             LibraryScreenActions(
                 mangaClick = openManga,
                 mangaLongClick = libraryViewModel::libraryItemLongClick,
@@ -123,8 +119,11 @@ fun LibraryScreen(
                         },
                     )
                 },
-            ),
-        librarySheetActions =
+            )
+        }
+
+    val librarySheetActions =
+        remember(libraryViewModel) {
             LibrarySheetActions(
                 groupByClick = libraryViewModel::groupByClick,
                 categoryItemLibrarySortClick = libraryViewModel::categoryItemLibrarySortClick,
@@ -138,8 +137,11 @@ fun LibraryScreen(
                 showLibraryButtonBarToggled = libraryViewModel::showLibraryButtonBarToggled,
                 editCategories = libraryViewModel::editCategories,
                 addNewCategory = libraryViewModel::addNewCategory,
-            ),
-        libraryCategoryActions =
+            )
+        }
+
+    val libraryCategoryActions =
+        remember(libraryViewModel, context) {
             LibraryCategoryActions(
                 categoryItemClick = libraryViewModel::categoryItemClick,
                 categoryAscendingClick = libraryViewModel::categoryAscendingClick,
@@ -160,7 +162,19 @@ fun LibraryScreen(
                             },
                     )
                 },
-            ),
+            )
+        }
+
+    LibraryWrapper(
+        navigationRail = navigationRail,
+        bottomBar = bottomBar,
+        mainDropdown = mainDropdown,
+        mainDropdownShowing = mainDropdownShowing,
+        libraryStateFlow = libraryViewModel.libraryScreenState,
+        onSearchLoaded = libraryViewModel::clearInitialSearch,
+        libraryScreenActions = libraryScreenActions,
+        librarySheetActions = librarySheetActions,
+        libraryCategoryActions = libraryCategoryActions,
         windowSizeClass = windowSizeClass,
     )
 }


### PR DESCRIPTION
💡 What: Memoize action holder classes in `LibraryScreen.kt`.
🎯 Why: Prevent unnecessary recompositions of child components when `LibraryScreen` recomposes.
📊 Impact: Reduces recompositions of the entire library list structure on minor state changes.
🔬 Measurement: Verified by code review and compilation check.


---
*PR created automatically by Jules for task [6346218666678824951](https://jules.google.com/task/6346218666678824951) started by @nonproto*