### PR TITLE
chore: optimize Update Rolling Draft Release Workflow

### DIFF
--- a/.github/workflows/ci-draft-release.yml
+++ b/.github/workflows/ci-draft-release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate_gradle_wrapper:
     name: Validate Gradle Wrapper
@@ -20,15 +24,11 @@ jobs:
     name: Build and Update Draft Release
     needs: validate_gradle_wrapper
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: write
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.13.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
@@ -48,9 +48,6 @@ jobs:
         with:
           path: app/google-services.json
           contents: ${{ secrets.GOOGLE_SERVICE_JSON }}
-
-      - name: Install Android Build Tools
-        run: echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "build-tools;29.0.3"
 
       - name: Build App
         run: ./gradlew assembleStandardRelease

--- a/.jules/operator.md
+++ b/.jules/operator.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Android Build Tools Redundancy
+**Learning:** Manual installation of specific Android Build Tools versions (e.g., 29.0.3) in CI workflows is often redundant when using modern Android Gradle Plugin (AGP), which automatically downloads the required version.
+**Action:** Audit Android workflows for `sdkmanager "build-tools;..."` steps and remove them if the project uses a recent AGP version, saving setup time.


### PR DESCRIPTION
💡 What: Implemented native concurrency, removed redundant build tools installation.
🎯 Why: CI speed and reliability.
⏱️ Impact: Prevents redundant builds and reduces setup overhead.
Note: Original action versions (checkout@v6, setup-java@v5) were preserved as requested.

---
*PR created automatically by Jules for task [15884528758015738987](https://jules.google.com/task/15884528758015738987) started by @nonproto*