### PR TITLE
perf: hoist ChapterRow callbacks to parent screen

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
@@ -95,6 +95,7 @@ fun ChapterRow(
                 Size.small,
             )
 
+        val onSwipeRead = remember(chapterItem, onRead) { { onRead(chapterItem) } }
         val markReadSwipeAction =
             SwipeAction(
                 icon = {
@@ -105,9 +106,10 @@ fun ChapterRow(
                     )
                 },
                 background = swipeActionBackgroundColor,
-                onSwipe = { onRead(chapterItem) },
+                onSwipe = onSwipeRead,
             )
 
+        val onSwipeBookmark = remember(chapterItem, onBookmark) { { onBookmark(chapterItem) } }
         val markBookmarkAction =
             SwipeAction(
                 icon = {
@@ -118,7 +120,7 @@ fun ChapterRow(
                     )
                 },
                 background = swipeActionBackgroundColor,
-                onSwipe = { onBookmark(chapterItem) },
+                onSwipe = onSwipeBookmark,
             )
 
         ChapterSwipe(
@@ -172,21 +174,31 @@ private fun ChapterRowContent(
             else onSurfaceColor.copy(alpha = NekoColors.mediumAlphaLowContrast)
         }
 
+    val onWebViewAction = remember(chapterItem, onWebView) { { onWebView(chapterItem) } }
+    val onCommentAction =
+        remember(chapterItem, onComment) { { onComment(chapterItem.chapter.mangaDexChapterId) } }
+    val markPreviousAction =
+        remember(chapterItem, markPrevious) { { read: Boolean -> markPrevious(chapterItem, read) } }
+
     val dropdownItems =
         remember(
             chapterItem.chapter.isLocalSource(),
             chapterItem.chapter.isMergedChapter(),
             chapterItem.chapter.scanlator,
             chapterItem.chapter.uploader,
+            onWebViewAction,
+            onCommentAction,
+            markPreviousAction,
+            blockScanlator,
         ) {
             buildChapterDropdownItems(
                 isLocal = chapterItem.chapter.isLocalSource(),
                 isMerged = chapterItem.chapter.isMergedChapter(),
                 scanlator = chapterItem.chapter.scanlator,
                 uploader = chapterItem.chapter.uploader,
-                onWebView = { onWebView(chapterItem) },
-                onComment = { onComment(chapterItem.chapter.mangaDexChapterId) },
-                markPrevious = { read -> markPrevious(chapterItem, read) },
+                onWebView = onWebViewAction,
+                onComment = onCommentAction,
+                markPrevious = markPreviousAction,
                 blockScanlator = blockScanlator,
             )
         }
@@ -200,6 +212,8 @@ private fun ChapterRowContent(
 
     themeColorState.rippleConfiguration
 
+    val onClickAction = remember(chapterItem, onClick) { { onClick(chapterItem) } }
+
     Row(
         modifier =
             Modifier.fillMaxWidth()
@@ -207,7 +221,7 @@ private fun ChapterRowContent(
                     background(themeColorState.rippleColor.copy(alpha = 0.2f))
                 }
                 .combinedClickable(
-                    onClick = { onClick(chapterItem) },
+                    onClick = onClickAction,
                     onLongClick = {
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         isDropdownExpanded = true
@@ -280,12 +294,16 @@ private fun ChapterRowContent(
                 textColor = secondaryTextColor,
             )
         }
+        val onDownloadAction =
+            remember(chapterItem, onDownload) {
+                { action: MangaConstants.DownloadAction -> onDownload(listOf(chapterItem), action) }
+            }
         ChapterDownloadIndicator(
             isUnavailable = chapterItem.chapter.isUnavailable,
             scanlator = chapterItem.chapter.scanlator,
             downloadState = chapterItem.downloadState,
             downloadProgress = chapterItem.downloadProgress,
-            onDownload = { action -> onDownload(listOf(chapterItem), action) },
+            onDownload = onDownloadAction,
             themeColorState = themeColorState,
         )
     }

--- a/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
@@ -71,14 +71,14 @@ fun ChapterRow(
     themeColor: ThemeColorState,
     chapterItem: ChapterItem,
     shouldHideChapterTitles: Boolean = false,
-    onClick: () -> Unit,
-    onBookmark: () -> Unit,
-    onRead: () -> Unit,
-    onWebView: () -> Unit,
-    onComment: () -> Unit,
-    onDownload: (MangaConstants.DownloadAction) -> Unit,
+    onClick: (ChapterItem) -> Unit,
+    onBookmark: (ChapterItem) -> Unit,
+    onRead: (ChapterItem) -> Unit,
+    onWebView: (ChapterItem) -> Unit,
+    onComment: (String) -> Unit,
+    onDownload: (List<ChapterItem>, MangaConstants.DownloadAction) -> Unit,
     blockScanlator: (MangaConstants.BlockType, String) -> Unit,
-    markPrevious: (Boolean) -> Unit,
+    markPrevious: (ChapterItem, Boolean) -> Unit,
 ) {
     CompositionLocalProvider(LocalRippleConfiguration provides themeColor.rippleConfiguration) {
         val (readIcon, readTextRes) =
@@ -105,7 +105,7 @@ fun ChapterRow(
                     )
                 },
                 background = swipeActionBackgroundColor,
-                onSwipe = onRead,
+                onSwipe = { onRead(chapterItem) },
             )
 
         val markBookmarkAction =
@@ -118,7 +118,7 @@ fun ChapterRow(
                     )
                 },
                 background = swipeActionBackgroundColor,
-                onSwipe = onBookmark,
+                onSwipe = { onBookmark(chapterItem) },
             )
 
         ChapterSwipe(
@@ -145,11 +145,11 @@ private fun ChapterRowContent(
     themeColorState: ThemeColorState,
     shouldHideChapterTitles: Boolean,
     chapterItem: ChapterItem,
-    onClick: () -> Unit,
-    onWebView: () -> Unit,
-    onComment: () -> Unit,
-    onDownload: (MangaConstants.DownloadAction) -> Unit,
-    markPrevious: (Boolean) -> Unit,
+    onClick: (ChapterItem) -> Unit,
+    onWebView: (ChapterItem) -> Unit,
+    onComment: (String) -> Unit,
+    onDownload: (List<ChapterItem>, MangaConstants.DownloadAction) -> Unit,
+    markPrevious: (ChapterItem, Boolean) -> Unit,
     blockScanlator: (MangaConstants.BlockType, String) -> Unit,
 ) {
     var isDropdownExpanded by remember { mutableStateOf(false) }
@@ -184,9 +184,9 @@ private fun ChapterRowContent(
                 isMerged = chapterItem.chapter.isMergedChapter(),
                 scanlator = chapterItem.chapter.scanlator,
                 uploader = chapterItem.chapter.uploader,
-                onWebView = onWebView,
-                onComment = onComment,
-                markPrevious = markPrevious,
+                onWebView = { onWebView(chapterItem) },
+                onComment = { onComment(chapterItem.chapter.mangaDexChapterId) },
+                markPrevious = { read -> markPrevious(chapterItem, read) },
                 blockScanlator = blockScanlator,
             )
         }
@@ -207,7 +207,7 @@ private fun ChapterRowContent(
                     background(themeColorState.rippleColor.copy(alpha = 0.2f))
                 }
                 .combinedClickable(
-                    onClick = onClick,
+                    onClick = { onClick(chapterItem) },
                     onLongClick = {
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         isDropdownExpanded = true
@@ -285,7 +285,7 @@ private fun ChapterRowContent(
             scanlator = chapterItem.chapter.scanlator,
             downloadState = chapterItem.downloadState,
             downloadProgress = chapterItem.downloadProgress,
-            onDownload = onDownload,
+            onDownload = { action -> onDownload(listOf(chapterItem), action) },
             themeColorState = themeColorState,
         )
     }

--- a/app/src/main/java/org/nekomanga/presentation/components/ChapterRowPreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ChapterRowPreview.kt
@@ -30,9 +30,9 @@ private fun ChapterRowPreviewContent(chapterItem: ChapterItem) {
             onRead = {},
             onWebView = {},
             onComment = {},
-            onDownload = {},
+            onDownload = { _, _ -> },
             blockScanlator = { _, _ -> },
-            markPrevious = {},
+            markPrevious = { _, _ -> },
         )
     }
 }

--- a/app/src/main/java/org/nekomanga/presentation/screens/manga/MangaChapterListItem.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/manga/MangaChapterListItem.kt
@@ -4,11 +4,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import eu.kanade.tachiyomi.ui.manga.MangaConstants.ChapterActions
 import org.nekomanga.domain.chapter.ChapterItem
-import org.nekomanga.domain.chapter.ChapterMarkActions
 import org.nekomanga.presentation.components.ChapterRow
 import org.nekomanga.presentation.components.listcard.ExpressiveListCard
 import org.nekomanga.presentation.components.listcard.ListCardType
@@ -39,28 +37,6 @@ fun MangaChapterListItem(
         listCardType = listCardType,
         themeColorState = themeColorState,
     ) {
-        val onBookmark: (ChapterItem) -> Unit =
-            remember(chapterActions) {
-                { item ->
-                    chapterActions.mark(
-                        listOf(item),
-                        if (item.chapter.bookmark) ChapterMarkActions.UnBookmark(true)
-                        else ChapterMarkActions.Bookmark(true),
-                    )
-                }
-            }
-
-        val onRead: (ChapterItem) -> Unit =
-            remember(chapterActions) {
-                { item ->
-                    chapterActions.mark(
-                        listOf(item),
-                        if (item.chapter.read) ChapterMarkActions.Unread(true)
-                        else ChapterMarkActions.Read(true),
-                    )
-                }
-            }
-
         ChapterRow(
             themeColor = themeColorState,
             chapterItem = chapterItem,

--- a/app/src/main/java/org/nekomanga/presentation/screens/manga/MangaChapterListItem.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/manga/MangaChapterListItem.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import eu.kanade.tachiyomi.ui.manga.MangaConstants.ChapterActions
 import org.nekomanga.domain.chapter.ChapterItem
@@ -22,6 +23,8 @@ fun MangaChapterListItem(
     themeColorState: ThemeColorState,
     shouldHideChapterTitles: Boolean,
     chapterActions: ChapterActions,
+    onBookmark: (ChapterItem) -> Unit,
+    onRead: (ChapterItem) -> Unit,
 ) {
     val listCardType =
         when {
@@ -36,34 +39,40 @@ fun MangaChapterListItem(
         listCardType = listCardType,
         themeColorState = themeColorState,
     ) {
+        val onBookmark: (ChapterItem) -> Unit =
+            remember(chapterActions) {
+                { item ->
+                    chapterActions.mark(
+                        listOf(item),
+                        if (item.chapter.bookmark) ChapterMarkActions.UnBookmark(true)
+                        else ChapterMarkActions.Bookmark(true),
+                    )
+                }
+            }
+
+        val onRead: (ChapterItem) -> Unit =
+            remember(chapterActions) {
+                { item ->
+                    chapterActions.mark(
+                        listOf(item),
+                        if (item.chapter.read) ChapterMarkActions.Unread(true)
+                        else ChapterMarkActions.Read(true),
+                    )
+                }
+            }
+
         ChapterRow(
             themeColor = themeColorState,
             chapterItem = chapterItem,
             shouldHideChapterTitles = shouldHideChapterTitles,
-            onClick = { chapterActions.open(chapterItem) },
-            onBookmark = {
-                chapterActions.mark(
-                    listOf(chapterItem),
-                    if (chapterItem.chapter.bookmark) ChapterMarkActions.UnBookmark(true)
-                    else ChapterMarkActions.Bookmark(true),
-                )
-            },
-            onRead = {
-                chapterActions.mark(
-                    listOf(chapterItem),
-                    if (chapterItem.chapter.read) ChapterMarkActions.Unread(true)
-                    else ChapterMarkActions.Read(true),
-                )
-            },
-            onWebView = { chapterActions.openInBrowser(chapterItem) },
-            onComment = { chapterActions.openComment(chapterItem.chapter.mangaDexChapterId) },
-            onDownload = { downloadAction ->
-                chapterActions.download(listOf(chapterItem), downloadAction)
-            },
-            markPrevious = { read -> chapterActions.markPrevious(chapterItem, read) },
-            blockScanlator = { blockType, blocked ->
-                chapterActions.blockScanlator(blockType, blocked)
-            },
+            onClick = chapterActions.open,
+            onBookmark = onBookmark,
+            onRead = onRead,
+            onWebView = chapterActions.openInBrowser,
+            onComment = chapterActions.openComment,
+            onDownload = chapterActions.download,
+            markPrevious = chapterActions.markPrevious,
+            blockScanlator = chapterActions.blockScanlator,
         )
     }
     if (listCardType != ListCardType.Bottom) {


### PR DESCRIPTION
💡 What:
- Updated `MangaChapterListItem` to accept `onBookmark` and `onRead` callbacks as parameters instead of creating them internally.
- Hoisted the creation of these callbacks to `MangaScreen.kt`, using `remember(chapterActions)` to create them once for the entire chapter list.
- Passed these stable callbacks down through the composition tree (`MangaScreenWrapper` -> `SideBySideLayout`/`VerticalLayout` -> `chapterList` -> `MangaChapterListItem`).

🎯 Why:
- The previous implementation (even with `remember` inside `MangaChapterListItem`) still executed `remember` for every single item in the list.
- By hoisting the creation to the parent screen, we reduce the overhead of callback creation and ensure that the exact same lambda instances are passed to every item, further optimizing recomposition skipping.

📊 Impact:
- Reduces the work done per item during composition of the chapter list.
- Ensures optimal stability of callback references for `MangaChapterListItem`.

🔬 Measurement:
- Verified that the code compiles successfully.
- This is a further optimization of the initial lambda hoisting strategy, following best practices for Compose performance in lazy lists.

---
*PR created automatically by Jules for task [3080682972127365581](https://jules.google.com/task/3080682972127365581) started by @nonproto*