### PR TITLE
fix: library toolbar visibility and appearance in selection mode

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/bars/TitleTopAppBar.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/bars/TitleTopAppBar.kt
@@ -39,12 +39,13 @@ fun TitleTopAppBar(
     incognitoMode: Boolean,
     onNavigationIconClicked: () -> Unit = {},
     actions: @Composable (RowScope.() -> Unit) = {},
+    scrolledContainerColor: Color = Color.Transparent,
     scrollBehavior: TopAppBarScrollBehavior,
 ) {
     FlexibleTopBar(
         scrollBehavior = scrollBehavior,
         colors =
-            FlexibleTopBarColors(containerColor = color, scrolledContainerColor = Color.Transparent),
+            FlexibleTopBarColors(containerColor = color, scrolledContainerColor = scrolledContainerColor),
     ) {
         Box(
             modifier = Modifier.fillMaxWidth().statusBarsPadding().padding(horizontal = Size.small)

--- a/app/src/main/java/org/nekomanga/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/LibraryScreen.kt
@@ -248,7 +248,19 @@ private fun LibraryWrapper(
             )
         }
 
-        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
+        val topAppBarState = rememberTopAppBarState()
+        val scrollBehavior =
+            if (selectionMode) {
+                TopAppBarDefaults.pinnedScrollBehavior(state = topAppBarState)
+            } else {
+                TopAppBarDefaults.enterAlwaysScrollBehavior(state = topAppBarState)
+            }
+
+        LaunchedEffect(selectionMode) {
+            if (selectionMode) {
+                topAppBarState.heightOffset = 0f
+            }
+        }
 
         val refreshState =
             remember(libraryScreenState.isRefreshing, libraryScreenActions.updateLibrary) {

--- a/app/src/main/java/org/nekomanga/presentation/screens/library/LibraryScreenTopBar.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/library/LibraryScreenTopBar.kt
@@ -51,6 +51,7 @@ fun LibraryScreenTopBar(
             navigationIconLabel = stringResource(id = R.string.back),
             onNavigationIconClicked = { libraryScreenActions.clearSelectedManga() },
             incognitoMode = libraryScreenState.incognitoMode,
+            scrolledContainerColor = color,
             actions = {
                 LibraryAppBarActions(
                     downloadChapters = libraryScreenActions.downloadChapters,


### PR DESCRIPTION
The library toolbar was hidden when scrolling down due to `enterAlwaysScrollBehavior`. Entering selection mode did not consistently reveal it, and `pinnedScrollBehavior` caused the toolbar to become transparent (scrolled state) if the list was scrolled.
This change:
1. Hoists `TopAppBarState` in `LibraryScreen`.
2. Switches `ScrollBehavior` to `pinned` when `selectionMode` is true.
3. Resets `heightOffset` to `0f` when entering selection mode.
4. Updates `TitleTopAppBar` to support custom `scrolledContainerColor`.
5. Passes the opaque `containerColor` as `scrolledContainerColor` in `LibraryScreenTopBar` during selection mode.

---
*PR created automatically by Jules for task [8866887534754539396](https://jules.google.com/task/8866887534754539396) started by @nonproto*