### PR TITLE
Revert removal of build tool install in GitHub actions

### DIFF
--- a/.github/workflows/ci-draft-release.yml
+++ b/.github/workflows/ci-draft-release.yml
@@ -40,6 +40,9 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Install Android Build Tools
+        run: echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "build-tools;36.0.0"
+
       - name: Setup Gradle and Enable Caching
         uses: gradle/actions/setup-gradle@v5
 

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -26,6 +26,9 @@ jobs:
           distribution: adopt
           java-version: 17
 
+      - name: Install Android Build Tools
+        run: echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "build-tools;36.0.0"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 


### PR DESCRIPTION
Restores the installation of Android Build Tools in GitHub Actions workflows.

---
*PR created automatically by Jules for task [17126130916714985410](https://jules.google.com/task/17126130916714985410) started by @nonproto*