### PR TITLE
perf: Add indexes for bookmarked and unavailable chapters

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-02-18 - Stabilizing Data Classes with Function Properties
 **Learning:** Data classes containing function types (e.g., event handlers like `LibraryScreenActions`) are recreated on every recomposition if initialized with unstable method references (e.g., `viewModel::method`) or capturing lambdas. This forces downstream recomposition of all children accepting these objects. Using `remember` to memoize the data class instance stabilizes the object across recompositions where dependencies (ViewModel, Context) remain unchanged.
 **Action:** When passing a bag of callbacks to a composable, memoize the data class creation using `remember` with appropriate keys (e.g., `remember(viewModel) { Actions(...) }`).
+
+## 2025-02-24 - Missing Partial Indexes on Frequently Filtered Booleans
+**Learning:** The application frequently queries `chapters` table filtering by boolean flags like `bookmark=1` or `unavailable=1` inside complex library refresh queries. Without specific partial indexes (e.g., `WHERE bookmark=1`), these queries rely on wider indexes (like `manga_id`) or full table scans, causing significant IO overhead during library updates, especially for users with large libraries but few bookmarks.
+**Action:** Always verify execution plans for queries involving boolean flags on large tables. Use partial indexes (e.g., `CREATE INDEX ... WHERE flag=1`) to drastically reduce index size and lookup time for sparse attributes.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenCallback.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenCallback.kt
@@ -22,7 +22,7 @@ class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
         const val DATABASE_NAME = "tachiyomi.db"
 
         /** Version of the database. */
-        const val DATABASE_VERSION = 43
+        const val DATABASE_VERSION = 44
     }
 
     override fun onOpen(db: SupportSQLiteDatabase) {
@@ -58,6 +58,8 @@ class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
             execSQL(MangaTable.createLibraryIndexQuery)
             execSQL(ChapterTable.createMangaIdIndexQuery)
             execSQL(ChapterTable.createUnreadChaptersIndexQuery)
+            execSQL(ChapterTable.createBookmarkedChaptersIndexQuery)
+            execSQL(ChapterTable.createUnavailableChaptersIndexQuery)
             execSQL(HistoryTable.createChapterIdIndexQuery)
         }
 
@@ -194,6 +196,10 @@ class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
         }
         if (oldVersion < 43) {
             db.execSQL(MangaTable.addDynamicCover)
+        }
+        if (oldVersion < 44) {
+            db.execSQL(ChapterTable.createBookmarkedChaptersIndexQuery)
+            db.execSQL(ChapterTable.createUnavailableChaptersIndexQuery)
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/ChapterTable.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/ChapterTable.kt
@@ -86,6 +86,16 @@ object ChapterTable {
             "CREATE INDEX ${TABLE}_unread_by_manga_index ON $TABLE($COL_MANGA_ID, $COL_READ) " +
                 "WHERE $COL_READ = 0"
 
+    val createBookmarkedChaptersIndexQuery: String
+        get() =
+            "CREATE INDEX ${TABLE}_bookmarked_by_manga_index ON $TABLE($COL_MANGA_ID) " +
+                "WHERE $COL_BOOKMARK = 1"
+
+    val createUnavailableChaptersIndexQuery: String
+        get() =
+            "CREATE INDEX ${TABLE}_unavailable_by_manga_index ON $TABLE($COL_MANGA_ID) " +
+                "WHERE $COL_UNAVAILABLE = 1"
+
     val addChapterCol: String
         get() = "ALTER TABLE $TABLE ADD COLUMN $COL_CHP_TXT TEXT DEFAULT ''"
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/LibraryScreen.kt
@@ -74,7 +74,8 @@ fun LibraryScreen(
 ) {
     val context = LocalContext.current
 
-    // Optimize: Remember the action objects to prevent unnecessary recompositions of child composables
+    // Optimize: Remember the action objects to prevent unnecessary recompositions of child
+    // composables
     // when LibraryScreen recomposes but these actions (and their dependencies) haven't changed.
     val libraryScreenActions =
         remember(libraryViewModel, openManga, onSearchMangaDex, context) {


### PR DESCRIPTION
💡 What: Added partial indexes on the 'chapters' table for rows where 'bookmark = 1' and 'unavailable = 1'.
🎯 Why: Library queries frequently filter by these boolean flags, causing full table scans or inefficient index usage on large tables.
📊 Impact: Reduces IO for library refreshes and filtering operations by allowing the query optimizer to target specific subsets of chapters.
🔬 Measurement: Verify execution plan for library queries or benchmark library load time with large libraries.

---
*PR created automatically by Jules for task [10807532158964209867](https://jules.google.com/task/10807532158964209867) started by @nonproto*