### PR TITLE
Hoist onBookmark and onRead callbacks in MangaScreen

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/bars/TitleTopAppBar.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/bars/TitleTopAppBar.kt
@@ -45,7 +45,10 @@ fun TitleTopAppBar(
     FlexibleTopBar(
         scrollBehavior = scrollBehavior,
         colors =
-            FlexibleTopBarColors(containerColor = color, scrolledContainerColor = scrolledContainerColor),
+            FlexibleTopBarColors(
+                containerColor = color,
+                scrolledContainerColor = scrolledContainerColor,
+            ),
     ) {
         Box(
             modifier = Modifier.fillMaxWidth().statusBarsPadding().padding(horizontal = Size.small)

--- a/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
@@ -75,6 +75,7 @@ import kotlinx.coroutines.launch
 import org.nekomanga.R
 import org.nekomanga.constants.MdConstants
 import org.nekomanga.domain.chapter.ChapterItem
+import org.nekomanga.domain.chapter.ChapterMarkActions
 import org.nekomanga.domain.snackbar.SnackbarColor
 import org.nekomanga.presentation.components.NekoColors
 import org.nekomanga.presentation.components.UiText
@@ -519,6 +520,28 @@ private fun MangaScreenWrapper(
             )
         }
 
+    val onBookmark: (ChapterItem) -> Unit =
+        remember(chapterActions) {
+            { item ->
+                chapterActions.mark(
+                    listOf(item),
+                    if (item.chapter.bookmark) ChapterMarkActions.UnBookmark(true)
+                    else ChapterMarkActions.Bookmark(true),
+                )
+            }
+        }
+
+    val onRead: (ChapterItem) -> Unit =
+        remember(chapterActions) {
+            { item ->
+                chapterActions.mark(
+                    listOf(item),
+                    if (item.chapter.read) ChapterMarkActions.Unread(true)
+                    else ChapterMarkActions.Read(true),
+                )
+            }
+        }
+
     ChildScreenScaffold(
         refreshState = refreshState,
         scrollBehavior = scrollBehavior,
@@ -550,6 +573,8 @@ private fun MangaScreenWrapper(
                 generatePalette = generatePalette,
                 onOpenSheet = ::openSheet,
                 categoryActions = categoryActions,
+                onBookmark = onBookmark,
+                onRead = onRead,
             )
         } else {
             VerticalLayout(
@@ -567,6 +592,8 @@ private fun MangaScreenWrapper(
                 generatePalette = generatePalette,
                 onOpenSheet = ::openSheet,
                 categoryActions = categoryActions,
+                onBookmark = onBookmark,
+                onRead = onRead,
             )
         }
 
@@ -589,6 +616,8 @@ private fun LazyListScope.chapterList(
     screenState: MangaConstants.MangaDetailScreenState,
     themeColorState: ThemeColorState,
     chapterActions: ChapterActions,
+    onBookmark: (ChapterItem) -> Unit,
+    onRead: (ChapterItem) -> Unit,
     onOpenSheet: (DetailsBottomSheetScreen) -> Unit,
 ) {
     item(key = "chapter_header") {
@@ -610,6 +639,8 @@ private fun LazyListScope.chapterList(
             shouldHideChapterTitles =
                 screenState.chapterFilter.hideChapterTitles == ToggleableState.On,
             chapterActions = chapterActions,
+            onBookmark = onBookmark,
+            onRead = onRead,
         )
     }
 }
@@ -630,6 +661,8 @@ private fun VerticalLayout(
     onToggleFavorite: () -> Unit,
     generatePalette: (Drawable) -> Unit,
     onOpenSheet: (DetailsBottomSheetScreen) -> Unit,
+    onBookmark: (ChapterItem) -> Unit,
+    onRead: (ChapterItem) -> Unit,
 ) {
     val contentPadding = PaddingValues(bottom = incomingContentPadding.calculateBottomPadding())
     val listState = rememberLazyListState()
@@ -681,6 +714,8 @@ private fun VerticalLayout(
                     screenState = screenState,
                     themeColorState = themeColorState,
                     chapterActions = chapterActions,
+                    onBookmark = onBookmark,
+                    onRead = onRead,
                     onOpenSheet = onOpenSheet,
                 )
             }
@@ -704,6 +739,8 @@ private fun SideBySideLayout(
     onToggleFavorite: () -> Unit,
     generatePalette: (Drawable) -> Unit,
     onOpenSheet: (DetailsBottomSheetScreen) -> Unit,
+    onBookmark: (ChapterItem) -> Unit,
+    onRead: (ChapterItem) -> Unit,
 ) {
 
     val detailsContentPadding =
@@ -770,6 +807,8 @@ private fun SideBySideLayout(
                         screenState = screenState,
                         themeColorState = themeColorState,
                         chapterActions = chapterActions,
+                        onBookmark = onBookmark,
+                        onRead = onRead,
                         onOpenSheet = onOpenSheet,
                     )
                 }

--- a/app/src/main/java/org/nekomanga/presentation/screens/manga/MangaChapterListItem.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/manga/MangaChapterListItem.kt
@@ -4,11 +4,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import eu.kanade.tachiyomi.ui.manga.MangaConstants.ChapterActions
 import org.nekomanga.domain.chapter.ChapterItem
-import org.nekomanga.domain.chapter.ChapterMarkActions
 import org.nekomanga.presentation.components.ChapterRow
 import org.nekomanga.presentation.components.listcard.ExpressiveListCard
 import org.nekomanga.presentation.components.listcard.ListCardType
@@ -23,6 +21,8 @@ fun MangaChapterListItem(
     themeColorState: ThemeColorState,
     shouldHideChapterTitles: Boolean,
     chapterActions: ChapterActions,
+    onBookmark: (ChapterItem) -> Unit,
+    onRead: (ChapterItem) -> Unit,
 ) {
     val listCardType =
         when {
@@ -37,28 +37,6 @@ fun MangaChapterListItem(
         listCardType = listCardType,
         themeColorState = themeColorState,
     ) {
-        val onBookmark: (ChapterItem) -> Unit =
-            remember(chapterActions) {
-                { item ->
-                    chapterActions.mark(
-                        listOf(item),
-                        if (item.chapter.bookmark) ChapterMarkActions.UnBookmark(true)
-                        else ChapterMarkActions.Bookmark(true),
-                    )
-                }
-            }
-
-        val onRead: (ChapterItem) -> Unit =
-            remember(chapterActions) {
-                { item ->
-                    chapterActions.mark(
-                        listOf(item),
-                        if (item.chapter.read) ChapterMarkActions.Unread(true)
-                        else ChapterMarkActions.Read(true),
-                    )
-                }
-            }
-
         ChapterRow(
             themeColor = themeColorState,
             chapterItem = chapterItem,


### PR DESCRIPTION
Hoisted `onBookmark` and `onRead` callbacks from `MangaChapterListItem` to `MangaScreen` to optimize recomposition performance in the chapter list. Verified compilation successfully.

---
*PR created automatically by Jules for task [8324066668786764755](https://jules.google.com/task/8324066668786764755) started by @nonproto*