### PR TITLE
⚙️ Operator: Optimize Pull Request CI

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -3,6 +3,10 @@ name: Pull Request CI
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr_check_wrapper:
     name: Validate Gradle Wrapper
@@ -23,7 +27,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 17
 
       - name: Install Android Build Tools


### PR DESCRIPTION
💡 What:
- Implemented a GitHub Actions concurrency group for the `pull_request` workflow (`pr-ci.yaml`) with `cancel-in-progress: true`.
- Updated the Java distribution for `actions/setup-java` from the deprecated `adopt` to `temurin`.

🎯 Why:
- CI Speed and Reliability: Redundant CI builds are expensive and slow down the testing pipeline. By canceling outdated PR builds when new commits are pushed, we save significant runner minutes.
- Addressing deprecations: The `adopt` Java distribution is no longer actively supported in the setup action; migrating to `temurin` ensures the CI environment remains stable and free of deprecation warnings.

⏱️ Impact:
- Expected to save multiple minutes of CI execution time per updated PR by preventing parallel execution of obsolete commits.

---
*PR created automatically by Jules for task [7192888247202110773](https://jules.google.com/task/7192888247202110773) started by @nonproto*