### PR TITLE
fix: Don't attempt to update trackers offline

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -47,6 +47,7 @@ import eu.kanade.tachiyomi.util.chapter.syncChaptersWithSource
 import eu.kanade.tachiyomi.util.chapter.updateTrackChapterRead
 import eu.kanade.tachiyomi.util.system.ImageUtil
 import eu.kanade.tachiyomi.util.system.executeOnIO
+import eu.kanade.tachiyomi.util.system.isOnline
 import eu.kanade.tachiyomi.util.system.launchIO
 import eu.kanade.tachiyomi.util.system.launchNonCancellable
 import eu.kanade.tachiyomi.util.system.sharedCacheDir
@@ -1098,6 +1099,7 @@ constructor(
      */
     private fun updateTrackChapterAfterReading(readerChapter: ReaderChapter) {
         if (!preferences.autoUpdateTrack().get()) return
+        if (!preferences.context.isOnline()) return
         viewModelScope.launchIO {
             val newChapterRead = readerChapter.chapter.chapter_number
             updateTrackChapterRead(


### PR DESCRIPTION
💡 What:
Added a network connectivity check before attempting to update trackers in `ReaderViewModel.kt`.

🎯 Why:
To prevent unnecessary network requests and potential error toasts when a user is reading offline.

🐛 Change:
Modified `updateTrackChapterAfterReading` to return early if `preferences.context.isOnline()` is false.

---
*PR created automatically by Jules for task [3235501783884264729](https://jules.google.com/task/3235501783884264729) started by @nonproto*