### PR TITLE
chore: Add ARIA label to icon-only options button in DownloadChapterRow

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - [Accessibility in Dynamic Button Blocks]
 **Learning:** In `ButtonBlock.kt`, buttons can have their text labels hidden via `hideText` or be initialized with empty text (like the Favorite button). This creates icon-only buttons that are inaccessible to screen readers.
 **Action:** When designing data-driven button components, always include an optional `contentDescription` field in the data model (e.g., `ActionButtonData`) to provide a fallback accessible label when the visual text is hidden or empty.
+
+## 2024-05-23 - [Accessibility in Icon-only Buttons]
+**Learning:** In Jetpack Compose UI components, icon-only `IconButton`s often leave the `contentDescription` of the inner `Icon` as `null` (e.g., `Icons.Default.MoreVert`). This renders the buttons inaccessible to screen readers like TalkBack.
+**Action:** When working on Compose UI, always ensure that `Icon` components inside `IconButton`s have a valid `contentDescription` using an appropriate string resource (e.g., `stringResource(id = R.string.options)`) instead of `null`.

--- a/app/src/main/java/org/nekomanga/presentation/screens/download/DownloadChapterRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/download/DownloadChapterRow.kt
@@ -158,7 +158,10 @@ private fun ChapterRow(
             onClick = { dropdown = !dropdown },
             modifier = Modifier.padding(end = Size.medium),
         ) {
-            Icon(imageVector = Icons.Default.MoreVert, contentDescription = null)
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = stringResource(id = R.string.options),
+            )
             SimpleDropdownMenu(
                 expanded = dropdown,
                 themeColorState = defaultThemeColorState(),


### PR DESCRIPTION
💡 **What:** Added a `contentDescription` to the `MoreVert` icon in `DownloadChapterRow.kt` using `R.string.options` instead of `null`.
🎯 **Why:** To improve accessibility by providing screen readers (like TalkBack) with a semantic label ("Options") for the icon-only button that opens the dropdown menu for downloaded chapters.
♿ **Accessibility:** This directly addresses an accessibility issue where visually impaired users using screen readers would hear no description when focusing on the options button for a download row. This aligns with WCAG guidelines for providing text alternatives to non-text content.

---
*PR created automatically by Jules for task [13047485482767361577](https://jules.google.com/task/13047485482767361577) started by @nonproto*