### PR TITLE
chore: Add ARIA labels to category sort IconButtons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-23 - [Accessibility in Icon-only Buttons]
 **Learning:** In Jetpack Compose UI components, icon-only `IconButton`s often leave the `contentDescription` of the inner `Icon` as `null` (e.g., `Icons.Default.MoreVert`). This renders the buttons inaccessible to screen readers like TalkBack.
 **Action:** When working on Compose UI, always ensure that `Icon` components inside `IconButton`s have a valid `contentDescription` using an appropriate string resource (e.g., `stringResource(id = R.string.options)`) instead of `null`.
+
+## 2026-03-08 - [Missing ContentDescription on IconButtons]
+**Learning:** Found an accessibility issue: missing `contentDescription` on some icon-only IconButtons in Jetpack Compose UI components. For instance, `org.nekomanga.presentation.screens.library.CategorySortButtons.kt` has multiple icon-only `IconButton`s containing `Icon` elements with `contentDescription = null`. This violates accessibility guidelines because screen readers will not announce anything useful when navigating to these buttons.
+**Action:** Always provide a valid localized string resource for the `contentDescription` of `Icon` components when they act as the sole visual element inside an interactive component like an `IconButton`.

--- a/app/src/main/java/org/nekomanga/presentation/screens/library/CategorySortButtons.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/library/CategorySortButtons.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import eu.kanade.tachiyomi.R
 import jp.wasabeef.gap.Gap
 import org.nekomanga.presentation.theme.Size
 
@@ -72,7 +74,7 @@ fun RowScope.CategorySortButtons(
                     isAscending -> Icons.Default.ArrowDownward
                     else -> Icons.Default.ArrowUpward
                 },
-            contentDescription = null,
+            contentDescription = stringResource(id = R.string.sort),
             modifier = Modifier.size(Size.mediumLarge),
         )
     }
@@ -115,7 +117,7 @@ fun RowScope.CategorySortButtons(
                 ) {
                     Icon(
                         imageVector = Icons.Default.Refresh,
-                        contentDescription = null,
+                        contentDescription = stringResource(id = R.string.refresh),
                         modifier = Modifier.size(Size.mediumLarge),
                     )
                 }


### PR DESCRIPTION
💡 What: Added missing `contentDescription` to icon-only `IconButton`s in `CategorySortButtons.kt` (used for sorting direction and refreshing).
🎯 Why: Without these descriptions, screen readers (like TalkBack) cannot announce the button's purpose, making the interface less accessible.
📸 Before/After: Accessibility descriptions changed from `null` to appropriate `stringResource(id = R.string...)`.
♿ Accessibility: Improved screen reader navigation by ensuring all interactive elements have meaningful labels.

---
*PR created automatically by Jules for task [4278226362867938136](https://jules.google.com/task/4278226362867938136) started by @nonproto*