### PR TITLE
chore: Add ARIA labels to category sort IconButtons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -3,5 +3,5 @@
 **Action:** When designing data-driven button components, always include an optional `contentDescription` field in the data model (e.g., `ActionButtonData`) to provide a fallback accessible label when the visual text is hidden or empty.
 
 ## 2024-05-23 - [Accessibility in Icon-only Buttons]
-**Learning:** In Jetpack Compose UI components, icon-only `IconButton`s often leave the `contentDescription` of the inner `Icon` as `null` (e.g., `Icons.Default.MoreVert` or in `org.nekomanga.presentation.screens.library.CategorySortButtons.kt`). This renders the buttons inaccessible to screen readers like TalkBack.
+**Learning:** In Jetpack Compose UI components, icon-only `IconButton`s often leave the `contentDescription` of the inner `Icon` as `null` (e.g., `Icons.Default.MoreVert`). This renders the buttons inaccessible to screen readers like TalkBack.
 **Action:** When working on Compose UI, always ensure that `Icon` components inside `IconButton`s have a valid `contentDescription` using an appropriate string resource (e.g., `stringResource(id = R.string.options)`) instead of `null`.


### PR DESCRIPTION
💡 What: Added missing `contentDescription` to icon-only `IconButton`s in `CategorySortButtons.kt` (used for sorting direction and refreshing).
🎯 Why: Without these descriptions, screen readers (like TalkBack) cannot announce the button's purpose, making the interface less accessible.
📸 Before/After: Accessibility descriptions changed from `null` to appropriate `stringResource(id = R.string...)`.
♿ Accessibility: Improved screen reader navigation by ensuring all interactive elements have meaningful labels.

---
*PR created automatically by Jules for task [4278226362867938136](https://jules.google.com/task/4278226362867938136) started by @nonproto*