### PR TITLE
opt: Optimize background task TrackingSyncJob

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/jobs/tracking/TrackingSyncJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jobs/tracking/TrackingSyncJob.kt
@@ -3,9 +3,11 @@ package eu.kanade.tachiyomi.jobs.tracking
 import android.content.Context
 import android.content.pm.ServiceInfo
 import android.os.Build
+import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingWorkPolicy
 import androidx.work.ForegroundInfo
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
@@ -91,7 +93,17 @@ class TrackingSyncJob(val context: Context, params: WorkerParameters) :
         val TAG = "tracking_sync_job"
 
         fun doWorkNow(context: Context) {
-            val request = OneTimeWorkRequestBuilder<TrackingSyncJob>().addTag(TAG).build()
+            val constraints =
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .setRequiresBatteryNotLow(true)
+                    .build()
+
+            val request =
+                OneTimeWorkRequestBuilder<TrackingSyncJob>()
+                    .addTag(TAG)
+                    .setConstraints(constraints)
+                    .build()
 
             WorkManager.getInstance(context)
                 .enqueueUniqueWork(TAG, ExistingWorkPolicy.REPLACE, request)


### PR DESCRIPTION
💡 What: Added explicit `WorkManager` Constraints to `TrackingSyncJob` so it requires `NetworkType.CONNECTED` and `setRequiresBatteryNotLow(true)`.

🎯 Why: Battery efficiency and Doze mode compliance. `TrackingSyncJob` refreshes tracking metadata in the background; by ensuring the device has a network connection and isn't low on battery, we prevent the app from waking up and performing expensive I/O when it's inefficient to do so.

---
*PR created automatically by Jules for task [7442572281324205864](https://jules.google.com/task/7442572281324205864) started by @nonproto*