### PR TITLE
ref: neutralize UnusedPrivateMember in MangaViewModel.kt

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -1666,18 +1666,6 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
         }
     }
 
-    private fun updateMangaScanlator(manga: Manga, filteredScanlators: Set<String>) {
-        viewModelScope.launchIO {
-            manga.filtered_scanlators =
-                when (filteredScanlators.isEmpty()) {
-                    true -> null
-                    false -> ChapterUtil.getScanlatorString(filteredScanlators)
-                }
-
-            db.insertManga(manga).executeOnIO()
-        }
-    }
-
     /** Changes the filtered scanlators, if null then it resets the scanlator filter */
     fun changeLanguageOption(languageOptions: MangaConstants.LanguageOption?) {
         viewModelScope.launchIO {
@@ -1702,19 +1690,6 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                 (current ?: MangaFilterState()).copy(languages = newFilteredLanguages)
             }
             _persistFilterChannel.trySend(Unit)
-        }
-    }
-
-    /** Updates the filtered scanlators */
-    private fun updateMangaFilteredLanguages(manga: Manga, filteredLanguages: Set<String>) {
-        viewModelScope.launchIO {
-            manga.filtered_language =
-                when (filteredLanguages.isEmpty()) {
-                    true -> null
-                    false -> ChapterUtil.getLanguageString(filteredLanguages)
-                }
-
-            db.insertManga(manga).executeOnIO()
         }
     }
 


### PR DESCRIPTION
💡 What: Removed unused private functions `updateMangaScanlator` and `updateMangaFilteredLanguages` in `MangaViewModel.kt` that were flagged by Detekt.
🎯 Why: These functions were dead code left over from a previous refactor of the filtering logic. Removing them reduces file size, cognitive load, and resolves two Detekt `UnusedPrivateMember` warnings.
📊 Impact: Reduces function length by 26 lines. Resolves Detekt warnings without changing application behavior.

---
*PR created automatically by Jules for task [14915687549179455098](https://jules.google.com/task/14915687549179455098) started by @nonproto*