### PR TITLE
perf: Optimize search query splitting in LibraryViewModel

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-02-24 - Missing Partial Indexes on Frequently Filtered Booleans
 **Learning:** The application frequently queries `chapters` table filtering by boolean flags like `bookmark=1` or `unavailable=1` inside complex library refresh queries. Without specific partial indexes (e.g., `WHERE bookmark=1`), these queries rely on wider indexes (like `manga_id`) or full table scans, causing significant IO overhead during library updates, especially for users with large libraries but few bookmarks.
 **Action:** Always verify execution plans for queries involving boolean flags on large tables. Use partial indexes (e.g., `CREATE INDEX ... WHERE flag=1`) to drastically reduce index size and lookup time for sparse attributes.
+
+## 2026-03-09 - Move string parsing out of inner filter loop
+**Learning:** Found an unintentional O(n) loop optimization block where the `searchQuery` string was split on every iteration in the `LibraryMangaItem.matches` checking function. Since a comma query dynamically checks genre splits per item, a huge user library of thousands of manga resulted in thousands of list allocations.
+**Action:** Lift the parsing logic outside the iterative filter, and modify the data signature so `splitQuery` is passed down, eliminating massive loop overhead for filtered rendering.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -206,7 +206,10 @@ class LibraryViewModel() : ViewModel() {
                 if (searchQuery.isNullOrBlank()) {
                     mangaList
                 } else {
-                    mangaList.filter { libraryMangaItem -> libraryMangaItem.matches(searchQuery) }
+                    val splitQuery = if (searchQuery.contains(",")) searchQuery.split(",") else null
+                    mangaList.filter { libraryMangaItem ->
+                        libraryMangaItem.matches(searchQuery, splitQuery)
+                    }
                 }
             }
             .conflate()

--- a/app/src/main/java/org/nekomanga/domain/manga/Manga.kt
+++ b/app/src/main/java/org/nekomanga/domain/manga/Manga.kt
@@ -51,7 +51,7 @@ data class LibraryMangaItem(
     val hasStarted
         get() = readCount > 0
 
-    fun matches(searchQuery: String?): Boolean {
+    fun matches(searchQuery: String?, searchQuerySplit: List<String>? = null): Boolean {
         return if (searchQuery == null) {
             true
         } else {
@@ -60,7 +60,8 @@ data class LibraryMangaItem(
                 this.author.fastAny { author -> author.contains(searchQuery, true) } ||
                 if (searchQuery.contains(",")) {
                     this.genre.fastAll { genre -> genre.contains(searchQuery) }
-                    searchQuery.split(",").all { splitQuery ->
+                    val split = searchQuerySplit ?: searchQuery.split(",")
+                    split.all { splitQuery ->
                         this.genre.fastAny { genre ->
                             if (splitQuery.startsWith("-")) {
                                 !genre.contains(splitQuery.substringAfter("-"), true)


### PR DESCRIPTION
💡 What: Lifted `searchQuery.split(",")` logic out of the iterative filter loop inside `LibraryViewModel`, passing it as a pre-calculated argument down to `LibraryMangaItem.matches()`.

🎯 Why: To prevent the query from being re-parsed and split hundreds or thousands of times on every `filteredMangaListFlow` update. This reduces garbage collection overhead and list allocation significantly during library searches with comma-separated terms.

📊 Impact: Reduces O(n) list allocations to O(1) allocation during collection filtering, making large library searches measurably faster and smoother.

🔬 Measurement: Verify by typing comma-separated genre queries in the search box of a large library. CPU/Memory profiling will show eliminated inner-loop allocations.

---
*PR created automatically by Jules for task [10938193750443609630](https://jules.google.com/task/10938193750443609630) started by @nonproto*