### PR TITLE
perf: Prevent unnecessary manga item recompositions in HorizontalCategoriesPage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,5 @@
 ## 2026-03-09 - Move string parsing out of inner filter loop
 **Learning:** Found an unintentional O(n) loop optimization block where the `searchQuery` string was split on every iteration in the `LibraryMangaItem.matches` checking function. Since a comma query dynamically checks genre splits per item, a huge user library of thousands of manga resulted in thousands of list allocations.
 **Action:** Lift the parsing logic outside the iterative filter, and modify the data signature so `splitQuery` is passed down, eliminating massive loop overhead for filtered rendering.
+
+## 2024-05-19 - [Avoid Recomposition via Data Class Memoization] **Learning:** Passing multiple primitive state values from a main `State` object directly to list item composables triggers recomposition for all items whenever any unrelated property in that parent `State` changes (e.g. `pagerIndex`). **Action:** Group primitive display flags into a single `@Immutable` data class (like `LibraryItemDisplayOptions`) and memoize its instantiation using `remember` (with the primitive fields as keys). Pass this single object to child items instead of the parent `State`.

--- a/app/src/main/java/org/nekomanga/presentation/components/Loading.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/Loading.kt
@@ -23,9 +23,7 @@ fun Loading(modifier: Modifier = Modifier) {
     ) {
         CircularProgressIndicator(
             modifier =
-                Modifier.size(Size.largePlus)
-                    .padding(Size.extraTiny)
-                    .align(Alignment.Center),
+                Modifier.size(Size.largePlus).padding(Size.extraTiny).align(Alignment.Center),
             color = MaterialTheme.colorScheme.onSecondary,
             strokeWidth = Size.extraTiny,
         )

--- a/app/src/main/java/org/nekomanga/presentation/components/sheets/ExternalLinksSheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/sheets/ExternalLinksSheet.kt
@@ -79,8 +79,7 @@ private fun LinkCard(
                     painter = painterResource(id = externalLink.logo),
                     contentDescription = null,
                     modifier =
-                        Modifier.size(Size.largePlus)
-                            .padding(top = Size.tiny, bottom = Size.tiny),
+                        Modifier.size(Size.largePlus).padding(top = Size.tiny, bottom = Size.tiny),
                 )
                 Gap(Size.small)
             } else {

--- a/app/src/main/java/org/nekomanga/presentation/screens/library/HorizontalCategoriesPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/library/HorizontalCategoriesPage.kt
@@ -110,6 +110,23 @@ fun HorizontalCategoriesPage(
             MaterialTheme.colorScheme.onSurface
         }
 
+    val displayOptions =
+        remember(
+            libraryScreenState.showUnreadBadges,
+            libraryScreenState.showDownloadBadges,
+            libraryScreenState.showStartReadingButton,
+            libraryScreenState.outlineCovers,
+            libraryScreenState.dynamicCovers,
+        ) {
+            LibraryItemDisplayOptions(
+                showUnreadBadges = libraryScreenState.showUnreadBadges,
+                showDownloadBadges = libraryScreenState.showDownloadBadges,
+                showStartReadingButton = libraryScreenState.showStartReadingButton,
+                outlineCovers = libraryScreenState.outlineCovers,
+                dynamicCovers = libraryScreenState.dynamicCovers,
+            )
+        }
+
     Column(modifier = Modifier.fillMaxSize().padding(contentPadding).padding(top = Size.tiny)) {
         if (isValidState) {
             SecondaryScrollableTabRow(
@@ -200,7 +217,7 @@ fun HorizontalCategoriesPage(
                                 ) { index, libraryItem ->
                                     GridItem(
                                         libraryItem = libraryItem,
-                                        libraryScreenState = libraryScreenState,
+                                        displayOptions = displayOptions,
                                         libraryScreenActions = libraryScreenActions,
                                         selectedIds = selectedIds,
                                         isComfortable =
@@ -258,7 +275,7 @@ fun HorizontalCategoriesPage(
                                         index = index,
                                         totalSize = item.libraryItems.size,
                                         selectedIds = selectedIds,
-                                        libraryScreenState = libraryScreenState,
+                                        displayOptions = displayOptions,
                                         libraryItem = libraryItem,
                                         libraryScreenActions = libraryScreenActions,
                                     )
@@ -344,28 +361,28 @@ private fun HorizontalCategoryHeader(
 @Composable
 private fun GridItem(
     libraryItem: LibraryMangaItem,
-    libraryScreenState: LibraryScreenState,
+    displayOptions: LibraryItemDisplayOptions,
     libraryScreenActions: LibraryScreenActions,
     selectedIds: List<Long>,
     isComfortable: Boolean,
 ) {
     MangaGridItem(
         displayManga = libraryItem.displayManga,
-        showUnreadBadge = libraryScreenState.showUnreadBadges,
+        showUnreadBadge = displayOptions.showUnreadBadges,
         unreadCount = libraryItem.unreadCount,
-        showDownloadBadge = libraryScreenState.showDownloadBadges,
+        showDownloadBadge = displayOptions.showDownloadBadges,
         downloadCount = libraryItem.downloadCount,
-        shouldOutlineCover = libraryScreenState.outlineCovers,
-        dynamicCover = libraryScreenState.dynamicCovers,
+        shouldOutlineCover = displayOptions.outlineCovers,
+        dynamicCover = displayOptions.dynamicCovers,
         isComfortable = isComfortable,
         isSelected = selectedIds.contains(libraryItem.displayManga.mangaId),
         showStartReadingButton =
-            libraryScreenState.showStartReadingButton && libraryItem.unreadCount > 0,
+            displayOptions.showStartReadingButton && libraryItem.unreadCount > 0,
         onStartReadingClick = {
             libraryScreenActions.mangaStartReadingClick(libraryItem.displayManga.mangaId)
         },
         onClick = { _ ->
-            if (libraryScreenState.selectedItems.isNotEmpty()) {
+            if (selectedIds.isNotEmpty()) {
                 libraryScreenActions.mangaLongClick(libraryItem)
             } else {
                 libraryScreenActions.mangaClick(libraryItem.displayManga.mangaId)
@@ -381,7 +398,7 @@ private fun ListItem(
     index: Int,
     totalSize: Int,
     selectedIds: List<Long>,
-    libraryScreenState: LibraryScreenState,
+    displayOptions: LibraryItemDisplayOptions,
     libraryItem: LibraryMangaItem,
     libraryScreenActions: LibraryScreenActions,
 ) {
@@ -401,7 +418,7 @@ private fun ListItem(
                 Modifier.fillMaxWidth()
                     .combinedClickable(
                         onClick = {
-                            if (libraryScreenState.selectedItems.isNotEmpty()) {
+                            if (selectedIds.isNotEmpty()) {
                                 libraryScreenActions.mangaLongClick(libraryItem)
                             } else {
                                 libraryScreenActions.mangaClick(libraryItem.displayManga.mangaId)
@@ -411,17 +428,17 @@ private fun ListItem(
                     ),
             displayManga = libraryItem.displayManga,
             isSelected = selectedIds.contains(libraryItem.displayManga.mangaId),
-            showUnreadBadge = libraryScreenState.showUnreadBadges,
+            showUnreadBadge = displayOptions.showUnreadBadges,
             showStartReadingButton =
-                libraryScreenState.showStartReadingButton && libraryItem.unreadCount > 0,
+                displayOptions.showStartReadingButton && libraryItem.unreadCount > 0,
             onStartReadingClick = {
                 libraryScreenActions.mangaStartReadingClick(libraryItem.displayManga.mangaId)
             },
             unreadCount = libraryItem.unreadCount,
-            showDownloadBadge = libraryScreenState.showDownloadBadges,
+            showDownloadBadge = displayOptions.showDownloadBadges,
             downloadCount = libraryItem.downloadCount,
-            shouldOutlineCover = libraryScreenState.outlineCovers,
-            dynamicCover = libraryScreenState.dynamicCovers,
+            shouldOutlineCover = displayOptions.outlineCovers,
+            dynamicCover = displayOptions.dynamicCovers,
         )
     }
 }


### PR DESCRIPTION
💡 What:
Extracted primitive state properties (e.g. `showUnreadBadges`, `showDownloadBadges`, `outlineCovers`, `dynamicCovers`) from `LibraryScreenState` into a grouped `@Immutable` `LibraryItemDisplayOptions` data class, memoized with `remember`.

🎯 Why:
The `LibraryScreenState` object holds many unrelated state fields such as `pagerIndex` and `scrollPositions`. Previously, `GridItem` and `ListItem` composables received `LibraryScreenState` directly. Any change to the state, such as simply swiping between categories (updating `pagerIndex`), caused all visible list and grid items to recompose unnecessarily. Passing only the grouped, memoized display options ensures items only recompose when those specific UI options change or when the item data itself changes.

📊 Impact:
Reduces unnecessary re-renders of the manga library items by avoiding state thrashing when interacting with horizontal pagers.

🔬 Measurement:
Observe Jetpack Compose Layout Inspector or profiling tools to confirm that swipe gestures between categories in Horizontal display mode no longer trigger recompositions for the `GridItem` and `ListItem` instances.

---
*PR created automatically by Jules for task [4600117961508066258](https://jules.google.com/task/4600117961508066258) started by @nonproto*