### PR TITLE
✝️ Exorcist: Migrate ReaderChapter from RxJava to Coroutines

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/model/ReaderChapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/model/ReaderChapter.kt
@@ -1,9 +1,11 @@
 package eu.kanade.tachiyomi.ui.reader.model
 
-import com.jakewharton.rxrelay.BehaviorRelay
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.ui.reader.loader.PageLoader
 import eu.kanade.tachiyomi.util.system.HashCode
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import org.nekomanga.logging.TimberKt
 
 data class ReaderChapter(val chapter: Chapter) {
@@ -11,12 +13,11 @@ data class ReaderChapter(val chapter: Chapter) {
     var state: State = State.Wait
         set(value) {
             field = value
-            stateRelay.call(value)
+            _stateFlow.value = value
         }
 
-    private val stateRelay by lazy { BehaviorRelay.create(state) }
-
-    val stateObserver by lazy { stateRelay.asObservable().onBackpressureBuffer() }
+    private val _stateFlow = MutableStateFlow(state)
+    val stateFlow: StateFlow<State> = _stateFlow.asStateFlow()
 
     val pages: List<ReaderPage>?
         get() = (state as? State.Loaded)?.pages

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerTransitionHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerTransitionHolder.kt
@@ -14,9 +14,10 @@ import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderTransitionView
 import eu.kanade.tachiyomi.util.system.dpToPx
 import eu.kanade.tachiyomi.widget.ViewPagerAdapter
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import org.nekomanga.R
-import rx.Subscription
-import rx.android.schedulers.AndroidSchedulers
 
 /** View of the ViewPager that contains a chapter transition. */
 @SuppressLint("ViewConstructor")
@@ -27,8 +28,8 @@ class PagerTransitionHolder(val viewer: PagerViewer, val transition: ChapterTran
     override val item: Any
         get() = transition
 
-    /** Subscription for status changes of the transition page. */
-    private var statusSubscription: Subscription? = null
+    /** Job for status changes of the transition page. */
+    private var statusJob: Job? = null
 
     /**
      * View container of the current status of the transition page. Child views will be added
@@ -61,8 +62,8 @@ class PagerTransitionHolder(val viewer: PagerViewer, val transition: ChapterTran
     /** Called when this view is detached from the window. Unsubscribes any active subscription. */
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        statusSubscription?.unsubscribe()
-        statusSubscription = null
+        statusJob?.cancel()
+        statusJob = null
     }
 
     /**
@@ -70,15 +71,17 @@ class PagerTransitionHolder(val viewer: PagerViewer, val transition: ChapterTran
      * state, the pages container is cleaned up before setting the new state.
      */
     private fun observeStatus(chapter: ReaderChapter) {
-        statusSubscription?.unsubscribe()
-        statusSubscription =
-            chapter.stateObserver.observeOn(AndroidSchedulers.mainThread()).subscribe { state ->
-                pagesContainer.removeAllViews()
-                when (state) {
-                    is ReaderChapter.State.Wait -> {}
-                    is ReaderChapter.State.Loading -> setLoading()
-                    is ReaderChapter.State.Error -> setError(state.error)
-                    is ReaderChapter.State.Loaded -> setLoaded()
+        statusJob?.cancel()
+        statusJob =
+            viewer.scope.launch {
+                chapter.stateFlow.collectLatest { state ->
+                    pagesContainer.removeAllViews()
+                    when (state) {
+                        is ReaderChapter.State.Wait -> {}
+                        is ReaderChapter.State.Loading -> setLoading()
+                        is ReaderChapter.State.Error -> setError(state.error)
+                        is ReaderChapter.State.Loaded -> setLoaded()
+                    }
                 }
             }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonTransitionHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonTransitionHolder.kt
@@ -13,16 +13,17 @@ import eu.kanade.tachiyomi.ui.reader.model.ChapterTransition
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderTransitionView
 import eu.kanade.tachiyomi.util.system.dpToPx
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import org.nekomanga.R
-import rx.Subscription
-import rx.android.schedulers.AndroidSchedulers
 
 /** Holder of the webtoon viewer that contains a chapter transition. */
 class WebtoonTransitionHolder(val layout: LinearLayout, viewer: WebtoonViewer) :
     WebtoonBaseHolder(layout, viewer) {
 
-    /** Subscription for status changes of the transition page. */
-    private var statusSubscription: Subscription? = null
+    /** Job for status changes of the transition page. */
+    private var statusJob: Job? = null
 
     private val transitionView = ReaderTransitionView(context)
 
@@ -68,7 +69,7 @@ class WebtoonTransitionHolder(val layout: LinearLayout, viewer: WebtoonViewer) :
 
     /** Called when the view is recycled and being added to the view pool. */
     override fun recycle() {
-        unsubscribeStatus()
+        cancelStatusJob()
     }
 
     /**
@@ -76,27 +77,27 @@ class WebtoonTransitionHolder(val layout: LinearLayout, viewer: WebtoonViewer) :
      * state, the pages container is cleaned up before setting the new state.
      */
     private fun observeStatus(chapter: ReaderChapter, transition: ChapterTransition) {
-        unsubscribeStatus()
+        cancelStatusJob()
 
-        statusSubscription =
-            chapter.stateObserver.observeOn(AndroidSchedulers.mainThread()).subscribe { state ->
-                pagesContainer.removeAllViews()
-                when (state) {
-                    is ReaderChapter.State.Wait -> {}
-                    is ReaderChapter.State.Loading -> setLoading()
-                    is ReaderChapter.State.Error -> setError(state.error, transition)
-                    is ReaderChapter.State.Loaded -> setLoaded()
+        statusJob =
+            viewer.scope.launch {
+                chapter.stateFlow.collectLatest { state ->
+                    pagesContainer.removeAllViews()
+                    when (state) {
+                        is ReaderChapter.State.Wait -> {}
+                        is ReaderChapter.State.Loading -> setLoading()
+                        is ReaderChapter.State.Error -> setError(state.error, transition)
+                        is ReaderChapter.State.Loaded -> setLoaded()
+                    }
+                    pagesContainer.isVisible = pagesContainer.childCount > 0
                 }
-                pagesContainer.isVisible = pagesContainer.childCount > 0
             }
-
-        addSubscription(statusSubscription)
     }
 
-    /** Unsubscribes from the status subscription. */
-    private fun unsubscribeStatus() {
-        removeSubscription(statusSubscription)
-        statusSubscription = null
+    /** Cancels the status job. */
+    private fun cancelStatusJob() {
+        statusJob?.cancel()
+        statusJob = null
     }
 
     /** Sets the loading state on the pages container. */

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -31,7 +31,7 @@ class WebtoonViewer(val activity: ReaderActivity, val noWebtoonTag: Boolean = fa
 
     val downloadManager: DownloadManager by injectLazy()
 
-    private val scope = MainScope()
+    val scope = MainScope()
 
     /** Recycler view used by this viewer. */
     val recycler = WebtoonRecyclerView(activity)


### PR DESCRIPTION
💡 What: Removed BehaviorRelay in favor of MutableStateFlow for ReaderChapter.stateFlow. Updated PagerTransitionHolder and WebtoonTransitionHolder to consume StateFlow via CoroutineScope.launch.

🎯 Why: Codebase modernization and dependency reduction by migrating RxJava to Kotlin Coroutines and Flows.

⚠️ Nuances: `stateObserver.observeOn(AndroidSchedulers.mainThread())` was replaced with `scope.launch` using the View's scope, safely moving UI state updates into native Coroutine execution. No backpressure logic is needed since `StateFlow` automatically conflates to the latest value, matching the UI's need.

---
*PR created automatically by Jules for task [14334199799085337356](https://jules.google.com/task/14334199799085337356) started by @nonproto*