### PR TITLE
🪴 Steward: Remove unused `skipTrackFlowUpdate` parameter from `registerTracking`

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -1440,7 +1440,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
     }
 
     /** Register tracker with service */
-    fun registerTracking(trackAndService: TrackAndService, skipTrackFlowUpdate: Boolean = false) {
+    fun registerTracking(trackAndService: TrackAndService) {
         viewModelScope.launchIO {
             val trackingUpdate = trackingCoordinator.registerTracking(trackAndService, mangaId)
             handleTrackingUpdate(trackingUpdate)


### PR DESCRIPTION
🪴 Steward: Remove unused `skipTrackFlowUpdate` parameter from `registerTracking`

💡 What: Removed the `skipTrackFlowUpdate` parameter from the `registerTracking` function in `MangaViewModel.kt`.
🎯 Why: The parameter was detected as unused by Detekt (`UnusedParameter`) and was a default parameter that was never used inside the function body nor passed from any call site. Removing it simplifies the method signature and improves code health.

---
*PR created automatically by Jules for task [12420661749086841901](https://jules.google.com/task/12420661749086841901) started by @nonproto*