### PR TITLE
🎨 Artisan: Add content descriptions to edit/delete buttons in categories

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/AddEditCategoriesScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/AddEditCategoriesScreen.kt
@@ -184,7 +184,8 @@ internal class AddEditCategoriesScreen(
                                         IconButton(onClick = { editCategoryName = category.name }) {
                                             Icon(
                                                 imageVector = Icons.Filled.Edit,
-                                                contentDescription = null,
+                                                contentDescription =
+                                                    stringResource(id = R.string.edit),
                                             )
                                         }
                                         IconButton(
@@ -192,7 +193,8 @@ internal class AddEditCategoriesScreen(
                                         ) {
                                             Icon(
                                                 imageVector = Icons.Filled.Delete,
-                                                contentDescription = null,
+                                                contentDescription =
+                                                    stringResource(id = R.string.delete),
                                             )
                                         }
                                     }


### PR DESCRIPTION
🎨 Artisan: Add content descriptions to edit/delete buttons in categories

💡 What:
Replaced `contentDescription = null` with proper string resources (`R.string.edit`, `R.string.delete`) for the Edit and Delete `IconButton`s in `AddEditCategoriesScreen.kt`.

🎯 Why:
To ensure TalkBack accessibility for visually impaired users. Icon-only buttons without a content description prevent screen readers from accurately conveying the button's purpose, degrading the UX.

Accessibility Impacts:
- TalkBack users can now correctly identify the Edit and Delete buttons for categories.

---
*PR created automatically by Jules for task [18185850817551375024](https://jules.google.com/task/18185850817551375024) started by @nonproto*