### PR TITLE
perf: reduce intermediate list allocations and prevent stream memory leak in mangaview

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/weebdex/dto/ChapterDto.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/weebdex/dto/ChapterDto.kt
@@ -69,11 +69,10 @@ class ChapterDto(
 
         val scanlatorList = mutableListOf(WeebDex.name)
 
-        relationships?.groups
+        relationships
+            ?.groups
             ?.ifEmpty { null } // Converts empty list to null to trigger the Elvis operator
-            ?.forEach { scanlatorList.add(it.name) }
-            ?: scanlatorList.add(Constants.NO_GROUP)
-
+            ?.forEach { scanlatorList.add(it.name) } ?: scanlatorList.add(Constants.NO_GROUP)
 
         return SChapter.create().apply {
             url = "/chapter/$id"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -211,9 +211,10 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                 MangaConstants.CategoriesData(
                     all = allCategories.map { it.toCategoryItem() },
                     current =
-                        allCategories
-                            .filter { it.id != null && it.id in mangaCategorySet }
-                            .map { it.toCategoryItem() },
+                        allCategories.mapNotNull {
+                            if (it.id != null && it.id in mangaCategorySet) it.toCategoryItem()
+                            else null
+                        },
                 )
             }
             .distinctUntilChanged()
@@ -450,8 +451,10 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
 
                             val loggedInTrackerService =
                                 trackManager.services
-                                    .filter { it.value.isLogged() }
-                                    .map { it.value.toTrackServiceItem() }
+                                    .mapNotNull {
+                                        if (it.value.isLogged()) it.value.toTrackServiceItem()
+                                        else null
+                                    }
                                     .toPersistentList()
 
                             val trackCount =
@@ -684,9 +687,9 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                             chapterItems.map { it.chapter.toDbChapter() },
                         )
                         val localDbChapters =
-                            chapterItems
-                                .filter { it.chapter.isLocalSource() }
-                                .map { it.chapter.toDbChapter() }
+                            chapterItems.mapNotNull {
+                                if (it.chapter.isLocalSource()) it.chapter.toDbChapter() else null
+                            }
                         if (localDbChapters.isNotEmpty()) {
                             db.deleteChapters(localDbChapters).executeAsBlocking()
                         }
@@ -781,9 +784,10 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                     if (preferences.removeAfterMarkedAsRead().get()) {
                         // dont delete bookmarked chapters
                         deleteChapters(
-                            updatedChapterList
-                                .filter { it.chapter.canDeleteChapter() }
-                                .map { ChapterItem(chapter = it.chapter) },
+                            updatedChapterList.mapNotNull {
+                                if (it.chapter.canDeleteChapter()) ChapterItem(chapter = it.chapter)
+                                else null
+                            },
                             updatedChapterList.size == mangaDetailScreenState.value.allChapters.size,
                         )
                     }
@@ -1024,8 +1028,9 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
 
             val loggedInServices =
                 trackManager.services
-                    .filter { service -> service.value.isLogged() }
-                    .map { service -> service.value.toTrackServiceItem() }
+                    .mapNotNull { service ->
+                        if (service.value.isLogged()) service.value.toTrackServiceItem() else null
+                    }
                     .toPersistentList()
 
             _mangaDetailScreenState.update {
@@ -1919,7 +1924,9 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                 false -> coverCache.getCoverFile(artwork.cover)
             }
 
-        val type = ImageUtil.findImageType(cover.inputStream()) ?: throw Exception("Not an image")
+        val type =
+            cover.inputStream().use { ImageUtil.findImageType(it) }
+                ?: throw Exception("Not an image")
 
         // Build destination file.
         val fileNameNoExtension =


### PR DESCRIPTION
💡 What:
Replaced `.filter { ... }.map { ... }` chains with `.mapNotNull { ... }` in `MangaViewModel.kt`. Wrapped the `cover.inputStream()` inside a `.use { ... }` block where `ImageUtil.findImageType` is called.

🎯 Why:
To reduce intermediate list allocations for better performance and to prevent a file descriptor memory leak from an unclosed stream.

📊 Impact:
Lower memory footprint during sequence evaluation in `MangaViewModel` and safe stream closure.

🔭 Measurement:
Fewer intermediate array lists instantiated during `allChapters` evaluations and zero risk of leaking a file descriptor during image type checks.

---
*PR created automatically by Jules for task [9370550477404552923](https://jules.google.com/task/9370550477404552923) started by @nonproto*