### PR TITLE
ref: resolve TODO in InvalidHttpSource

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/InvalidHttpSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/InvalidHttpSource.kt
@@ -23,7 +23,7 @@ class InvalidHttpSource : ReducedHttpSource() {
     }
 
     override val headers: Headers
-        get() = TODO("Not yet implemented")
+        get() = Headers.Builder().build()
 
     override fun getChapterUrl(simpleChapter: SimpleChapter): String {
         return ""


### PR DESCRIPTION
**What**: Replaced `TODO("Not yet implemented")` with `Headers.Builder().build()` in `InvalidHttpSource.kt`.
**Why**: This resolves an outdated TODO comment and prevents a potential `NotImplementedError` if the `headers` property is ever accessed, returning empty headers which correctly suits a dummy/invalid source object.
**Impact**: Cleans up technical debt and improves code safety.

---
*PR created automatically by Jules for task [3532018073674223832](https://jules.google.com/task/3532018073674223832) started by @nonproto*