### PR TITLE
fix: add contentDescription for Incognito mode icons

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/bars/SearchOutlineTopAppBar.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/bars/SearchOutlineTopAppBar.kt
@@ -148,7 +148,8 @@ fun SearchOutlineTopAppBar(
                                     Icon(
                                         imageVector = IncognitoCircleIcon,
                                         modifier = Modifier.size(Size.extraLarge),
-                                        contentDescription = null,
+                                        contentDescription =
+                                            stringResource(id = R.string.incognito_mode),
                                     )
                                     Gap(Size.small)
                                 }

--- a/app/src/main/java/org/nekomanga/presentation/components/bars/SearchTopAppBar.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/bars/SearchTopAppBar.kt
@@ -89,7 +89,7 @@ fun SearchTopAppBar(
                         Icon(
                             imageVector = IncognitoCircleIcon,
                             modifier = Modifier.size(Size.extraLarge),
-                            contentDescription = null,
+                            contentDescription = stringResource(id = R.string.incognito_mode),
                         )
                         Gap(Size.small)
                     }

--- a/app/src/main/java/org/nekomanga/presentation/components/bars/TitleTopAppBar.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/bars/TitleTopAppBar.kt
@@ -94,7 +94,7 @@ fun TitleTopAppBar(
                     Icon(
                         imageVector = IncognitoCircleIcon,
                         modifier = Modifier.size(Size.extraLarge),
-                        contentDescription = null,
+                        contentDescription = stringResource(id = R.string.incognito_mode),
                     )
                 }
             }


### PR DESCRIPTION
💡 What: Added contentDescription for the `IncognitoCircleIcon` across `SearchOutlineTopAppBar.kt`, `SearchTopAppBar.kt`, and `TitleTopAppBar.kt`.
🎯 Why: To fix TalkBack accessibility for screen reader users by replacing `null` with a localized string resource.
🎨 Visual/Accessibility Impacts: No visual change. Screen readers will now announce the incognito icon as "Incognito mode".

---
*PR created automatically by Jules for task [9044348467627843268](https://jules.google.com/task/9044348467627843268) started by @nonproto*