### PR TITLE
perf: prevent N+1 queries when restoring manga categories

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupRestorer.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.data.backup.models.BackupHistory
 import eu.kanade.tachiyomi.data.backup.models.BackupManga
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
+import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.database.models.MergeMangaImpl
@@ -146,9 +147,11 @@ class BackupRestorer(val context: Context, val notifier: BackupNotifier) {
                 val itemsWithCovers = mutableListOf<RestorableItem>()
                 try {
                     db.inTransaction {
+                        // [OPTIMIZATION] Fetch dbCategories once per chunk instead of per manga
+                        val dbCategories = db.getCategories().executeAsBlocking()
                         preparedItems.forEach { item ->
                             val existingManga = dbMangaMap[MdUtil.getMangaUUID(item.manga.url)]
-                            writeMangaToDb(item, existingManga)
+                            writeMangaToDb(item, existingManga, dbCategories)
 
                             // Collect items that need covers, but don't process yet
                             if (!item.manga.user_cover.isNullOrBlank()) {
@@ -254,7 +257,11 @@ class BackupRestorer(val context: Context, val notifier: BackupNotifier) {
     }
 
     /** Writes data to DB. Must be called inside a transaction */
-    private fun writeMangaToDb(item: RestorableItem, existingDbManga: Manga?) {
+    private fun writeMangaToDb(
+        item: RestorableItem,
+        existingDbManga: Manga?,
+        dbCategories: List<Category>,
+    ) {
         try {
             val manga = item.manga
 
@@ -269,7 +276,12 @@ class BackupRestorer(val context: Context, val notifier: BackupNotifier) {
             // Restore related data using helper (Blocking calls are fine inside transaction)
             restoreHelper.restoreChaptersForMangaOffline(manga, item.chapters)
             restoreHelper.restoreMergeMangaForManga(manga, item.mergeMangaList)
-            restoreHelper.restoreCategoriesForManga(manga, item.categories, item.backupCategories)
+            restoreHelper.restoreCategoriesForManga(
+                manga,
+                item.categories,
+                item.backupCategories,
+                dbCategories,
+            )
             restoreHelper.restoreHistoryForManga(item.history)
             restoreHelper.restoreTrackForManga(manga, item.tracks)
         } catch (e: Exception) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/RestoreHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/RestoreHelper.kt
@@ -7,6 +7,7 @@ import androidx.core.content.ContextCompat
 import eu.kanade.tachiyomi.data.backup.models.BackupCategory
 import eu.kanade.tachiyomi.data.backup.models.BackupHistory
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
+import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.History
 import eu.kanade.tachiyomi.data.database.models.Manga
@@ -259,8 +260,8 @@ class RestoreHelper(val context: Context) {
         manga: Manga,
         categories: List<Int>,
         backupCategories: List<BackupCategory>,
+        dbCategories: List<Category> = db.getCategories().executeAsBlocking(),
     ) {
-        val dbCategories = db.getCategories().executeAsBlocking()
         val mangaCategoriesToUpdate = ArrayList<MangaCategory>(categories.size)
         categories.forEach { backupCategoryOrder ->
             backupCategories


### PR DESCRIPTION
💡 What: Pre-fetched database categories once per batch chunk during backup restoration and passed them into `restoreCategoriesForManga` to avoid redundant database queries.

🎯 Why: Previously, `RestoreHelper.restoreCategoriesForManga` queried the database for all categories (`db.getCategories().executeAsBlocking()`) inside the `forEach` loop iterating over the restored mangas inside `BackupRestorer.kt`. This caused an N+1 query problem, fetching the exact same categories over and over again, wasting CPU time and increasing I/O overhead.

📊 Impact: Reduces category database read queries during backup restore from N (number of restored manga) down to 1 query per batch chunk (10 manga). This results in slightly faster, more efficient DB writes without blocking loops with unneeded I/O.

🔬 Measurement: Profile the DB queries during restore to confirm the category list is queried once per chunk rather than once per manga.

---
*PR created automatically by Jules for task [12165294874338787257](https://jules.google.com/task/12165294874338787257) started by @nonproto*