### PR TITLE
test: add coverage for Unread action in MarkChapterUseCase

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -178,6 +178,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotest.assertions)
     testImplementation(libs.mockk) { exclude(group = "junit", module = "junit") }
+    testImplementation(kotlinx.coroutines.test)
 }
 
 tasks.withType<Test> { useJUnit() }

--- a/app/src/test/java/org/nekomanga/usecases/chapters/MarkChapterUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/chapters/MarkChapterUseCaseTest.kt
@@ -1,0 +1,90 @@
+package org.nekomanga.usecases.chapters
+
+import com.pushtorefresh.storio.sqlite.operations.put.PreparedPutCollectionOfObjects
+import eu.kanade.tachiyomi.data.database.DatabaseHelper
+import eu.kanade.tachiyomi.data.database.models.Chapter
+import eu.kanade.tachiyomi.util.system.executeOnIO
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.nekomanga.domain.chapter.ChapterItem
+import org.nekomanga.domain.chapter.ChapterMarkActions
+import org.nekomanga.domain.chapter.SimpleChapter
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MarkChapterUseCaseTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var db: DatabaseHelper
+    private lateinit var markChapterUseCase: MarkChapterUseCase
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        db = mockk()
+        markChapterUseCase = MarkChapterUseCase(db)
+
+        mockkStatic("eu.kanade.tachiyomi.util.system.DatabaseExtensionsKt")
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkStatic("eu.kanade.tachiyomi.util.system.DatabaseExtensionsKt")
+    }
+
+    @Test
+    fun `given unread action with specific parameters when marking chapters then chapters are updated correctly`() =
+        runTest {
+            // Arrange
+            val expectedLastRead = 5
+            val expectedPagesLeft = 10
+            val markAction =
+                ChapterMarkActions.Unread(
+                    lastRead = expectedLastRead,
+                    pagesLeft = expectedPagesLeft,
+                )
+
+            val simpleChapter =
+                SimpleChapter.create()
+                    .copy(id = 1L, mangaId = 100L, read = true, lastPageRead = 20, pagesLeft = 0)
+            val chapterItem = ChapterItem(chapter = simpleChapter)
+
+            val mockPreparedPut = mockk<PreparedPutCollectionOfObjects<Chapter>>()
+            val capturedChapters = slot<List<Chapter>>()
+
+            every { db.updateChaptersProgress(capture(capturedChapters)) } returns mockPreparedPut
+            coEvery { mockPreparedPut.executeOnIO() } returns mockk()
+
+            // Act
+            markChapterUseCase(markAction, listOf(chapterItem))
+
+            // Assert
+            coVerify(exactly = 1) { db.updateChaptersProgress(any()) }
+            coVerify(exactly = 1) { mockPreparedPut.executeOnIO() }
+
+            val updatedChapters = capturedChapters.captured
+            assertEquals(1, updatedChapters.size)
+
+            val updatedChapter = updatedChapters.first()
+            assertEquals(1L, updatedChapter.id)
+            assertFalse("Chapter should be marked as unread", updatedChapter.read)
+            assertEquals(expectedLastRead, updatedChapter.last_page_read)
+            assertEquals(expectedPagesLeft, updatedChapter.pages_left)
+        }
+}

--- a/gradle/kotlinx.versions.toml
+++ b/gradle/kotlinx.versions.toml
@@ -8,6 +8,7 @@ stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlinV
 reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinVersion" }
 gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinVersion" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutinesVersion" }
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesVersion" }
 coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutinesVersion" }
 
 serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serializationVersion" }


### PR DESCRIPTION
💡 What: Added unit test `MarkChapterUseCaseTest` for the `ChapterMarkActions.Unread` edge case, verifying that the pages left and last read parameters are passed correctly to the `updateChaptersProgress` database mapped chapters.

🎯 Why: Ensure the correct progress parameters are passed down through `MarkChapterUseCase` to the database, preventing regressions when managing Unread chapter status.

---
*PR created automatically by Jules for task [1030392476708131236](https://jules.google.com/task/1030392476708131236) started by @nonproto*