### PR TITLE
perf: use map lookup in restoreChaptersForMangaOffline

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/RestoreHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/RestoreHelper.kt
@@ -390,9 +390,10 @@ class RestoreHelper(val context: Context) {
 
     internal fun restoreChaptersForMangaOffline(manga: Manga, chapters: List<Chapter>) {
         val dbChapters = db.getChapters(manga).executeAsBlocking()
+        val dbChaptersByUrl = dbChapters.associateBy { it.url }
 
         chapters.forEach { chapter ->
-            val dbChapter = dbChapters.find { it.url == chapter.url }
+            val dbChapter = dbChaptersByUrl[chapter.url]
 
             if (dbChapter != null) {
                 chapter.id = dbChapter.id

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -748,9 +748,10 @@ class LibraryViewModel() : ViewModel() {
 
             val mangaIds = mangaList.map { it.mangaId }
             val dbMangas = db.getMangas(mangaIds).executeOnIO()
-            val mangaCategories = dbMangas.flatMap { dbManga ->
-                dbCategories.map { MangaCategory.create(dbManga, it) }
-            }
+            val mangaCategories =
+                dbMangas.flatMap { dbManga ->
+                    dbCategories.map { MangaCategory.create(dbManga, it) }
+                }
             db.setMangaCategories(mangaCategories, dbMangas)
 
             clearSelectedManga()
@@ -1033,9 +1034,7 @@ class LibraryViewModel() : ViewModel() {
             val mangaIds = currentSelected.map { it.displayManga.mangaId }
             val dbMangas = db.getMangas(mangaIds).executeOnIO()
 
-            dbMangas.forEach { dbManga ->
-                dbManga.favorite = false
-            }
+            dbMangas.forEach { dbManga -> dbManga.favorite = false }
 
             db.insertMangaList(dbMangas).executeOnIO()
 


### PR DESCRIPTION
💡 What: Replaced an O(N^2) list search operation with an O(N) map lookup inside `restoreChaptersForMangaOffline`.

🎯 Why: In `RestoreHelper.kt`, the inner loop iterates over a list of chapters and searches for a matching chapter in the `dbChapters` list using `.find { it.url == chapter.url }`. For mangas with hundreds or thousands of chapters, this causes a severe CPU bottleneck due to quadratic O(N*M) time complexity during restores. Pre-computing a lookup map speeds this up to O(N+M) complexity.

📊 Impact: Significantly faster and more CPU-efficient backup restorations for mangas with large numbers of chapters.

🔬 Measurement: Profile the CPU usage or measure execution time of `restoreChaptersForMangaOffline` during a full restore with a large library. The time spent in `List.find` should disappear.

---
*PR created automatically by Jules for task [11990438898827259053](https://jules.google.com/task/11990438898827259053) started by @nonproto*