### PR TITLE
perf: reduce intermediate list allocations in FeedRepository

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedRepository.kt
@@ -195,8 +195,11 @@ class FeedRepository(
                             entry to feedMangaFiltered
                         }
 
+                    // ⚡ BOLT OPTIMIZATION: Replaced .filter {}.map {} chain with .mapNotNull {}
                     val mangaIdsToFetch =
-                        processedEntries.filter { it.second.isEmpty() }.map { it.first.key }
+                        processedEntries.mapNotNull {
+                            if (it.second.isEmpty()) it.first.key else null
+                        }
 
                     val mangasMap =
                         if (mangaIdsToFetch.isNotEmpty()) {


### PR DESCRIPTION
💡 **What:**
Replaced the `.filter { it.second.isEmpty() }.map { it.first.key }` chain with a single `.mapNotNull { if (it.second.isEmpty()) it.first.key else null }` call in `FeedRepository.kt`.

🎯 **Why:**
Using chained `filter` and `map` operations on collections creates intermediate lists that must be allocated and subsequently garbage collected. By combining these into a single `mapNotNull` pass, we eliminate the intermediate allocation, reducing memory pressure and GC overhead during potentially frequent UI state updates.

📊 **Expected Measurement of Impact:**
- **Speed Gain:** Slightly faster processing of the updates feed list due to reduced iterations (O(N) instead of O(2N)).
- **Memory Gain:** Elimination of one intermediate list allocation per function call.

---
*PR created automatically by Jules for task [4765953115158419252](https://jules.google.com/task/4765953115158419252) started by @nonproto*