### PR TITLE
fix: [leak fix] resolve potential stream resource leak in WebtoonPageHolder

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -235,9 +235,9 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
             scope.launch(Dispatchers.IO) {
                 try {
                     val stream = streamFn().source().buffer()
-                    openStream = process(stream)
-
+                    openStream = stream
                     val isAnimated = ImageUtil.isAnimatedAndSupported(stream)
+                    openStream = process(stream)
 
                     withContext(Dispatchers.Main) {
                         openStream?.let {


### PR DESCRIPTION
💡 What:
Assigned the created `BufferedSource` directly to `openStream` immediately after its instantiation in `WebtoonPageHolder`.

🎯 Why:
This prevents a potential resource leak if subsequent operations (e.g., `ImageUtil.isAnimatedAndSupported(stream)` or `process(stream)`) throw an exception. The finally block can now safely and reliably close `openStream` in error scenarios.

📊 Impact:
Improved stability and memory management when decoding potentially corrupted or unsupported images in Webtoon viewer.

---
*PR created automatically by Jules for task [4566703769940345755](https://jules.google.com/task/4566703769940345755) started by @nonproto*