### PR TITLE
fix: check animated status after stream processing

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -235,9 +235,10 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
             scope.launch(Dispatchers.IO) {
                 try {
                     val stream = streamFn().source().buffer()
+                    openStream = stream
                     openStream = process(stream)
 
-                    val isAnimated = ImageUtil.isAnimatedAndSupported(stream)
+                    val isAnimated = ImageUtil.isAnimatedAndSupported(checkNotNull(openStream))
 
                     withContext(Dispatchers.Main) {
                         openStream?.let {


### PR DESCRIPTION
💡 What:
Updated `WebtoonPageHolder` to process the stream first and then check if it's animated on the processed stream, using `checkNotNull`.

🎯 Why:
This prevents incorrectly flagging a processed (and now static) image as animated, ensuring the correct image loading path is chosen by `frame.setImage`.

📊 Impact:
Fixes potential image loading errors for wide images that are split and processed.

---
*PR created automatically by Jules for task [4566703769940345755](https://jules.google.com/task/4566703769940345755) started by @nonproto*