### PR TITLE
perf: defer MangaCoverMetadata loading to background thread post-TTID

### DIFF
--- a/app/src/main/java/org/nekomanga/App.kt
+++ b/app/src/main/java/org/nekomanga/App.kt
@@ -38,8 +38,10 @@ import eu.kanade.tachiyomi.util.manga.MangaCoverMetadata
 import eu.kanade.tachiyomi.util.system.AuthenticatorUtil
 import eu.kanade.tachiyomi.util.system.notification
 import java.security.Security
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import org.conscrypt.Conscrypt
 import org.nekomanga.core.network.NetworkPreferences
 import org.nekomanga.core.security.SecurityPreferences
@@ -105,7 +107,10 @@ open class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.F
 
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
 
-        MangaCoverMetadata.load()
+        ProcessLifecycleOwner.get().lifecycleScope.launch(Dispatchers.Default) {
+            MangaCoverMetadata.load()
+        }
+
         preferences
             .nightMode()
             .changes()


### PR DESCRIPTION
💡 What:
Moved `MangaCoverMetadata.load()` from the main thread during `Application.onCreate()` to a background coroutine using `ProcessLifecycleOwner.get().lifecycleScope.launch(Dispatchers.Default)`.

🎯 Why:
To improve Time to Initial Display (TTID) during cold starts. `MangaCoverMetadata.load()` involves disk I/O (deleting and reading preferences) and string parsing. Running this synchronously blocks the main thread, delaying the initial UI frame. By deferring it, the app can render the first frame significantly faster.

🏗️ Architecture:
Utilized Jetpack Lifecycle's `ProcessLifecycleOwner` to launch a coroutine on `Dispatchers.Default` immediately after the observer is attached. This avoids blocking without requiring a complex App Startup initializer for a single method call.

📊 Impact:
Faster Time to Initial Display (TTID). The blocking disk reads and preference manipulations have been successfully offloaded.

---
*PR created automatically by Jules for task [16883621845787694128](https://jules.google.com/task/16883621845787694128) started by @nonproto*