### PR TITLE
chore: remove gross mutable side-effects from Downloader state flows

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -626,8 +626,8 @@ class Downloader(
     }
 
     private inline fun removeFromQueueIf(predicate: (Download) -> Boolean) {
-        val removed =
-            _queueState.getAndUpdate { queue -> queue.filterNot(predicate) }.filter(predicate)
+        val queueBeforeUpdate = _queueState.getAndUpdate { queue -> queue.filterNot(predicate) }
+        val removed = queueBeforeUpdate.filter(predicate)
 
         if (removed.isNotEmpty()) {
             store.removeAll(removed)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -626,17 +626,20 @@ class Downloader(
     }
 
     private inline fun removeFromQueueIf(predicate: (Download) -> Boolean) {
-        val downloads = _queueState.value.filter { predicate(it) }
-        store.removeAll(downloads)
-        downloads.forEach { download ->
-            if (
-                download.status == Download.State.DOWNLOADING ||
-                    download.status == Download.State.QUEUE
-            ) {
-                download.status = Download.State.NOT_DOWNLOADED
+        val removed =
+            _queueState.getAndUpdate { queue -> queue.filterNot(predicate) }.filter(predicate)
+
+        if (removed.isNotEmpty()) {
+            store.removeAll(removed)
+            removed.forEach { download ->
+                if (
+                    download.status == Download.State.DOWNLOADING ||
+                        download.status == Download.State.QUEUE
+                ) {
+                    download.status = Download.State.NOT_DOWNLOADED
+                }
             }
         }
-        _queueState.update { queue -> queue - downloads.toSet() }
     }
 
     fun removeFromQueue(chapters: List<Chapter>) {
@@ -649,7 +652,9 @@ class Downloader(
     }
 
     private fun clearQueueState() {
-        _queueState.value.forEach { download ->
+        val downloadsToClear = _queueState.getAndUpdate { emptyList() }
+
+        downloadsToClear.forEach { download ->
             if (
                 download.status == Download.State.DOWNLOADING ||
                     download.status == Download.State.QUEUE
@@ -658,7 +663,6 @@ class Downloader(
             }
         }
         store.clear()
-        _queueState.update { emptyList() }
     }
 
     fun updateQueue(downloads: List<Download>) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -626,8 +626,13 @@ class Downloader(
     }
 
     private inline fun removeFromQueueIf(predicate: (Download) -> Boolean) {
-        val queueBeforeUpdate = _queueState.getAndUpdate { queue -> queue.filterNot(predicate) }
-        val removed = queueBeforeUpdate.filter(predicate)
+        val removed = mutableListOf<Download>()
+        _queueState.update { queue ->
+            val (toRemove, toKeep) = queue.partition(predicate)
+            removed.clear()
+            removed.addAll(toRemove)
+            toKeep
+        }
 
         if (removed.isNotEmpty()) {
             store.removeAll(removed)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -610,41 +610,33 @@ class Downloader(
     }
 
     private fun addAllToQueue(downloads: List<Download>) {
-        _queueState.update {
-            // TODO make this not gross mutable
-            downloads.forEach { download -> download.status = Download.State.QUEUE }
-            store.addAll(downloads)
-            it + downloads
-        }
+        downloads.forEach { download -> download.status = Download.State.QUEUE }
+        store.addAll(downloads)
+        _queueState.update { it + downloads }
     }
 
     private fun removeFromQueue(download: Download) {
-        _queueState.update {
-            store.remove(download)
+        store.remove(download)
+        if (
+            download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE
+        ) {
+            download.status = Download.State.NOT_DOWNLOADED
+        }
+        _queueState.update { it - download }
+    }
+
+    private inline fun removeFromQueueIf(predicate: (Download) -> Boolean) {
+        val downloads = _queueState.value.filter { predicate(it) }
+        store.removeAll(downloads)
+        downloads.forEach { download ->
             if (
                 download.status == Download.State.DOWNLOADING ||
                     download.status == Download.State.QUEUE
             ) {
                 download.status = Download.State.NOT_DOWNLOADED
             }
-            it - download
         }
-    }
-
-    private inline fun removeFromQueueIf(predicate: (Download) -> Boolean) {
-        _queueState.update { queue ->
-            val downloads = queue.filter { predicate(it) }
-            store.removeAll(downloads)
-            downloads.forEach { download ->
-                if (
-                    download.status == Download.State.DOWNLOADING ||
-                        download.status == Download.State.QUEUE
-                ) {
-                    download.status = Download.State.NOT_DOWNLOADED
-                }
-            }
-            queue - downloads
-        }
+        _queueState.update { queue -> queue - downloads.toSet() }
     }
 
     fun removeFromQueue(chapters: List<Chapter>) {
@@ -657,18 +649,16 @@ class Downloader(
     }
 
     private fun clearQueueState() {
-        _queueState.update {
-            it.forEach { download ->
-                if (
-                    download.status == Download.State.DOWNLOADING ||
-                        download.status == Download.State.QUEUE
-                ) {
-                    download.status = Download.State.NOT_DOWNLOADED
-                }
+        _queueState.value.forEach { download ->
+            if (
+                download.status == Download.State.DOWNLOADING ||
+                    download.status == Download.State.QUEUE
+            ) {
+                download.status = Download.State.NOT_DOWNLOADED
             }
-            store.clear()
-            emptyList()
         }
+        store.clear()
+        _queueState.update { emptyList() }
     }
 
     fun updateQueue(downloads: List<Download>) {


### PR DESCRIPTION
**What:** Refactored `addAllToQueue`, `removeFromQueue`, `removeFromQueueIf`, and `clearQueueState` in `Downloader.kt` to extract side-effect logic (such as changing `download.status` and saving to `store`) out of `_queueState.update { ... }`.
**Why:** The `update` function on `MutableStateFlow` utilizes a Compare-And-Swap (CAS) loop underneath. If concurrent modifications to the flow occur, the lambda block will execute multiple times until the swap succeeds. Side-effects within this block could cause items to be improperly mutated multiple times and file I/O `store` operations to fire redundantly.
**Impact:** Resolved a pending TODO regarding "gross mutable" logic, guaranteeing predictable and performant atomic state updates for the downloading queue. Tests, formatting, and linting successfully passed.

---
*PR created automatically by Jules for task [789928660105731719](https://jules.google.com/task/789928660105731719) started by @nonproto*