### PR TITLE
fix: [Reader] correctly detect animated images before processing stream

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -230,15 +230,14 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
         unsubscribeReadImageHeader()
         val streamFn = page?.stream ?: return
 
-        var openStream: BufferedSource? = null
         readImageHeaderSubscription =
             scope.launch(Dispatchers.IO) {
+                var openStream: BufferedSource? = null
                 try {
                     val stream = streamFn().source().buffer()
                     openStream = stream
+                    val isAnimated = ImageUtil.isAnimatedAndSupported(stream)
                     openStream = process(stream)
-
-                    val isAnimated = ImageUtil.isAnimatedAndSupported(checkNotNull(openStream))
 
                     withContext(Dispatchers.Main) {
                         openStream?.let {


### PR DESCRIPTION
💡 What:
Moved `ImageUtil.isAnimatedAndSupported(stream)` to run before `process(stream)` and scoped `openStream` inside the coroutine block.

🎯 Why:
The `process(stream)` function may consume the stream if it decides to split the page. If `ImageUtil.isAnimatedAndSupported` is called after this processing, it could read from an empty/consumed stream and return an incorrect result. Limiting the scope of `openStream` to inside the launch block is cleaner and avoids keeping references unnecessarily.

📊 Impact:
Webtoon reader now properly correctly detects animated GIFs even when pages might be split. Cleaned up variable scoping.

---
*PR created automatically by Jules for task [7526130827238589033](https://jules.google.com/task/7526130827238589033) started by @nonproto*