### PR TITLE
ref: extract track service login into LoginToTrackServiceUseCase

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
@@ -157,7 +157,7 @@ class AppModule(val app: Application) : InjektModule {
 
         addSingleton(MangaUseCases())
 
-        addSingleton(org.nekomanga.usecases.tracking.TrackUseCases())
+        addSingleton(TrackUseCases())
 
         addSingleton(FeedRepository())
 

--- a/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
@@ -157,6 +157,8 @@ class AppModule(val app: Application) : InjektModule {
 
         addSingleton(MangaUseCases())
 
+        addSingleton(org.nekomanga.usecases.tracking.TrackUseCases())
+
         addSingleton(FeedRepository())
 
         addSingleton(AppSnackbarManager())

--- a/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
@@ -157,7 +157,7 @@ class AppModule(val app: Application) : InjektModule {
 
         addSingleton(MangaUseCases())
 
-        addSingleton(TrackUseCases())
+        addSingleton(org.nekomanga.usecases.tracking.TrackUseCases())
 
         addSingleton(FeedRepository())
 

--- a/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
@@ -56,6 +56,7 @@ import org.nekomanga.domain.storage.StoragePreferences
 import org.nekomanga.domain.track.store.DelayedTrackingStore
 import org.nekomanga.usecases.chapters.ChapterUseCases
 import org.nekomanga.usecases.manga.MangaUseCases
+import org.nekomanga.usecases.tracking.TrackUseCases
 import tachiyomi.core.preference.AndroidPreferenceStore
 import tachiyomi.core.preference.PreferenceStore
 import tachiyomi.core.util.storage.AndroidStorageFolderProvider
@@ -157,7 +158,7 @@ class AppModule(val app: Application) : InjektModule {
 
         addSingleton(MangaUseCases())
 
-        addSingleton(org.nekomanga.usecases.tracking.TrackUseCases())
+        addSingleton(TrackUseCases())
 
         addSingleton(FeedRepository())
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/TrackingSettingsViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/TrackingSettingsViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import org.nekomanga.domain.track.TrackServiceItem
 import org.nekomanga.domain.track.toTrackServiceItem
+import org.nekomanga.usecases.tracking.TrackUseCases
 import uy.kohesive.injekt.injectLazy
 
 class TrackingSettingsViewModel : ViewModel() {
@@ -26,6 +27,8 @@ class TrackingSettingsViewModel : ViewModel() {
     val preferences: PreferencesHelper by injectLazy()
 
     private val trackManager: TrackManager by injectLazy()
+
+    private val trackUseCases: TrackUseCases by injectLazy()
 
     private val _loginEvent = MutableSharedFlow<MergeLoginEvent>()
     val loginEvent = _loginEvent.asSharedFlow()
@@ -103,7 +106,7 @@ class TrackingSettingsViewModel : ViewModel() {
     fun login(trackServiceItem: TrackServiceItem, username: String, password: String) {
         viewModelScope.launchIO {
             val loginSuccessful =
-                trackManager.getService(trackServiceItem.id)?.login(username, password) ?: false
+                trackUseCases.loginToTrackService(trackServiceItem, username, password)
 
             when (loginSuccessful) {
                 true -> {

--- a/app/src/main/java/org/nekomanga/usecases/tracking/LoginToTrackService.kt
+++ b/app/src/main/java/org/nekomanga/usecases/tracking/LoginToTrackService.kt
@@ -1,0 +1,14 @@
+package org.nekomanga.usecases.tracking
+
+import eu.kanade.tachiyomi.data.track.TrackManager
+import org.nekomanga.domain.track.TrackServiceItem
+
+class LoginToTrackService(private val trackManager: TrackManager) {
+    suspend operator fun invoke(
+        trackServiceItem: TrackServiceItem,
+        username: String,
+        password: String,
+    ): Boolean {
+        return trackManager.getService(trackServiceItem.id)?.login(username, password) ?: false
+    }
+}

--- a/app/src/main/java/org/nekomanga/usecases/tracking/TrackUseCases.kt
+++ b/app/src/main/java/org/nekomanga/usecases/tracking/TrackUseCases.kt
@@ -1,0 +1,9 @@
+package org.nekomanga.usecases.tracking
+
+import eu.kanade.tachiyomi.data.track.TrackManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class TrackUseCases(trackManager: TrackManager = Injekt.get()) {
+    val loginToTrackService = LoginToTrackService(trackManager)
+}

--- a/app/src/test/java/org/nekomanga/usecases/tracking/LoginToTrackServiceTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/tracking/LoginToTrackServiceTest.kt
@@ -50,7 +50,7 @@ class LoginToTrackServiceTest {
 
         val result = loginToTrackService(trackServiceItem, "user", "pass")
 
-        assertTrue(result)
+        assertEquals(true, result)
     }
 
     @Test
@@ -59,7 +59,7 @@ class LoginToTrackServiceTest {
 
         val result = loginToTrackService(trackServiceItem, "user", "pass")
 
-        assertFalse(result)
+        assertEquals(false, result)
     }
 
     @Test
@@ -68,6 +68,6 @@ class LoginToTrackServiceTest {
 
         val result = loginToTrackService(trackServiceItem, "user", "pass")
 
-        assertFalse(result)
+        assertEquals(false, result)
     }
 }

--- a/app/src/test/java/org/nekomanga/usecases/tracking/LoginToTrackServiceTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/tracking/LoginToTrackServiceTest.kt
@@ -6,7 +6,8 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.nekomanga.domain.track.TrackServiceItem
@@ -50,7 +51,7 @@ class LoginToTrackServiceTest {
 
         val result = loginToTrackService(trackServiceItem, "user", "pass")
 
-        assertEquals(true, result)
+        assertTrue(result)
     }
 
     @Test
@@ -59,7 +60,7 @@ class LoginToTrackServiceTest {
 
         val result = loginToTrackService(trackServiceItem, "user", "pass")
 
-        assertEquals(false, result)
+        assertFalse(result)
     }
 
     @Test
@@ -68,6 +69,6 @@ class LoginToTrackServiceTest {
 
         val result = loginToTrackService(trackServiceItem, "user", "pass")
 
-        assertEquals(false, result)
+        assertFalse(result)
     }
 }

--- a/app/src/test/java/org/nekomanga/usecases/tracking/LoginToTrackServiceTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/tracking/LoginToTrackServiceTest.kt
@@ -50,7 +50,7 @@ class LoginToTrackServiceTest {
 
         val result = loginToTrackService(trackServiceItem, "user", "pass")
 
-        assertEquals(true, result)
+        assertTrue(result)
     }
 
     @Test
@@ -59,7 +59,7 @@ class LoginToTrackServiceTest {
 
         val result = loginToTrackService(trackServiceItem, "user", "pass")
 
-        assertEquals(false, result)
+        assertFalse(result)
     }
 
     @Test
@@ -68,6 +68,6 @@ class LoginToTrackServiceTest {
 
         val result = loginToTrackService(trackServiceItem, "user", "pass")
 
-        assertEquals(false, result)
+        assertFalse(result)
     }
 }

--- a/app/src/test/java/org/nekomanga/usecases/tracking/LoginToTrackServiceTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/tracking/LoginToTrackServiceTest.kt
@@ -1,0 +1,73 @@
+package org.nekomanga.usecases.tracking
+
+import eu.kanade.tachiyomi.data.track.TrackManager
+import eu.kanade.tachiyomi.data.track.TrackService
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.nekomanga.domain.track.TrackServiceItem
+
+class LoginToTrackServiceTest {
+
+    private lateinit var loginToTrackService: LoginToTrackService
+    private lateinit var trackManager: TrackManager
+    private lateinit var trackService: TrackService
+    private lateinit var trackServiceItem: TrackServiceItem
+
+    @Before
+    fun setUp() {
+        trackManager = mockk()
+        trackService = mockk()
+        loginToTrackService = LoginToTrackService(trackManager)
+
+        trackServiceItem =
+            TrackServiceItem(
+                id = 1,
+                nameRes = 1,
+                logoRes = 1,
+                logoColor = 1,
+                statusList = persistentListOf(1, 2, 3),
+                supportsReadingDates = false,
+                canRemoveFromService = false,
+                isAutoAddTracker = false,
+                isMdList = false,
+                status = { "status" },
+                displayScore = { "score" },
+                scoreList = persistentListOf("1", "2"),
+                indexToScore = { 1f },
+            )
+
+        coEvery { trackManager.getService(1) } returns trackService
+    }
+
+    @Test
+    fun `when login is successful then return true`() = runTest {
+        coEvery { trackService.login("user", "pass") } returns true
+
+        val result = loginToTrackService(trackServiceItem, "user", "pass")
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `when login fails then return false`() = runTest {
+        coEvery { trackService.login("user", "pass") } returns false
+
+        val result = loginToTrackService(trackServiceItem, "user", "pass")
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `when track service is null then return false`() = runTest {
+        coEvery { trackManager.getService(1) } returns null
+
+        val result = loginToTrackService(trackServiceItem, "user", "pass")
+
+        assertEquals(false, result)
+    }
+}


### PR DESCRIPTION
Extracts TrackService login out of TrackingSettingsViewModel into `LoginToTrackService` Use Case as part of The Distiller guidelines. Evaluated success case, failure case, and missing service case via rigorous Unit Tests. Registered via `TrackUseCases` in `AppModule`. Code formatted via ktfmt.

---
*PR created automatically by Jules for task [3976901772203913078](https://jules.google.com/task/3976901772203913078) started by @nonproto*