### PR TITLE
ref: remove side-effects from Downloader state updates

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.flow.update


### PR DESCRIPTION
**What:**
Removed side effects (updating properties, modifying the underlying storage) from `_queueState.update { ... }` blocks inside `Downloader.kt` and removed an old TODO comment.

**Why:**
`MutableStateFlow.update` uses a Compare-and-Set (CAS) loop under the hood. If there's contention, the lambda can be executed multiple times. Placing side-effects (like database calls, or modifying properties of other objects) inside the closure is an anti-pattern. By pulling these modifications out to happen strictly before or after the immutable state computation, we guarantee safety.

**How it improves readability:**
The logic inside the state flow update is now pure and isolated to simply returning the new state of the list. Also removes a stale TODO.

---
*PR created automatically by Jules for task [9711432244572655758](https://jules.google.com/task/9711432244572655758) started by @nonproto*