### PR TITLE
chore: refactor preference observers in BrowseViewModel

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/similar/SimilarViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/similar/SimilarViewModel.kt
@@ -88,7 +88,9 @@ class SimilarViewModel(val mangaUUID: String) : ViewModel() {
             .browseAsList()
             .changes()
             .distinctUntilChanged()
-.onEach { isList -> _similarScreenState.update { state -> state.copy(isList = isList) } }
+            .onEach { isList ->
+                _similarScreenState.update { state -> state.copy(isList = isList) }
+            }
             .launchIn(viewModelScope)
 
         preferences

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseViewModel.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
@@ -191,33 +190,40 @@ class BrowseViewModel() : ViewModel() {
                 )
             }
         }
-        viewModelScope.launch {
-            preferences.browseAsList().changes().collectLatest {
-                _browseScreenState.update { state -> state.copy(isList = it) }
-            }
-        }
+        preferences
+            .browseAsList()
+            .changes()
+            .distinctUntilChanged()
+            .onEach { _browseScreenState.update { state -> state.copy(isList = it) } }
+            .launchIn(viewModelScope)
 
-        viewModelScope.launchIO {
-            preferences.useVividColorHeaders().changes().distinctUntilChanged().collectLatest {
-                enabled ->
+        preferences
+            .useVividColorHeaders()
+            .changes()
+            .distinctUntilChanged()
+            .onEach { enabled ->
                 _browseScreenState.update { it.copy(useVividColorHeaders = enabled) }
             }
-        }
+            .launchIn(viewModelScope)
 
-        viewModelScope.launch {
-            securityPreferences.incognitoMode().changes().collectLatest {
-                _browseScreenState.update { state -> state.copy(incognitoMode = it) }
-            }
-        }
+        securityPreferences
+            .incognitoMode()
+            .changes()
+            .distinctUntilChanged()
+            .onEach { _browseScreenState.update { state -> state.copy(incognitoMode = it) } }
+            .launchIn(viewModelScope)
 
-        viewModelScope.launch {
-            browseRepository.loginHelper.isLoggedInFlow().collectLatest {
-                _browseScreenState.update { state -> state.copy(isLoggedIn = it) }
-            }
-        }
+        browseRepository.loginHelper
+            .isLoggedInFlow()
+            .distinctUntilChanged()
+            .onEach { _browseScreenState.update { state -> state.copy(isLoggedIn = it) } }
+            .launchIn(viewModelScope)
 
-        viewModelScope.launch {
-            preferences.browseDisplayMode().changes().collectLatest { visibility ->
+        preferences
+            .browseDisplayMode()
+            .changes()
+            .distinctUntilChanged()
+            .onEach { visibility ->
                 _browseScreenState.update { it.copy(libraryEntryVisibility = visibility) }
                 viewModelScope.launch {
                     _browseScreenState.update {
@@ -248,7 +254,7 @@ class BrowseViewModel() : ViewModel() {
                     }
                 }
             }
-        }
+            .launchIn(viewModelScope)
     }
 
     fun loadNextItems() {


### PR DESCRIPTION
💡 What:
Updated preference state flows in `BrowseViewModel.kt` to uniformly utilize `.distinctUntilChanged()`, `.onEach {}`, and `.launchIn(viewModelScope)`.

🎯 Why:
To prevent redundant UI recompositions caused by identical state values being emitted, improving the efficiency of application reactivity. Additionally, adopting a single uniform reactive flow pattern is considered best practice.

---
*PR created automatically by Jules for task [162343953216009558](https://jules.google.com/task/162343953216009558) started by @nonproto*