### PR TITLE
fix: prevent CursorWindow crash on libraryQuery for large mangas

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
@@ -21,26 +21,36 @@ val libraryQuery =
         LEFT JOIN (
             SELECT ${Chapter.COL_MANGA_ID},
                 GROUP_CONCAT(
-                    IFNULL(${Chapter.TABLE}.${Chapter.COL_SCANLATOR}, 'N/A')
-                        || '${Constants.RAW_SCANLATOR_TYPE_SEPARATOR}'
-                        || IFNULL(${Chapter.TABLE}.${Chapter.COL_UPLOADER}, 'N/A'),
+                    agg_scanlator || '${Constants.RAW_SCANLATOR_TYPE_SEPARATOR}' || agg_uploader || '${Constants.RAW_CHAPTER_COUNT_SEPARATOR}' || agg_count,
                     '${Constants.RAW_CHAPTER_SEPARATOR}'
                 ) AS unread
-            FROM ${Chapter.TABLE}
-            WHERE ${Chapter.COL_READ} = 0
+            FROM (
+                SELECT ${Chapter.COL_MANGA_ID},
+                       IFNULL(${Chapter.TABLE}.${Chapter.COL_SCANLATOR}, 'N/A') AS agg_scanlator,
+                       IFNULL(${Chapter.TABLE}.${Chapter.COL_UPLOADER}, 'N/A') AS agg_uploader,
+                       COUNT(*) AS agg_count
+                FROM ${Chapter.TABLE}
+                WHERE ${Chapter.COL_READ} = 0
+                GROUP BY ${Chapter.COL_MANGA_ID}, agg_scanlator, agg_uploader
+            )
             GROUP BY ${Chapter.COL_MANGA_ID}
         ) AS C
         ON ${Manga.COL_ID} = C.${Chapter.COL_MANGA_ID}
         LEFT JOIN (
             SELECT ${Chapter.COL_MANGA_ID},
                 GROUP_CONCAT(
-                    IFNULL(${Chapter.TABLE}.${Chapter.COL_SCANLATOR}, 'N/A')
-                        || '${Constants.RAW_SCANLATOR_TYPE_SEPARATOR}'
-                        || IFNULL(${Chapter.TABLE}.${Chapter.COL_UPLOADER}, 'N/A'),
+                    agg_scanlator || '${Constants.RAW_SCANLATOR_TYPE_SEPARATOR}' || agg_uploader || '${Constants.RAW_CHAPTER_COUNT_SEPARATOR}' || agg_count,
                     '${Constants.RAW_CHAPTER_SEPARATOR}'
                 ) AS hasread
-            FROM ${Chapter.TABLE}
-            WHERE ${Chapter.COL_READ} = 1
+            FROM (
+                SELECT ${Chapter.COL_MANGA_ID},
+                       IFNULL(${Chapter.TABLE}.${Chapter.COL_SCANLATOR}, 'N/A') AS agg_scanlator,
+                       IFNULL(${Chapter.TABLE}.${Chapter.COL_UPLOADER}, 'N/A') AS agg_uploader,
+                       COUNT(*) AS agg_count
+                FROM ${Chapter.TABLE}
+                WHERE ${Chapter.COL_READ} = 1
+                GROUP BY ${Chapter.COL_MANGA_ID}, agg_scanlator, agg_uploader
+            )
             GROUP BY ${Chapter.COL_MANGA_ID}
         ) AS R
         ON ${Manga.COL_ID} = R.${Chapter.COL_MANGA_ID}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/resolvers/LibraryMangaGetResolver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/resolvers/LibraryMangaGetResolver.kt
@@ -76,12 +76,17 @@ class LibraryMangaGetResolver : DefaultGetResolver<LibraryManga>(), BaseMangaGet
             }
 
             val typeSeparatorIndex = indexOf(Constants.RAW_SCANLATOR_TYPE_SEPARATOR, startIndex)
+            val countSeparatorIndex = indexOf(Constants.RAW_CHAPTER_COUNT_SEPARATOR, startIndex)
+
+            val infoEndIndex =
+                if (countSeparatorIndex != -1 && countSeparatorIndex < endIndex) countSeparatorIndex
+                else endIndex
 
             val scanlator =
-                if (typeSeparatorIndex != -1 && typeSeparatorIndex < endIndex) {
+                if (typeSeparatorIndex != -1 && typeSeparatorIndex < infoEndIndex) {
                     substring(startIndex, typeSeparatorIndex)
                 } else {
-                    substring(startIndex, endIndex)
+                    substring(startIndex, infoEndIndex)
                 }
 
             if (MergeType.containsMergeSourceName(scanlator)) {
@@ -102,17 +107,31 @@ class LibraryMangaGetResolver : DefaultGetResolver<LibraryManga>(), BaseMangaGet
                 blockedUploaders.isNullOrEmpty() &&
                 manga.filtered_scanlators == null
         ) {
-            var count = 1
-            var index = indexOf(Constants.RAW_CHAPTER_SEPARATOR)
-            while (index != -1) {
-                count++
-                index =
-                    indexOf(
-                        Constants.RAW_CHAPTER_SEPARATOR,
-                        index + Constants.RAW_CHAPTER_SEPARATOR.length,
-                    )
+            var totalCount = 0
+            var startIndex = 0
+            val length = this.length
+
+            while (startIndex < length) {
+                var endIndex = indexOf(Constants.RAW_CHAPTER_SEPARATOR, startIndex)
+                if (endIndex == -1) {
+                    endIndex = length
+                }
+
+                val countSeparatorIndex = indexOf(Constants.RAW_CHAPTER_COUNT_SEPARATOR, startIndex)
+                if (countSeparatorIndex != -1 && countSeparatorIndex < endIndex) {
+                    val countStr =
+                        substring(
+                            countSeparatorIndex + Constants.RAW_CHAPTER_COUNT_SEPARATOR.length,
+                            endIndex,
+                        )
+                    totalCount += countStr.toIntOrNull() ?: 1
+                } else {
+                    totalCount++
+                }
+
+                startIndex = endIndex + Constants.RAW_CHAPTER_SEPARATOR.length
             }
-            return count
+            return totalCount
         }
 
         var validChapterCount = 0
@@ -136,18 +155,36 @@ class LibraryMangaGetResolver : DefaultGetResolver<LibraryManga>(), BaseMangaGet
             }
 
             val typeSeparatorIndex = indexOf(Constants.RAW_SCANLATOR_TYPE_SEPARATOR, startIndex)
+            val countSeparatorIndex = indexOf(Constants.RAW_CHAPTER_COUNT_SEPARATOR, startIndex)
 
             val scanlator: String
             val uploader: String
-            if (typeSeparatorIndex != -1 && typeSeparatorIndex < endIndex) {
+            val currentGroupCount: Int
+
+            val infoEndIndex =
+                if (countSeparatorIndex != -1 && countSeparatorIndex < endIndex) countSeparatorIndex
+                else endIndex
+
+            if (countSeparatorIndex != -1 && countSeparatorIndex < endIndex) {
+                val countStr =
+                    substring(
+                        countSeparatorIndex + Constants.RAW_CHAPTER_COUNT_SEPARATOR.length,
+                        endIndex,
+                    )
+                currentGroupCount = countStr.toIntOrNull() ?: 1
+            } else {
+                currentGroupCount = 1
+            }
+
+            if (typeSeparatorIndex != -1 && typeSeparatorIndex < infoEndIndex) {
                 scanlator = substring(startIndex, typeSeparatorIndex)
                 uploader =
                     substring(
                         typeSeparatorIndex + Constants.RAW_SCANLATOR_TYPE_SEPARATOR.length,
-                        endIndex,
+                        infoEndIndex,
                     )
             } else {
-                scanlator = substring(startIndex, endIndex)
+                scanlator = substring(startIndex, infoEndIndex)
                 uploader = ""
             }
 
@@ -164,7 +201,7 @@ class LibraryMangaGetResolver : DefaultGetResolver<LibraryManga>(), BaseMangaGet
 
             if (!isBlocked) {
                 if (filtered == null) {
-                    validChapterCount++
+                    validChapterCount += currentGroupCount
                 } else {
                     // Check if the chapter passes the manga-specific filter
                     var isFilteredOut = false
@@ -199,7 +236,7 @@ class LibraryMangaGetResolver : DefaultGetResolver<LibraryManga>(), BaseMangaGet
                     }
 
                     if (!isFilteredOut) {
-                        validChapterCount++
+                        validChapterCount += currentGroupCount
                     }
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedViewModel.kt
@@ -206,7 +206,9 @@ class FeedViewModel() : ViewModel() {
             .incognitoMode()
             .changes()
             .distinctUntilChanged()
-.onEach { incognito -> _feedScreenState.update { state -> state.copy(incognitoMode = incognito) } }
+            .onEach { incognito ->
+                _feedScreenState.update { state -> state.copy(incognitoMode = incognito) }
+            }
             .launchIn(viewModelScope)
 
         preferences

--- a/constants/src/main/kotlin/org/nekomanga/constants/Constants.kt
+++ b/constants/src/main/kotlin/org/nekomanga/constants/Constants.kt
@@ -25,6 +25,7 @@ object Constants {
     const val ALT_TITLES_SEPARATOR = "|~|"
     const val RAW_CHAPTER_SEPARATOR = " [.] "
     const val RAW_SCANLATOR_TYPE_SEPARATOR = " [;] "
+    const val RAW_CHAPTER_COUNT_SEPARATOR = " [-] "
 
     const val TMP_DIR_SUFFIX = "_tmp"
     const val TMP_FILE_SUFFIX = ".tmp"


### PR DESCRIPTION
Fix `java.lang.IllegalStateException: Couldn't read row 212 column 0` crash when removing a favorite manga.

The `libraryQuery` was generating a massive string for `unread` and `hasread` strings by blindly `GROUP_CONCAT`-ing every chapter for a manga to allow for in-memory scanlator filtering. If a manga had thousands of chapters, this exceeded the 2MB Android `CursorWindow` limit.

This patch fixes the issue by aggregating identical scanlators & uploaders in the SQL subquery using `COUNT(*)`, appending that count to the string, and modifying the resolver to parse and increment `validChapterCount` by the matched count rather than one.

💡 What: Changed the way we group concat read and unread chapters in the `libraryQuery` and updated `LibraryMangaGetResolver` to accommodate it.
🎯 Why: To drastically reduce the payload size in the `libraryQuery` and avoid exceeding the CursorWindow size limit.
🏗️ Architecture: A new string separator (`[-]`) was introduced in Constants to distinguish between the Scanlator/Uploader strings and the count of chapters for that group.
📊 Impact: High for users with mangas that have a high chapter count. This solves a crash and uses significantly less memory.

---
*PR created automatically by Jules for task [2988976262324592671](https://jules.google.com/task/2988976262324592671) started by @nonproto*