### PR TITLE
fix: add contentDescription for SortRow icons

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/SortRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/SortRow.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -59,7 +60,7 @@ fun SortRow(
             MangaConstants.SortState.Ascending -> {
                 Icon(
                     imageVector = Icons.Filled.ArrowUpward,
-                    contentDescription = null,
+                    contentDescription = stringResource(id = org.nekomanga.R.string.ascending),
                     tint = tintColor,
                     modifier = Modifier.size(24.dp),
                 )
@@ -67,7 +68,7 @@ fun SortRow(
             MangaConstants.SortState.Descending -> {
                 Icon(
                     imageVector = Icons.Filled.ArrowDownward,
-                    contentDescription = null,
+                    contentDescription = stringResource(id = org.nekomanga.R.string.descending),
                     tint = tintColor,
                     modifier = Modifier.size(24.dp),
                 )


### PR DESCRIPTION
💡 What: Replaced `contentDescription = null` with explicit `stringResource` values (`org.nekomanga.R.string.ascending` and `descending`) for the directional sort icons in the `SortRow` Composable.
🎯 Why: To provide proper accessibility support for screen readers (like TalkBack), enabling visually impaired users to understand the current sorting state without relying purely on visuals.
📊 Impact: Improves accessibility (A11y) score on screens using the `SortRow` component while maintaining the exact visual presentation. All formatting and tests pass.

---
*PR created automatically by Jules for task [7883393874257789091](https://jules.google.com/task/7883393874257789091) started by @nonproto*