### PR TITLE
perf: optimize list operations by replacing filter.map chains with mapNotNull

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupFileValidator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupFileValidator.kt
@@ -45,8 +45,13 @@ class BackupFileValidator(private val trackManager: TrackManager = Injekt.get())
         val missingTrackers =
             trackers
                 .mapNotNull { trackManager.getService(it) }
-                .filter { !it.isLogged() }
-                .map { context.getString(it.nameRes()) }
+                .mapNotNull { service ->
+                    if (!service.isLogged()) {
+                        context.getString(service.nameRes())
+                    } else {
+                        null
+                    }
+                }
                 .sorted()
 
         return Results(missingTrackers, !hasDexEntries)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -270,13 +270,16 @@ class Downloader(
                 .map { it.toSimpleChapter()!!.toChapterItem() }
                 .sortedWith(ChapterItemSort().sortComparator(manga, true))
                 .map { it.chapter }
+
                 // Add chapters to queue from the start.
-                // Filter out those already enqueued.
-                .filter { chapter -> queueState.value.none { it.chapterItem.id == chapter.id } }
-                // Create a download for each one.
-                .map {
-                    val source = it.getHttpSource(sourceManager)
-                    Download(source, manga.toSimpleManga(), it)
+                // Filter out those already enqueued and create a download for each one.
+                .mapNotNull { chapter ->
+                    if (queueState.value.none { it.chapterItem.id == chapter.id }) {
+                        val source = chapter.getHttpSource(sourceManager)
+                        Download(source, manga.toSimpleManga(), chapter)
+                    } else {
+                        null
+                    }
                 }
                 .toList()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -603,7 +603,9 @@ class LibraryUpdateJob(private val context: Context, workerParameters: WorkerPar
                                             .collect { chapterIds ->
                                                 val markRead =
                                                     nonMergedChapters
-// Optimized by replacing chained filters and map with mapNotNull to avoid intermediate list allocations.
+                                                        // Optimized by replacing chained filters
+                                                        // and map with mapNotNull to avoid
+                                                        // intermediate list allocations.
                                                         .mapNotNull {
                                                             if (
                                                                 chapterIds.contains(
@@ -623,14 +625,21 @@ class LibraryUpdateJob(private val context: Context, workerParameters: WorkerPar
                                             }
                                     }
                                     if (mergedChapters.isNotEmpty()) {
+
+                                        // with .mapNotNull {}
                                         val readChapters =
-                                            mergedList
-                                                .flatten()
-                                                .filter { it.second }
-                                                .map { Pair(it.first.scanlator, it.first.url) }
+                                            mergedList.flatten().mapNotNull {
+                                                if (it.second) {
+                                                    Pair(it.first.scanlator, it.first.url)
+                                                } else {
+                                                    null
+                                                }
+                                            }
                                         val markRead =
                                             mergedChapters
-// Optimized by replacing chained filters and map with mapNotNull to avoid intermediate list allocations.
+                                                // Optimized by replacing chained filters and map
+                                                // with mapNotNull to avoid intermediate list
+                                                // allocations.
                                                 .mapNotNull {
                                                     if (
                                                         readChapters.contains(

--- a/app/src/main/java/eu/kanade/tachiyomi/jobs/follows/FollowsSyncProcessor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jobs/follows/FollowsSyncProcessor.kt
@@ -71,10 +71,13 @@ class FollowsSyncProcessor {
                     val defaultCategory = categories.find { it.id == defaultCategoryId }
 
                     val allDbMangaByUuid =
-                        db.getMangaList()
-                            .executeOnIO()
-                            .filter { it.favorite }
-                            .map { it.uuid() to it }
+                        db.getMangaList().executeOnIO().mapNotNull { manga ->
+                            if (manga.favorite) {
+                                manga.uuid() to manga
+                            } else {
+                                null
+                            }
+                        }
 
                     val mangaIdsToUpdate = listManga.mapNotNull { networkManga ->
                         updateNotification(networkManga.title, count.andIncrement, listManga.size)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
@@ -181,8 +181,13 @@ class ApiMangaParser {
 
         val uploaderName =
             networkChapter.relationships
-                .filter { it.type == MdConstants.Types.uploader }
-                .map { uploaders[it.id] }
+                .mapNotNull { relationship ->
+                    if (relationship.type == MdConstants.Types.uploader) {
+                        uploaders[relationship.id]
+                    } else {
+                        null
+                    }
+                }
                 .firstOrNull()
 
         if (scanlatorName.isEmpty()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ListHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ListHandler.kt
@@ -43,9 +43,13 @@ class ListHandler {
         return withContext(Dispatchers.IO) {
             service.viewList(listUUID).getOrResultError("Error getting list").andThen { listDto ->
                 val allMangaIds =
-                    listDto.data.relationships
-                        .filter { it.type == MdConstants.Types.manga }
-                        .map { it.id }
+                    listDto.data.relationships.mapNotNull { relationship ->
+                        if (relationship.type == MdConstants.Types.manga) {
+                            relationship.id
+                        } else {
+                            null
+                        }
+                    }
                 when (
                     allMangaIds.isEmpty() || allMangaIds.size <= MdUtil.getMangaListOffset(page)
                 ) {
@@ -76,10 +80,15 @@ class ListHandler {
 
                         val enabledContentRatings =
                             mangaDexPreferences.visibleContentRatings().get()
+
                         val contentRatings =
-                            MangaContentRating.getOrdered()
-                                .filter { enabledContentRatings.contains(it.key) }
-                                .map { it.key }
+                            MangaContentRating.getOrdered().mapNotNull { rating ->
+                                if (enabledContentRatings.contains(rating.key)) {
+                                    rating.key
+                                } else {
+                                    null
+                                }
+                            }
 
                         val queryParameters =
                             mutableMapOf(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedRepository.kt
@@ -194,7 +194,6 @@ class FeedRepository(
                         entry to feedMangaFiltered
                     }
 
-                    // ⚡ BOLT OPTIMIZATION: Replaced .filter {}.map {} chain with .mapNotNull {}
                     val mangaIdsToFetch = processedEntries.mapNotNull {
                         if (it.second.isEmpty()) it.first.key else null
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -1242,7 +1242,6 @@ class LibraryViewModel() : ViewModel() {
             manga ?: return@launchIO
             val chapters = db.getChapters(manga).executeAsBlocking()
 
-            // ⚡ BOLT OPTIMIZATION: Replaced .filter {}.map {} chain with .mapNotNull {}
             // to avoid allocating an intermediate list of available chapters,
             // reducing GC overhead when the user quickly jumps to reading.
             val availableChapters = chapters.mapNotNull { chapter ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivityViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivityViewModel.kt
@@ -73,7 +73,7 @@ class MainActivityViewModel : ViewModel() {
 
     init {
         viewModelScope.launchIO {
-            // ⚡ BOLT OPTIMIZATION: Added distinctUntilChanged() to prevent redundant state updates
+
             // and UI recompositions when preferences emit the same value.
             securityPreferences.incognitoMode().changes().distinctUntilChanged().collect {
                 incognitoMode ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaUpdateCoordinator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaUpdateCoordinator.kt
@@ -226,10 +226,13 @@ class MangaUpdateCoordinator {
         val blockedGroups = mangaDexPreferences.blockedGroups().get()
         val blockedUploaders = mangaDexPreferences.blockedUploaders().get()
 
-        val chaptersToDownload =
-            chapters
-                .filter { isChapterDownloadable(it, blockedGroups, blockedUploaders) }
-                .map { it.chapter.toDbChapter() }
+        val chaptersToDownload = chapters.mapNotNull { item ->
+            if (isChapterDownloadable(item, blockedGroups, blockedUploaders)) {
+                item.chapter.toDbChapter()
+            } else {
+                null
+            }
+        }
 
         downloadManager.downloadChapters(manga, chaptersToDownload)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayViewModel.kt
@@ -141,7 +141,6 @@ class DisplayViewModel(val displayScreenType: DisplayScreenType) : ViewModel() {
             }
         }
 
-        // ⚡ BOLT OPTIMIZATION: Used observeAndUpdate which internally applies
         // distinctUntilChanged()
         // to prevent redundant state updates and UI recompositions.
         preferences.browseAsList().changes().observeAndUpdate(viewModelScope) {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
@@ -276,8 +276,13 @@ fun syncChaptersWithSource(
     val dupes =
         dbChapters
             .groupBy { it.url }
-            .filter { entry -> entry.value.size > 1 }
-            .map { entry -> entry.value.firstOrNull { !it.read } ?: entry.value.first() }
+            .mapNotNull { entry ->
+                if (entry.value.size > 1) {
+                    entry.value.firstOrNull { !it.read } ?: entry.value.first()
+                } else {
+                    null
+                }
+            }
             .toMutableList()
     if (dupes.isNotEmpty()) {
         dupes.addAll(toDelete)

--- a/app/src/main/java/org/nekomanga/presentation/screens/stats/DetailedStats.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/stats/DetailedStats.kt
@@ -357,10 +357,16 @@ private fun StartYearView(
             .sortedBy { it.key }
             .toPersistentList()
     }
+
     val lineData = remember {
         sortedSeries
-            .filter { it.key != notStartedString }
-            .map { LineData(xValue = it.key, yValue = it.value.size.toFloat()) }
+            .mapNotNull {
+                if (it.key != notStartedString) {
+                    LineData(xValue = it.key, yValue = it.value.size.toFloat())
+                } else {
+                    null
+                }
+            }
             .toPersistentList()
     }
     val colorMap = remember { sortedSeries.associate { it.key to colors[0] }.toImmutableMap() }

--- a/app/src/main/java/org/nekomanga/presentation/screens/stats/SimpleStats.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/stats/SimpleStats.kt
@@ -66,9 +66,13 @@ fun SimpleStats(
             }
 
         val mergeCounts =
-            statsState.mergeCounts
-                .filter { it.second > 0 }
-                .map { (it.first.scanlatorName + " merged") to it.second.toString() }
+            statsState.mergeCounts.mapNotNull {
+                if (it.second > 0) {
+                    (it.first.scanlatorName + " merged") to it.second.toString()
+                } else {
+                    null
+                }
+            }
 
         (listOf(
                 numberFormat.format(statsState.mangaCount).toString() to


### PR DESCRIPTION
Replaced chained `.filter {}.map {}` operations with `.mapNotNull {}` across the application to prevent the creation of intermediate lists.
This reduces GC overhead and memory allocations during list processing, specifically on paths like backup validation, chapter syncing, downloading, updates, and UI statistical mapping.

Impact:
- Reduced intermediate list memory allocations and memory thrashing.
- Improved overall performance slightly in data heavy screens or background jobs processing manga and chapters lists.

---
*PR created automatically by Jules for task [8176715839716109876](https://jules.google.com/task/8176715839716109876) started by @nonproto*