### PR TITLE
perf: replace N+1 Room query with bulk chunked fetch in DisplayManga.resync

### DIFF
--- a/.jules/overclock.md
+++ b/.jules/overclock.md
@@ -16,3 +16,7 @@
 ## 2026-03-20 - Refactoring massive UiState data classes into distinct StateFlows
 **Learning:** In Compose UI architectures, massive single `UiState` data classes cause full-screen recompositions when minor fields (like `isRefreshing`) are updated. This forces the entire layout (e.g., `MangaScreen`) to re-evaluate.
 **Action:** Always refactor massive `UiState` data classes into smaller, distinct `StateFlow`s inside the ViewModel (e.g., separating `generalState` from `chapterState`). In Compose, collect each `StateFlow` separately and pass the specific state data classes to individual Composables to ensure precise and efficient recomposition scoping.
+
+## 2026-03-23 - [Overclock: DisplayManga.resync N+1 Optimization]
+**Learning:** Looping over lists of `DisplayManga` and performing individual `db.getManga(displayManga.mangaId).executeAsBlocking()` calls creates a massive N+1 bottleneck, locking up the CPU and stalling screens like Latest and Browse that handle large lists.
+**Action:** Replaced individual iterations with a chunked `db.getMangas(chunk)` query to fetch all required records in a few bulk queries, mapping them by ID into memory before re-syncing properties.

--- a/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
@@ -270,8 +270,18 @@ fun List<HomePageManga>.resync(db: DatabaseHelper): PersistentList<HomePageManga
 }
 
 fun List<DisplayManga>.resync(db: DatabaseHelper): List<DisplayManga> {
+    if (this.isEmpty()) return emptyList()
+
+    // Fetch existing mangas from database by IDs in chunks to avoid SQLite parameter limit
+    val mangaIds = this.map { it.mangaId }.distinct()
+    val existingMangas =
+        mangaIds
+            .chunked(900)
+            .flatMap { chunk -> db.getMangas(chunk).executeAsBlocking() }
+            .associateBy { it.id }
+
     return this.mapNotNull { displayManga ->
-        val dbManga = db.getManga(displayManga.mangaId).executeAsBlocking()
+        val dbManga = existingMangas[displayManga.mangaId]
         when (dbManga == null) {
             true -> null
             else ->


### PR DESCRIPTION
💡 What: The architectural optimization replaces individual database calls for each item in the `resync` list with a bulk query of chunked sizes.

🎯 Why: To fix an N+1 query issue where the loop processed one item at a time causing massive UI thread slowdowns. The bottleneck was inside the extension method `List<DisplayManga>.resync()` in `MangaExtensions.kt`.

🏗️ Architecture: Replaced `db.getManga` queries within a `mapNotNull` loop with an initial `distinct` ID fetch mapped into chunks to execute `db.getMangas` safely around SQLite limits. Lookups are handled quickly via O(1) in-memory `associateBy` indexing.

📊 Impact: Reduces O(N) database reads to O(1) batched lookups, substantially unblocking CPU resources and speeding up rendering on features handling large lists (e.g. Latest and Browse views).

---
*PR created automatically by Jules for task [1656941687803972783](https://jules.google.com/task/1656941687803972783) started by @nonproto*