### PR TITLE
perf: add distinctUntilChanged to prevent redundant recompositions in Library Flow

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -390,6 +390,7 @@ class LibraryViewModel() : ViewModel() {
                     filterUnread = it[8] as FilterUnread,
                 )
             }
+            .distinctUntilChanged()
             .shareIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1)
     // 1. FILTER FLOW: Applies filters and fetches necessary data (Download counts)
     private val activeMangaFlow =


### PR DESCRIPTION
Adding `.distinctUntilChanged()` to `filterPreferencesFlow` inside `LibraryViewModel.kt` to avoid redundant recompositions in the library view when preferences emit the exact same value.

### What
Added `.distinctUntilChanged()` to `filterPreferencesFlow` in `LibraryViewModel`.

### Why
Flows like `libraryPreferences.filterBookmarked().changes()` do not apply `distinctUntilChanged()`. If `changes()` emits the identical value multiple times, `combine` gets re-triggered and downstream UI flows (e.g. `libraryScreenState`) receive identical lists that trigger unnecessary recompositions in large `LazyColumn`s/`LazyVerticalGrid`s in Compose, which is costly.

### Expected Measurement
It is expected that redundant library items recalculations and subsequent UI recompositions are reduced when background systems or unrelated sync jobs trigger SharedPreferences changes for those specific filter preferences.

---
*PR created automatically by Jules for task [545585173565177303](https://jules.google.com/task/545585173565177303) started by @nonproto*