### PR TITLE
perf: replace N+1 Room queries with chunked bulk fetch in cleanupDownloads

### DIFF
--- a/.jules/overclock.md
+++ b/.jules/overclock.md
@@ -20,3 +20,6 @@
 ## 2026-03-23 - [Overclock: DisplayManga.resync N+1 Optimization]
 **Learning:** Looping over lists of `DisplayManga` and performing individual `db.getManga(displayManga.mangaId).executeAsBlocking()` calls creates a massive N+1 bottleneck, locking up the CPU and stalling screens like Latest and Browse that handle large lists.
 **Action:** Replaced individual iterations with a chunked `db.getMangas(chunk)` query to fetch all required records in a few bulk queries, mapping them by ID into memory before re-syncing properties.
+## 2024-05-24 - [Overclock: Chunked Bulk Query Optimization]
+**Learning:** When trying to eliminate an N+1 query loop by mapping list items to a list of IDs and performing a bulk fetch, fetching a massive list of IDs directly can hit SQLite bind parameter limits or memory pressure.
+**Action:** Use `.chunked(900).flatMap { db.getChapters(it).executeAsBlocking() }` when fetching lists of items by IDs to safely handle thousands of IDs in smaller batches, preventing application crashes.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/AdvancedSettingsViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/AdvancedSettingsViewModel.kt
@@ -53,6 +53,13 @@ class AdvancedSettingsViewModel : ViewModel() {
                     }
                 val mangaFolders = downloadManager.getMangaFolders()
 
+                val mangaIds = mangaFolders.mapNotNull { mangaMap[it.name]?.id }
+                val chaptersByMangaId =
+                    mangaIds
+                        .chunked(900)
+                        .flatMap { db.getChapters(it).executeAsBlocking() }
+                        .groupBy { it.manga_id }
+
                 for (mangaFolder in mangaFolders) {
                     val manga = mangaMap[mangaFolder.name]
                     if (manga == null) {
@@ -63,7 +70,7 @@ class AdvancedSettingsViewModel : ViewModel() {
                         }
                         continue
                     }
-                    val chapterList = db.getChapters(manga).executeAsBlocking()
+                    val chapterList = chaptersByMangaId[manga.id] ?: emptyList()
                     foldersCleared +=
                         downloadManager.cleanupChapters(
                             chapterList,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/AdvancedSettingsViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/AdvancedSettingsViewModel.kt
@@ -53,9 +53,9 @@ class AdvancedSettingsViewModel : ViewModel() {
                     }
                 val mangaFolders = downloadManager.getMangaFolders()
 
-                val mangaIds = mangaFolders.mapNotNull { mangaMap[it.name]?.id }
                 val chaptersByMangaId =
-                    mangaIds
+                    mangaFolders.asSequence()
+                        .mapNotNull { mangaMap[it.name]?.id }
                         .chunked(900)
                         .flatMap { db.getChapters(it).executeAsBlocking() }
                         .groupBy { it.manga_id }


### PR DESCRIPTION
💡 What: The architectural/structural optimization implemented
Refactored the `cleanupDownloads` function inside `AdvancedSettingsViewModel` to fetch chapters for all manga in chunked bulk queries instead of iterating and querying individually for each manga folder.

🎯 Why: The deep bottleneck it solves
An O(N) database iteration executing `db.getChapters(manga).executeAsBlocking()` for potentially thousands of manga folders caused significant CPU locking and stuttering during cleanup operations.

🏗️ Architecture: How the data flow or layout was changed
- Mapped existing manga folder names to a list of needed `Manga` IDs.
- Used `mangaIds.chunked(900).flatMap { db.getChapters(it).executeAsBlocking() }` to securely pre-fetch the chapters in bulk, and `groupBy { it.manga_id }` for O(1) in-memory lookup during the iterative processing.

📊 Impact: Expected massive performance gain
Transforms thousands of blocking individual SQLite reads into a small handful of chunked queries, massively improving the performance of the "cleanup downloads" operation on large libraries.

---
*PR created automatically by Jules for task [16074724739862067464](https://jules.google.com/task/16074724739862067464) started by @nonproto*