### PR TITLE
fix: replace empty catch block with Timber logger

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/AdvancedSettingsViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/AdvancedSettingsViewModel.kt
@@ -54,7 +54,8 @@ class AdvancedSettingsViewModel : ViewModel() {
                 val mangaFolders = downloadManager.getMangaFolders()
 
                 val chaptersByMangaId =
-                    mangaFolders.asSequence()
+                    mangaFolders
+                        .asSequence()
                         .mapNotNull { mangaMap[it.name]?.id }
                         .chunked(900)
                         .flatMap { db.getChapters(it).executeAsBlocking() }

--- a/core/src/main/kotlin/tachiyomi/core/network/interceptors/CookieInterceptor.kt
+++ b/core/src/main/kotlin/tachiyomi/core/network/interceptors/CookieInterceptor.kt
@@ -3,6 +3,7 @@ package tachiyomi.core.network.interceptors
 import android.webkit.CookieManager
 import okhttp3.Interceptor
 import okhttp3.Response
+import org.nekomanga.logging.TimberKt
 
 class CookieInterceptor(
     private val domain: String,
@@ -50,6 +51,8 @@ class CookieInterceptor(
     private fun setCookie(url: String, value: String) {
         try {
             cookieManager.setCookie(url, value)
-        } catch (_: Exception) {}
+        } catch (e: Exception) {
+            TimberKt.e(e) { "Error setting cookie" }
+        }
     }
 }


### PR DESCRIPTION
Fixed a silent exception by replacing an empty catch block with a Timber error log in `CookieInterceptor.kt`. Also ran ktfmt and verified tests.

---
*PR created automatically by Jules for task [5931550840922586323](https://jules.google.com/task/5931550840922586323) started by @nonproto*