### PR TITLE
perf: replace N+1 Room queries with bulk IN fetch in Browse/Display repo

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/ScanlatorGroupQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/ScanlatorGroupQueries.kt
@@ -22,6 +22,23 @@ interface ScanlatorGroupQueries : DbProvider {
             )
             .prepare()
 
+    fun getScanlatorGroupsByNames(names: List<String>) =
+        db.get()
+            .listOfObjects(ScanlatorGroupImpl::class.java)
+            .withQuery(
+                Query.builder().table(ScanlatorGroupTable.TABLE).let { builder ->
+                    if (names.isEmpty()) {
+                        builder.where("1 = 0")
+                    } else {
+                        val placeHolders = names.joinToString { "?" }
+                        builder.where("${ScanlatorGroupTable.COL_NAME} IN ($placeHolders)")
+                        builder.whereArgs(*names.toTypedArray())
+                    }
+                    builder.build()
+                }
+            )
+            .prepare()
+
     fun deleteScanlatorGroup(name: String) =
         db.delete()
             .byQuery(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/UploaderQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/UploaderQueries.kt
@@ -22,6 +22,23 @@ interface UploaderQueries : DbProvider {
             )
             .prepare()
 
+    fun getUploadersByNames(names: List<String>) =
+        db.get()
+            .listOfObjects(UploaderImpl::class.java)
+            .withQuery(
+                Query.builder().table(UploaderTable.TABLE).let { builder ->
+                    if (names.isEmpty()) {
+                        builder.where("1 = 0")
+                    } else {
+                        val placeHolders = names.joinToString { "?" }
+                        builder.where("${UploaderTable.COL_USERNAME} IN ($placeHolders)")
+                        builder.whereArgs(*names.toTypedArray())
+                    }
+                    builder.build()
+                }
+            )
+            .prepare()
+
     fun deleteUploader(name: String) =
         db.delete()
             .byQuery(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseRepository.kt
@@ -3,7 +3,7 @@ package eu.kanade.tachiyomi.ui.source.browse
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.andThen
-import com.github.michaelbull.result.filterValues
+import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.map
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.source.SourceManager
@@ -13,6 +13,9 @@ import eu.kanade.tachiyomi.util.manga.toDisplayManga
 import eu.kanade.tachiyomi.util.system.executeOnIO
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import org.nekomanga.domain.filter.DexFilters
 import org.nekomanga.domain.manga.DisplayManga
 import org.nekomanga.domain.network.ResultError
@@ -47,36 +50,52 @@ class BrowseRepository(
     }
 
     suspend fun getHomePage(): Result<List<HomePageManga>, ResultError> {
-        val blockedGroupUUIDs =
-            mangaDexPreferences.blockedGroups().get().map {
-                var scanlatorGroupImpl = db.getScanlatorGroupByName(it).executeAsBlocking()
-                if (scanlatorGroupImpl == null) {
-                    mangaDex.getScanlatorGroup(group = it).map { group ->
-                        scanlatorGroupImpl = group.toScanlatorGroupImpl()
-                        db.insertScanlatorGroups(listOf(scanlatorGroupImpl!!)).executeOnIO()
-                        scanlatorGroupImpl!!
-                    }
-                } else {
-                    Ok(scanlatorGroupImpl!!)
-                }
+        val blockedGroupNames = mangaDexPreferences.blockedGroups().get().toList()
+        val blockedGroupUUIDs = coroutineScope {
+            val chunks = blockedGroupNames.chunked(900)
+            val existingGroups = chunks.flatMap { chunk ->
+                db.getScanlatorGroupsByNames(chunk).executeAsBlocking()
             }
-        val blockedUploaderUUIDs =
-            mangaDexPreferences.blockedUploaders().get().map {
-                var uploaderImpl = db.getUploaderByName(it).executeAsBlocking()
-                if (uploaderImpl == null) {
-                    mangaDex.getUploader(uploader = it).map { uploader ->
-                        uploaderImpl = uploader.toUploaderImpl()
-                        db.insertUploader(listOf(uploaderImpl!!)).executeOnIO()
-                        uploaderImpl!!
-                    }
-                } else {
-                    Ok(uploaderImpl!!)
-                }
+            val existingGroupNames = existingGroups.map { it.name }.toSet()
+            val missingGroupNames = blockedGroupNames.filterNot { it in existingGroupNames }
+
+            val fetchedGroups =
+                missingGroupNames
+                    .map { name -> async { mangaDex.getScanlatorGroup(group = name) } }
+                    .awaitAll()
+                    .mapNotNull { result -> result.getOrElse { null }?.toScanlatorGroupImpl() }
+
+            if (fetchedGroups.isNotEmpty()) {
+                db.insertScanlatorGroups(fetchedGroups).executeOnIO()
+            }
+            (existingGroups + fetchedGroups).map { it.uuid }
+        }
+
+        val blockedUploaderNames = mangaDexPreferences.blockedUploaders().get().toList()
+        val blockedUploaderUUIDs = coroutineScope {
+            val chunks = blockedUploaderNames.chunked(900)
+            val existingUploaders = chunks.flatMap { chunk ->
+                db.getUploadersByNames(chunk).executeAsBlocking()
+            }
+            val existingUploaderNames = existingUploaders.map { it.username }.toSet()
+            val missingUploaderNames = blockedUploaderNames.filterNot {
+                it in existingUploaderNames
             }
 
-        val scanlatorUUIDs = blockedGroupUUIDs.filterValues().map { it.uuid }
-        val uploaderUUIDs = blockedUploaderUUIDs.filterValues().map { it.uuid }
-        return mangaDex.fetchHomePageInfo(scanlatorUUIDs, uploaderUUIDs).andThen { listResults ->
+            val fetchedUploaders =
+                missingUploaderNames
+                    .map { name -> async { mangaDex.getUploader(uploader = name) } }
+                    .awaitAll()
+                    .mapNotNull { result -> result.getOrElse { null }?.toUploaderImpl() }
+
+            if (fetchedUploaders.isNotEmpty()) {
+                db.insertUploader(fetchedUploaders).executeOnIO()
+            }
+            (existingUploaders + fetchedUploaders).map { it.uuid }
+        }
+
+        return mangaDex.fetchHomePageInfo(blockedGroupUUIDs, blockedUploaderUUIDs).andThen {
+            listResults ->
             Ok(
                 listResults.map { listResult ->
                     HomePageManga(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseRepository.kt.patch
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseRepository.kt.patch
@@ -1,0 +1,76 @@
+--- app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseRepository.kt
++++ app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseRepository.kt
+@@ -10,6 +10,10 @@
+ import eu.kanade.tachiyomi.source.online.MangaDexLoginHelper
+ import eu.kanade.tachiyomi.util.manga.toDisplayManga
+ import eu.kanade.tachiyomi.util.system.executeOnIO
++import kotlinx.coroutines.async
++import kotlinx.coroutines.awaitAll
++import kotlinx.coroutines.coroutineScope
+ import kotlinx.collections.immutable.PersistentList
+ import kotlinx.collections.immutable.toPersistentList
+ import org.nekomanga.domain.filter.DexFilters
+@@ -48,34 +52,38 @@
+     }
+
+     suspend fun getHomePage(): Result<List<HomePageManga>, ResultError> {
+-        val blockedGroupUUIDs =
+-            mangaDexPreferences.blockedGroups().get().map {
+-                var scanlatorGroupImpl = db.getScanlatorGroupByName(it).executeAsBlocking()
+-                if (scanlatorGroupImpl == null) {
+-                    mangaDex.getScanlatorGroup(group = it).map { group ->
+-                        scanlatorGroupImpl = group.toScanlatorGroupImpl()
+-                        db.insertScanlatorGroups(listOf(scanlatorGroupImpl!!)).executeOnIO()
+-                        scanlatorGroupImpl!!
+-                    }
+-                } else {
+-                    Ok(scanlatorGroupImpl!!)
+-                }
++        val blockedGroupNames = mangaDexPreferences.blockedGroups().get().toList()
++        val blockedGroupUUIDs = coroutineScope {
++            val chunks = blockedGroupNames.chunked(900)
++            val existingGroups = chunks.flatMap { chunk -> db.getScanlatorGroupsByNames(chunk).executeAsBlocking() }
++            val existingGroupNames = existingGroups.map { it.name }.toSet()
++            val missingGroupNames = blockedGroupNames.filterNot { it in existingGroupNames }
++            val fetchedGroups = missingGroupNames.map { name ->
++                async { mangaDex.getScanlatorGroup(group = name) }
++            }.awaitAll().mapNotNull { it.getOrNull()?.toScanlatorGroupImpl() }
++            if (fetchedGroups.isNotEmpty()) {
++                db.insertScanlatorGroups(fetchedGroups).executeOnIO()
+             }
+-        val blockedUploaderUUIDs =
+-            mangaDexPreferences.blockedUploaders().get().map {
+-                var uploaderImpl = db.getUploaderByName(it).executeAsBlocking()
+-                if (uploaderImpl == null) {
+-                    mangaDex.getUploader(uploader = it).map { uploader ->
+-                        uploaderImpl = uploader.toUploaderImpl()
+-                        db.insertUploader(listOf(uploaderImpl!!)).executeOnIO()
+-                        uploaderImpl!!
+-                    }
+-                } else {
+-                    Ok(uploaderImpl!!)
+-                }
++            (existingGroups + fetchedGroups).map { it.uuid }
++        }
++
++        val blockedUploaderNames = mangaDexPreferences.blockedUploaders().get().toList()
++        val blockedUploaderUUIDs = coroutineScope {
++            val chunks = blockedUploaderNames.chunked(900)
++            val existingUploaders = chunks.flatMap { chunk -> db.getUploadersByNames(chunk).executeAsBlocking() }
++            val existingUploaderNames = existingUploaders.map { it.username }.toSet()
++            val missingUploaderNames = blockedUploaderNames.filterNot { it in existingUploaderNames }
++            val fetchedUploaders = missingUploaderNames.map { name ->
++                async { mangaDex.getUploader(uploader = name) }
++            }.awaitAll().mapNotNull { it.getOrNull()?.toUploaderImpl() }
++            if (fetchedUploaders.isNotEmpty()) {
++                db.insertUploader(fetchedUploaders).executeOnIO()
+             }
++            (existingUploaders + fetchedUploaders).map { it.uuid }
++        }
+
+-        val scanlatorUUIDs = blockedGroupUUIDs.filterValues().map { it.uuid }
+-        val uploaderUUIDs = blockedUploaderUUIDs.filterValues().map { it.uuid }
+-        return mangaDex.fetchHomePageInfo(scanlatorUUIDs, uploaderUUIDs).andThen { listResults ->
++        return mangaDex.fetchHomePageInfo(blockedGroupUUIDs, blockedUploaderUUIDs).andThen { listResults ->
+             Ok(
+                 listResults.map { listResult ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayRepository.kt
@@ -4,15 +4,18 @@ import androidx.compose.ui.state.ToggleableState
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.map
 import com.github.michaelbull.result.mapBoth
-import com.github.michaelbull.result.onSuccess
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.online.MangaDex
 import eu.kanade.tachiyomi.util.manga.toDisplayManga
 import eu.kanade.tachiyomi.util.system.executeOnIO
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import org.nekomanga.domain.filter.DexFilters
 import org.nekomanga.domain.filter.Filter
 import org.nekomanga.domain.manga.MangaContentRating
@@ -108,36 +111,50 @@ class DisplayRepository(
     }
 
     private suspend fun getFeedUpdatesPage(page: Int): Result<DisplayPageResult, ResultError> {
-        val blockedGroupUUIDs =
-            mangaDexPreferences
-                .blockedGroups()
-                .get()
-                .map {
-                    var scanlatorGroupImpl = db.getScanlatorGroupByName(it).executeAsBlocking()
-                    if (scanlatorGroupImpl == null) {
-                        mangaDex.getScanlatorGroup(group = it).map { scanlator ->
-                            scanlatorGroupImpl = scanlator.toScanlatorGroupImpl()
-                        }
-                        db.insertScanlatorGroups(listOf(scanlatorGroupImpl!!)).executeOnIO()
-                    }
-                    scanlatorGroupImpl
-                }
-                .map { it.uuid }
-        val blockedUploaderUUIDs =
-            mangaDexPreferences
-                .blockedUploaders()
-                .get()
-                .map {
-                    var uploaderImpl = db.getUploaderByName(it).executeAsBlocking()
-                    if (uploaderImpl == null) {
-                        mangaDex.getUploader(uploader = it).map { uploader ->
-                            uploaderImpl = uploader.toUploaderImpl()
-                        }
-                        db.insertUploader(listOf(uploaderImpl!!)).executeOnIO()
-                    }
-                    uploaderImpl
-                }
-                .map { it.uuid }
+        val blockedGroupNames = mangaDexPreferences.blockedGroups().get().toList()
+        val blockedGroupUUIDs = coroutineScope {
+            val chunks = blockedGroupNames.chunked(900)
+            val existingGroups = chunks.flatMap { chunk ->
+                db.getScanlatorGroupsByNames(chunk).executeAsBlocking()
+            }
+            val existingGroupNames = existingGroups.map { it.name }.toSet()
+            val missingGroupNames = blockedGroupNames.filterNot { it in existingGroupNames }
+
+            val fetchedGroups =
+                missingGroupNames
+                    .map { name -> async { mangaDex.getScanlatorGroup(group = name) } }
+                    .awaitAll()
+                    .mapNotNull { result -> result.getOrElse { null }?.toScanlatorGroupImpl() }
+
+            if (fetchedGroups.isNotEmpty()) {
+                db.insertScanlatorGroups(fetchedGroups).executeOnIO()
+            }
+            (existingGroups + fetchedGroups).map { it.uuid }
+        }
+
+        val blockedUploaderNames = mangaDexPreferences.blockedUploaders().get().toList()
+        val blockedUploaderUUIDs = coroutineScope {
+            val chunks = blockedUploaderNames.chunked(900)
+            val existingUploaders = chunks.flatMap { chunk ->
+                db.getUploadersByNames(chunk).executeAsBlocking()
+            }
+            val existingUploaderNames = existingUploaders.map { it.username }.toSet()
+            val missingUploaderNames = blockedUploaderNames.filterNot {
+                it in existingUploaderNames
+            }
+
+            val fetchedUploaders =
+                missingUploaderNames
+                    .map { name -> async { mangaDex.getUploader(uploader = name) } }
+                    .awaitAll()
+                    .mapNotNull { result -> result.getOrElse { null }?.toUploaderImpl() }
+
+            if (fetchedUploaders.isNotEmpty()) {
+                db.insertUploader(fetchedUploaders).executeOnIO()
+            }
+            (existingUploaders + fetchedUploaders).map { it.uuid }
+        }
+
         return mangaDex
             .feedUpdates(page, blockedGroupUUIDs, blockedUploaderUUIDs)
             .mapBoth(
@@ -155,38 +172,50 @@ class DisplayRepository(
     }
 
     private suspend fun getLatestChapterPage(page: Int): Result<DisplayPageResult, ResultError> {
-        val blockedGroupUUIDs =
-            mangaDexPreferences
-                .blockedGroups()
-                .get()
-                .mapNotNull {
-                    var scanlatorGroupImpl = db.getScanlatorGroupByName(it).executeAsBlocking()
-                    if (scanlatorGroupImpl == null) {
-                        mangaDex
-                            .getScanlatorGroup(group = it)
-                            .map { group -> scanlatorGroupImpl = group.toScanlatorGroupImpl() }
-                            .onSuccess {
-                                db.insertScanlatorGroups(listOf(scanlatorGroupImpl!!)).executeOnIO()
-                            }
-                    }
-                    scanlatorGroupImpl
-                }
-                .map { it.uuid }
-        val blockedUploaderUUIDs =
-            mangaDexPreferences
-                .blockedUploaders()
-                .get()
-                .mapNotNull {
-                    var uploaderImpl = db.getUploaderByName(it).executeAsBlocking()
-                    if (uploaderImpl == null) {
-                        mangaDex
-                            .getUploader(uploader = it)
-                            .map { uploader -> uploaderImpl = uploader.toUploaderImpl() }
-                            .onSuccess { db.insertUploader(listOf(uploaderImpl!!)).executeOnIO() }
-                    }
-                    uploaderImpl
-                }
-                .map { it.uuid }
+        val blockedGroupNames = mangaDexPreferences.blockedGroups().get().toList()
+        val blockedGroupUUIDs = coroutineScope {
+            val chunks = blockedGroupNames.chunked(900)
+            val existingGroups = chunks.flatMap { chunk ->
+                db.getScanlatorGroupsByNames(chunk).executeAsBlocking()
+            }
+            val existingGroupNames = existingGroups.map { it.name }.toSet()
+            val missingGroupNames = blockedGroupNames.filterNot { it in existingGroupNames }
+
+            val fetchedGroups =
+                missingGroupNames
+                    .map { name -> async { mangaDex.getScanlatorGroup(group = name) } }
+                    .awaitAll()
+                    .mapNotNull { result -> result.getOrElse { null }?.toScanlatorGroupImpl() }
+
+            if (fetchedGroups.isNotEmpty()) {
+                db.insertScanlatorGroups(fetchedGroups).executeOnIO()
+            }
+            (existingGroups + fetchedGroups).map { it.uuid }
+        }
+
+        val blockedUploaderNames = mangaDexPreferences.blockedUploaders().get().toList()
+        val blockedUploaderUUIDs = coroutineScope {
+            val chunks = blockedUploaderNames.chunked(900)
+            val existingUploaders = chunks.flatMap { chunk ->
+                db.getUploadersByNames(chunk).executeAsBlocking()
+            }
+            val existingUploaderNames = existingUploaders.map { it.username }.toSet()
+            val missingUploaderNames = blockedUploaderNames.filterNot {
+                it in existingUploaderNames
+            }
+
+            val fetchedUploaders =
+                missingUploaderNames
+                    .map { name -> async { mangaDex.getUploader(uploader = name) } }
+                    .awaitAll()
+                    .mapNotNull { result -> result.getOrElse { null }?.toUploaderImpl() }
+
+            if (fetchedUploaders.isNotEmpty()) {
+                db.insertUploader(fetchedUploaders).executeOnIO()
+            }
+            (existingUploaders + fetchedUploaders).map { it.uuid }
+        }
+
         return mangaDex
             .latestChapters(page, blockedGroupUUIDs, blockedUploaderUUIDs)
             .mapBoth(

--- a/patch_scanlator.diff
+++ b/patch_scanlator.diff
@@ -1,0 +1,44 @@
+<<<<<<< SEARCH
+    fun getScanlatorGroupByName(name: String) =
+        db.get()
+            .`object`(ScanlatorGroupImpl::class.java)
+            .withQuery(
+                Query.builder()
+                    .table(ScanlatorGroupTable.TABLE)
+                    .where("${ScanlatorGroupTable.COL_NAME} = ?")
+                    .whereArgs(name)
+                    .build()
+            )
+            .prepare()
+=======
+    fun getScanlatorGroupByName(name: String) =
+        db.get()
+            .`object`(ScanlatorGroupImpl::class.java)
+            .withQuery(
+                Query.builder()
+                    .table(ScanlatorGroupTable.TABLE)
+                    .where("${ScanlatorGroupTable.COL_NAME} = ?")
+                    .whereArgs(name)
+                    .build()
+            )
+            .prepare()
+
+    fun getScanlatorGroupsByNames(names: List<String>) =
+        db.get()
+            .listOfObjects(ScanlatorGroupImpl::class.java)
+            .withQuery(
+                Query.builder()
+                    .table(ScanlatorGroupTable.TABLE)
+                    .let { builder ->
+                        if (names.isEmpty()) {
+                            builder.where("1 = 0")
+                        } else {
+                            val placeHolders = names.joinToString { "?" }
+                            builder.where("${ScanlatorGroupTable.COL_NAME} IN ($placeHolders)")
+                            builder.whereArgs(*names.toTypedArray())
+                        }
+                        builder.build()
+                    }
+            )
+            .prepare()
+>>>>>>> REPLACE


### PR DESCRIPTION
💡 **What**: Replaced sequential O(N) blocking DB calls `executeAsBlocking()` and synchronous network fetches in `BrowseRepository` and `DisplayRepository` with chunked bulk IN queries and concurrent network fetching.

🎯 **Why**: Previously, when users loaded the home page, feeds, or latest chapters, the app would iterate through the `mangaDexPreferences.blockedGroups` and `blockedUploaders` and sequentially fire a blocking `executeAsBlocking()` DB lookup for every single item. Missing items would then be fetched sequentially over the network. This caused significant UI thread blocking, measurement delays, and frame drops because it tied up the coroutine while performing redundant I/O tasks.

🏗️ **Architecture**: 
- Added `getScanlatorGroupsByNames` and `getUploadersByNames` queries that use the `IN (...)` SQLite operator.
- Using `.chunked(900)`, the repositories now bulk fetch existing blocked groups/uploaders from the Room database.
- Missing entries are then mapped via `async { ... }.awaitAll()` to concurrently fetch them from MangaDex, reducing network latency.
- Finally, all retrieved items are batch-inserted back into the database.

📊 **Impact**: Massively reduces DB query overhead from O(N) to O(1) per chunk, removes I/O thread starvation, and speeds up the loading of the Browse Home Page and Feed/Latest lists.

---
*PR created automatically by Jules for task [16915590891783252248](https://jules.google.com/task/16915590891783252248) started by @nonproto*