### PR TITLE
fix: display more definitive reason for unknown errors

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -49,6 +49,7 @@ import eu.kanade.tachiyomi.util.chapter.ChapterUtil
 import eu.kanade.tachiyomi.util.chapter.getChapterNum
 import eu.kanade.tachiyomi.util.chapter.mergeSorted
 import eu.kanade.tachiyomi.util.chapter.syncChaptersWithSource
+import eu.kanade.tachiyomi.util.lang.toDisplayMessage
 import eu.kanade.tachiyomi.util.manga.shouldDownloadNewChapters
 import eu.kanade.tachiyomi.util.manga.toDisplayManga
 import eu.kanade.tachiyomi.util.storage.getUriCompat
@@ -683,15 +684,7 @@ class LibraryUpdateJob(private val context: Context, workerParameters: WorkerPar
                     if (e is CancellationException) {
                         throw e
                     } else {
-                        val errorMessage = e.message ?: ""
-                        failedUpdates[manga] =
-                            if (
-                                errorMessage.isBlank() || errorMessage.equals("unknown error", true)
-                            ) {
-                                e.javaClass.simpleName
-                            } else {
-                                errorMessage
-                            }
+                        failedUpdates[manga] = e.toDisplayMessage()
                         TimberKt.e(e) { "Failed updating: ${manga.title}" }
                     }
                     return@coroutineScope false

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -683,7 +683,15 @@ class LibraryUpdateJob(private val context: Context, workerParameters: WorkerPar
                     if (e is CancellationException) {
                         throw e
                     } else {
-                        failedUpdates[manga] = e.message ?: "unknown error"
+                        val errorMessage = e.message ?: ""
+                        failedUpdates[manga] =
+                            if (
+                                errorMessage.isBlank() || errorMessage.equals("unknown error", true)
+                            ) {
+                                e.javaClass.simpleName
+                            } else {
+                                errorMessage
+                            }
                         TimberKt.e(e) { "Failed updating: ${manga.title}" }
                     }
                     return@coroutineScope false

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FollowsHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FollowsHandler.kt
@@ -72,7 +72,14 @@ class FollowsHandler {
                 }
                 .getOrElse {
                     TimberKt.e(it) { "Error fetching all follows" }
-                    Err(ResultError.Generic("Unknown error fetching all follows"))
+                    val errorMessage = it.message ?: ""
+                    val reason =
+                        if (errorMessage.isBlank() || errorMessage.equals("unknown error", true)) {
+                            it.javaClass.simpleName
+                        } else {
+                            errorMessage
+                        }
+                    Err(ResultError.Generic(reason))
                 }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FollowsHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FollowsHandler.kt
@@ -22,6 +22,7 @@ import eu.kanade.tachiyomi.source.online.utils.FollowStatus
 import eu.kanade.tachiyomi.source.online.utils.MdUtil.Companion.getMangaUUID
 import eu.kanade.tachiyomi.source.online.utils.toSourceManga
 import eu.kanade.tachiyomi.util.getOrResultError
+import eu.kanade.tachiyomi.util.lang.toDisplayMessage
 import eu.kanade.tachiyomi.util.log
 import eu.kanade.tachiyomi.util.system.withIOContext
 import kotlinx.coroutines.Dispatchers
@@ -72,14 +73,7 @@ class FollowsHandler {
                 }
                 .getOrElse {
                     TimberKt.e(it) { "Error fetching all follows" }
-                    val errorMessage = it.message ?: ""
-                    val reason =
-                        if (errorMessage.isBlank() || errorMessage.equals("unknown error", true)) {
-                            it.javaClass.simpleName
-                        } else {
-                            errorMessage
-                        }
-                    Err(ResultError.Generic(reason))
+                    Err(ResultError.Generic(it.toDisplayMessage()))
                 }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/external/ComikeyHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/external/ComikeyHandler.kt
@@ -256,7 +256,7 @@ class ComikeyHandler {
                         const manifest = JSON.parse(document.querySelector("#lmao-init").textContent).manifest;
                         window.__interface__.passPayload(manifest, act, await e.detail);
                     } catch (e) {
-                        window.__interface__.passError(e.message || "Unknown error");
+                        window.__interface__.passError(e.message || e.name || "Unknown error");
                     }
                 },
                 { once: true },

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/external/ComikeyHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/external/ComikeyHandler.kt
@@ -256,7 +256,7 @@ class ComikeyHandler {
                         const manifest = JSON.parse(document.querySelector("#lmao-init").textContent).manifest;
                         window.__interface__.passPayload(manifest, act, await e.detail);
                     } catch (e) {
-                        window.__interface__.passError("Unknown error");
+                        window.__interface__.passError(e.message || "Unknown error");
                     }
                 },
                 { once: true },

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/comix/Comix.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/comix/Comix.kt
@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ReducedHttpSource
 import eu.kanade.tachiyomi.source.online.SChapterStatusPair
+import eu.kanade.tachiyomi.util.lang.toDisplayMessage
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -101,14 +102,7 @@ class Comix : ReducedHttpSource() {
             return Ok(chapterList.map { it.toSChapter(mangaHash) to false })
         } catch (e: Exception) {
             TimberKt.e(e) { "Error fetching chapters for Comix" }
-            val errorMessage = e.message ?: ""
-            val reason =
-                if (errorMessage.isBlank() || errorMessage.equals("unknown error", true)) {
-                    e.javaClass.simpleName
-                } else {
-                    errorMessage
-                }
-            return Err(ResultError.Generic(reason))
+            return Err(ResultError.Generic(e.toDisplayMessage()))
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/comix/Comix.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/comix/Comix.kt
@@ -15,6 +15,7 @@ import okhttp3.Request
 import org.nekomanga.core.network.GET
 import org.nekomanga.core.network.interceptor.rateLimit
 import org.nekomanga.domain.network.ResultError
+import org.nekomanga.logging.TimberKt
 import tachiyomi.core.network.await
 
 class Comix : ReducedHttpSource() {
@@ -99,7 +100,15 @@ class Comix : ReducedHttpSource() {
 
             return Ok(chapterList.map { it.toSChapter(mangaHash) to false })
         } catch (e: Exception) {
-            return Err(ResultError.Generic(e.message ?: "Unknown error"))
+            TimberKt.e(e) { "Error fetching chapters for Comix" }
+            val errorMessage = e.message ?: ""
+            val reason =
+                if (errorMessage.isBlank() || errorMessage.equals("unknown error", true)) {
+                    e.javaClass.simpleName
+                } else {
+                    errorMessage
+                }
+            return Err(ResultError.Generic(reason))
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/projectsuki/ProjectSuki.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/projectsuki/ProjectSuki.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ReducedHttpSource
 import eu.kanade.tachiyomi.source.online.SChapterStatusPair
 import eu.kanade.tachiyomi.util.asJsoup
+import eu.kanade.tachiyomi.util.lang.toDisplayMessage
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -88,14 +89,7 @@ class ProjectSuki : ReducedHttpSource() {
             Ok(chapters.map { it to false })
         } catch (e: Exception) {
             TimberKt.e(e) { "Error fetching chapters for Project Suki" }
-            val errorMessage = e.message ?: ""
-            val reason =
-                if (errorMessage.isBlank() || errorMessage.equals("unknown error", true)) {
-                    e.javaClass.simpleName
-                } else {
-                    errorMessage
-                }
-            Err(ResultError.Generic(reason))
+            Err(ResultError.Generic(e.toDisplayMessage()))
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/projectsuki/ProjectSuki.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/projectsuki/ProjectSuki.kt
@@ -32,6 +32,7 @@ import org.nekomanga.core.network.GET
 import org.nekomanga.core.network.POST
 import org.nekomanga.domain.chapter.SimpleChapter
 import org.nekomanga.domain.network.ResultError
+import org.nekomanga.logging.TimberKt
 import tachiyomi.core.network.await
 
 class ProjectSuki : ReducedHttpSource() {
@@ -86,7 +87,15 @@ class ProjectSuki : ReducedHttpSource() {
             val chapters = parseChapters(document)
             Ok(chapters.map { it to false })
         } catch (e: Exception) {
-            Err(ResultError.Generic(e.message ?: "Unknown error"))
+            TimberKt.e(e) { "Error fetching chapters for Project Suki" }
+            val errorMessage = e.message ?: ""
+            val reason =
+                if (errorMessage.isBlank() || errorMessage.equals("unknown error", true)) {
+                    e.javaClass.simpleName
+                } else {
+                    errorMessage
+                }
+            Err(ResultError.Generic(reason))
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/weebdex/WeebDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/weebdex/WeebDex.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.source.online.SChapterStatusPair
 import eu.kanade.tachiyomi.source.online.merged.weebdex.dto.ChapterDto
 import eu.kanade.tachiyomi.source.online.merged.weebdex.dto.ChapterListDto
 import eu.kanade.tachiyomi.source.online.merged.weebdex.dto.MangaListDto
+import eu.kanade.tachiyomi.util.lang.toDisplayMessage
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -98,14 +99,7 @@ class WeebDex : ReducedHttpSource() {
             }
         } catch (e: Exception) {
             TimberKt.e(e) { "Error fetching chapters for WeebDex" }
-            val errorMessage = e.message ?: ""
-            val reason =
-                if (errorMessage.isBlank() || errorMessage.equals("unknown error", true)) {
-                    e.javaClass.simpleName
-                } else {
-                    errorMessage
-                }
-            return Err(ResultError.Generic(reason))
+            return Err(ResultError.Generic(e.toDisplayMessage()))
         }
 
         return Ok(chapters.map { it to false })

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/weebdex/WeebDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/weebdex/WeebDex.kt
@@ -19,6 +19,7 @@ import org.nekomanga.core.network.GET
 import org.nekomanga.core.network.interceptor.rateLimit
 import org.nekomanga.domain.chapter.SimpleChapter
 import org.nekomanga.domain.network.ResultError
+import org.nekomanga.logging.TimberKt
 import tachiyomi.core.network.await
 
 class WeebDex : ReducedHttpSource() {
@@ -96,7 +97,15 @@ class WeebDex : ReducedHttpSource() {
                 }
             }
         } catch (e: Exception) {
-            return Err(ResultError.Generic(e.message ?: "Unknown error"))
+            TimberKt.e(e) { "Error fetching chapters for WeebDex" }
+            val errorMessage = e.message ?: ""
+            val reason =
+                if (errorMessage.isBlank() || errorMessage.equals("unknown error", true)) {
+                    e.javaClass.simpleName
+                } else {
+                    errorMessage
+                }
+            return Err(ResultError.Generic(reason))
         }
 
         return Ok(chapters.map { it to false })

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -1220,13 +1220,10 @@ class LibraryViewModel() : ViewModel() {
                         downloadManager.downloadChapters(dbManga, unreadDbChapters)
                     }
                     DownloadAction.DownloadUnread -> {
-                        val unreadDbChapters =
-                            chapterItems
-                                .mapNotNull { item ->
-                                    item.chapter.takeIf { !it.read }?.toDbChapter()
-                                }
-                                
-                                
+                        val unreadDbChapters = chapterItems.mapNotNull { item ->
+                            item.chapter.takeIf { !it.read }?.toDbChapter()
+                        }
+
                         downloadManager.downloadChapters(dbManga, unreadDbChapters)
                     }
                     DownloadAction.RemoveAll -> {
@@ -1236,13 +1233,10 @@ class LibraryViewModel() : ViewModel() {
                         )
                     }
                     DownloadAction.RemoveRead -> {
-                        val readDbChapters =
-                            chapterItems
-                                .mapNotNull { item ->
-                                    item.chapter.takeIf { it.read }?.toDbChapter()
-                                }
-                                
-                                
+                        val readDbChapters = chapterItems.mapNotNull { item ->
+                            item.chapter.takeIf { it.read }?.toDbChapter()
+                        }
+
                         downloadManager.deleteChapters(dbManga, readDbChapters)
                     }
                     else -> Unit

--- a/app/src/main/java/eu/kanade/tachiyomi/util/lang/ThrowableExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/lang/ThrowableExtensions.kt
@@ -1,0 +1,10 @@
+package eu.kanade.tachiyomi.util.lang
+
+fun Throwable.toDisplayMessage(): String {
+    val message = this.message.orEmpty()
+    return if (message.isBlank() || message.equals("unknown error", true)) {
+        this.javaClass.simpleName
+    } else {
+        message
+    }
+}


### PR DESCRIPTION
Replaces generic "unknown error" messages in LibraryUpdateJob and various source handlers with the simple name of the thrown Exception (e.g., SocketTimeoutException) when the original error message is blank or "unknown error". This provides a more definitive reason for failures.

---
*PR created automatically by Jules for task [9622099022477437650](https://jules.google.com/task/9622099022477437650) started by @nonproto*