### PR TITLE
test: [ChapterItemSort] test coverage

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -1,3 +1,6 @@
 ## 2026-03-21 - StorageManager Testing Insights
 **Learning:** `ModifyMangaUseCase` relies on global injection of `StorageManager` via `Injekt`. Furthermore, `DownloadProvider` internally relies on injected dependencies (`StorageManager` and `SourceManager`) which must be registered with `Injekt` before tests instantiate or mock `DownloadProvider`.
 **Action:** When testing classes that interact with download or storage subsystems, ensure `Injekt.addSingleton(...)` is configured for any globally required dependencies (like `StorageManager` or `SourceManager`) even if they are mocked and passed directly via constructors.
+## 2024-03-28 - Testing ChapterItemSort getNextUnreadChapter
+**Learning:** Injekt framework requires explicit mocking of internal dependencies. The preferences structure `MangaDetailsPreferences` is highly nested and requires chained mocking for values like `sortDescending().get()` and `sortChapterOrder().get()`. `MockK` matches explicit property calls well.
+**Action:** When testing components relying on nested preferences, ensure to mock the entire call chain (`preference.method().get()`) to avoid `NullPointerException` during test execution.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -1220,13 +1220,10 @@ class LibraryViewModel() : ViewModel() {
                         downloadManager.downloadChapters(dbManga, unreadDbChapters)
                     }
                     DownloadAction.DownloadUnread -> {
-                        val unreadDbChapters =
-                            chapterItems
-                                .mapNotNull { item ->
-                                    item.chapter.takeIf { !it.read }?.toDbChapter()
-                                }
-                                
-                                
+                        val unreadDbChapters = chapterItems.mapNotNull { item ->
+                            item.chapter.takeIf { !it.read }?.toDbChapter()
+                        }
+
                         downloadManager.downloadChapters(dbManga, unreadDbChapters)
                     }
                     DownloadAction.RemoveAll -> {
@@ -1236,13 +1233,10 @@ class LibraryViewModel() : ViewModel() {
                         )
                     }
                     DownloadAction.RemoveRead -> {
-                        val readDbChapters =
-                            chapterItems
-                                .mapNotNull { item ->
-                                    item.chapter.takeIf { it.read }?.toDbChapter()
-                                }
-                                
-                                
+                        val readDbChapters = chapterItems.mapNotNull { item ->
+                            item.chapter.takeIf { it.read }?.toDbChapter()
+                        }
+
                         downloadManager.deleteChapters(dbManga, readDbChapters)
                     }
                     else -> Unit

--- a/app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterItemSortTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterItemSortTest.kt
@@ -1,0 +1,177 @@
+package eu.kanade.tachiyomi.util.chapter
+
+import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.data.database.models.MangaImpl
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.nekomanga.constants.MdConstants
+import org.nekomanga.domain.chapter.ChapterItem
+import org.nekomanga.domain.chapter.SimpleChapter
+import org.nekomanga.domain.details.MangaDetailsPreferences
+
+class ChapterItemSortTest {
+
+    private lateinit var chapterFilter: ChapterItemFilter
+    private lateinit var preferencesHelper: PreferencesHelper
+    private lateinit var mangaDetailsPreferences: MangaDetailsPreferences
+    private lateinit var chapterItemSort: ChapterItemSort
+
+    @Before
+    fun setup() {
+        chapterFilter = mockk()
+        preferencesHelper = mockk()
+        mangaDetailsPreferences = mockk()
+
+        // Arrange
+        chapterItemSort = ChapterItemSort(chapterFilter, preferencesHelper, mangaDetailsPreferences)
+    }
+
+    @Test
+    fun `given unread chapters when getNextUnreadChapter then returns the first available unread chapter ignoring unsupported groups`() {
+        // Arrange
+        val manga = MangaImpl().apply { chapter_flags = Manga.CHAPTER_SORTING_SOURCE }
+
+        every { mangaDetailsPreferences.chaptersDescAsDefault().get() } returns true
+        every { mangaDetailsPreferences.sortChapterOrder().get() } returns
+            Manga.CHAPTER_SORTING_SOURCE
+
+        val chapter1 =
+            ChapterItem(
+                chapter =
+                    SimpleChapter(
+                        id = 1,
+                        mangaId = 1,
+                        read = true, // Read, should be skipped
+                        bookmark = false,
+                        lastPageRead = 0,
+                        dateFetch = 0,
+                        sourceOrder = 1,
+                        url = "",
+                        name = "Chapter 1",
+                        dateUpload = 0,
+                        chapterNumber = 1f,
+                        pagesLeft = 0,
+                        volume = "1",
+                        chapterText = "1",
+                        chapterTitle = "Title",
+                        language = "en",
+                        mangaDexChapterId = "1",
+                        oldMangaDexChapterId = null,
+                        scanlator = "ValidGroup",
+                        smartOrder = 1,
+                        uploader = "1",
+                        isUnavailable = false,
+                    ),
+                downloadState = mockk(),
+                downloadProgress = 0,
+            )
+
+        val chapter2 =
+            ChapterItem(
+                chapter =
+                    SimpleChapter(
+                        id = 2,
+                        mangaId = 1,
+                        read = false, // Unread, but unsupported group
+                        bookmark = false,
+                        lastPageRead = 0,
+                        dateFetch = 0,
+                        sourceOrder = 2,
+                        url = "",
+                        name = "Chapter 2",
+                        dateUpload = 0,
+                        chapterNumber = 2f,
+                        pagesLeft = 0,
+                        volume = "1",
+                        chapterText = "2",
+                        chapterTitle = "Title",
+                        language = "en",
+                        mangaDexChapterId = "2",
+                        oldMangaDexChapterId = null,
+                        scanlator =
+                            MdConstants.UnsupportedOfficialGroupList.first(), // Unsupported group
+                        smartOrder = 2,
+                        uploader = "1",
+                        isUnavailable = false,
+                    ),
+                downloadState = mockk(),
+                downloadProgress = 0,
+            )
+
+        val chapter3 =
+            ChapterItem(
+                chapter =
+                    SimpleChapter(
+                        id = 3,
+                        mangaId = 1,
+                        read = false, // Unread, valid group, unavailable
+                        bookmark = false,
+                        lastPageRead = 0,
+                        dateFetch = 0,
+                        sourceOrder = 3,
+                        url = "",
+                        name = "Chapter 3",
+                        dateUpload = 0,
+                        chapterNumber = 3f,
+                        pagesLeft = 0,
+                        volume = "1",
+                        chapterText = "3",
+                        chapterTitle = "Title",
+                        language = "en",
+                        mangaDexChapterId = "3",
+                        oldMangaDexChapterId = null,
+                        scanlator = "ValidGroup",
+                        smartOrder = 3,
+                        uploader = "1",
+                        isUnavailable = true,
+                    ),
+                downloadState = mockk(),
+                downloadProgress = 0,
+            )
+
+        val chapter4 =
+            ChapterItem(
+                chapter =
+                    SimpleChapter(
+                        id = 4,
+                        mangaId = 1,
+                        read = false, // Unread, valid group, available - SHOULD BE CHOSEN
+                        bookmark = false,
+                        lastPageRead = 0,
+                        dateFetch = 0,
+                        sourceOrder = 4,
+                        url = "",
+                        name = "Chapter 4",
+                        dateUpload = 0,
+                        chapterNumber = 4f,
+                        pagesLeft = 0,
+                        volume = "1",
+                        chapterText = "4",
+                        chapterTitle = "Title",
+                        language = "en",
+                        mangaDexChapterId = "4",
+                        oldMangaDexChapterId = null,
+                        scanlator = "ValidGroup",
+                        smartOrder = 4,
+                        uploader = "1",
+                        isUnavailable = false,
+                    ),
+                downloadState = mockk(),
+                downloadProgress = 0,
+            )
+
+        val chapters = listOf(chapter1, chapter2, chapter3, chapter4)
+
+        every { chapterFilter.filterChapters(chapters, manga) } returns chapters
+
+        // Act
+        val result = chapterItemSort.getNextUnreadChapter(manga, chapters)
+
+        // Assert
+        assertEquals(4L, result?.chapter?.id)
+    }
+}


### PR DESCRIPTION
💡 What: The new test added adds coverage for `ChapterItemSort.getNextUnreadChapter`. Specifically, it checks how the algorithm ignores unsupported scanlator groups and correctly selects the next available unread chapter.

🎯 Why: To ensure the algorithm properly skips read, unsupported, and unavailable chapters, avoiding potential regressions in user reading flow when jumping to the next chapter.

---
*PR created automatically by Jules for task [16702005526360672927](https://jules.google.com/task/16702005526360672927) started by @nonproto*