### PR TITLE
fix: update LibraryManga equals to check alt titles

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/LibraryManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/LibraryManga.kt
@@ -36,6 +36,8 @@ class LibraryManga : MangaImpl() {
             dynamic_cover == other.dynamic_cover &&
             user_cover == other.user_cover &&
             thumbnail_url == other.thumbnail_url &&
+            user_title == other.user_title &&
+            alt_titles == other.alt_titles &&
             title == other.title
     }
 
@@ -50,6 +52,8 @@ class LibraryManga : MangaImpl() {
         result = 31 * result + (dynamic_cover?.hashCode() ?: 0)
         result = 31 * result + (user_cover?.hashCode() ?: 0)
         result = 31 * result + (thumbnail_url?.hashCode() ?: 0)
+        result = 31 * result + (user_title?.hashCode() ?: 0)
+        result = 31 * result + (alt_titles?.hashCode() ?: 0)
         result = 31 * result + title.hashCode()
         return result
     }


### PR DESCRIPTION
When a user changes a manga's title to one of its alternative titles via `user_title`, the change is saved to the database. However, the library screen did not reflect this change because the `LibraryManga` class's custom `equals` and `hashCode` methods did not compare `user_title` or `alt_titles`. Therefore, when the database re-emitted the manga list, `StateFlow`'s `distinctUntilChanged` interpreted the items as equal, failing to trigger a re-render.

This PR adds `user_title` and `alt_titles` to the `equals()` and `hashCode()` checks in `LibraryManga`, ensuring the UI correctly updates when an alt title is selected.

Tests run:
- `./gradlew testDebugUnitTest` passed

---
*PR created automatically by Jules for task [13384120347294252236](https://jules.google.com/task/13384120347294252236) started by @nonproto*