### PR TITLE
chore: bump decoder and unifile dep commits

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,10 +61,10 @@ sqlite-android = { module = "com.github.requery:sqlite-android", version.ref = "
 storio-sqlite = "com.github.inorichi.storio:storio-sqlite:8be19de"
 storio-common = "com.github.inorichi.storio:storio-common:8be19de"
 sqlite = { module = "androidx.sqlite:sqlite", version.ref = "sqliteVersion" }
-tachi-image-decoder = "com.github.ivaniskandar:image-decoder:d7e0d3dfaa"
+tachi-image-decoder = "com.github.ivaniskandar:image-decoder:41c059e540"
 tachi-source-api = "org.tachiyomi:source-api:1.1"
 tachi-directional-view-pager = "com.github.tachiyomiorg:DirectionalViewPager:1.0.0"
-tachi-unifile = "com.github.tachiyomiorg:unifile:a9de196cc7"
+tachi-unifile = "com.github.tachiyomiorg:unifile:e0def6b3dc"
 
 
 # TLS 1.3 support for Android < 10


### PR DESCRIPTION
~~Update to the versions used by mihon~~

Nvm, they are up to date