### PR TITLE
fix: add contentDescription to ExpandableRow

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/ExpandableRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ExpandableRow.kt
@@ -15,7 +15,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import org.nekomanga.R
 import org.nekomanga.presentation.theme.Size
 
 @Composable
@@ -51,9 +53,14 @@ fun ExpandableRow(
                 true -> Icons.Default.ExpandLess
                 false -> Icons.Default.ExpandMore
             }
+        val contentDescription =
+            when (isExpanded) {
+                true -> stringResource(id = R.string.collapse)
+                false -> stringResource(id = R.string.expand)
+            }
         Icon(
             imageVector = icon,
-            contentDescription = null,
+            contentDescription = contentDescription,
             tint =
                 if (!disabled) textColor
                 else MaterialTheme.colorScheme.onSurface.copy(NekoColors.disabledAlphaLowContrast),

--- a/constants/src/main/res/values/strings.xml
+++ b/constants/src/main/res/values/strings.xml
@@ -216,6 +216,8 @@
     <string name="open_random_series">Open a random series</string>
     <string name="expand_all_categories">Expand all categories</string>
     <string name="collapse_all_categories">Collapse all categories</string>
+    <string name="expand">Expand</string>
+    <string name="collapse">Collapse</string>
     <string name="reorder_filters">Reorder filters</string>
     <string name="_unread">%d unread</string>
     <string name="search_library">Search library</string>


### PR DESCRIPTION
Added `contentDescription` attributes to the `ExpandableRow`'s `Icon` using localized string resources ("Expand" and "Collapse").

This fixes an issue where the expand/collapse icon was completely hidden from accessibility services due to `contentDescription = null`, preventing TalkBack users from understanding the state or purpose of the button. The strings were properly added to the `constants` resource directory so they can be reused and localized.

---
*PR created automatically by Jules for task [3305903303507457312](https://jules.google.com/task/3305903303507457312) started by @nonproto*