### PR TITLE
ref: replace verbose null check with `?.let` in SimilarScreen

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/screens/SimilarScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/SimilarScreen.kt
@@ -103,26 +103,24 @@ private fun SimilarWrapper(
 
     val openSheet: (DisplaySheetScreen) -> Unit = { scope.launch { currentBottomSheet = it } }
 
-    if (currentBottomSheet != null) {
+    currentBottomSheet?.let { currentSheet ->
         ModalBottomSheet(
             sheetState = sheetState,
             onDismissRequest = { currentBottomSheet = null },
             content = {
                 Box(modifier = Modifier.defaultMinSize(minHeight = Size.extraExtraTiny)) {
-                    currentBottomSheet?.let { currentSheet ->
-                        DisplayScreenSheet(
-                            currentScreen = currentSheet,
-                            addNewCategory = addNewCategory,
-                            contentPadding =
-                                WindowInsets.navigationBars
-                                    .only(WindowInsetsSides.Bottom)
-                                    .asPaddingValues(),
-                            closeSheet = { currentBottomSheet = null },
-                            categories = similarScreenState.categories,
-                            isList = similarScreenState.isList,
-                            libraryEntryVisibility = similarScreenState.libraryEntryVisibility,
-                        )
-                    }
+                    DisplayScreenSheet(
+                        currentScreen = currentSheet,
+                        addNewCategory = addNewCategory,
+                        contentPadding =
+                            WindowInsets.navigationBars
+                                .only(WindowInsetsSides.Bottom)
+                                .asPaddingValues(),
+                        closeSheet = { currentBottomSheet = null },
+                        categories = similarScreenState.categories,
+                        isList = similarScreenState.isList,
+                        libraryEntryVisibility = similarScreenState.libraryEntryVisibility,
+                    )
                 }
             },
         )


### PR DESCRIPTION
Replaced a verbose null check in `SimilarScreen.kt` with the more idiomatic Kotlin `?.let` operator, as requested by The Steward's guidelines. This simplifies code structure and removes the redundant `if (currentBottomSheet != null)` check that wrapped an inner `.let`.

---
*PR created automatically by Jules for task [13493179458895876717](https://jules.google.com/task/13493179458895876717) started by @nonproto*