### PR TITLE
perf: fix N+1 StorIO queries in SimilarViewModel updateCovers

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/similar/SimilarViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/similar/SimilarViewModel.kt
@@ -247,7 +247,18 @@ class SimilarViewModel(val mangaUUID: String) : ViewModel() {
     }
 
     fun updateCovers() {
-        viewModelScope.launch {
+        viewModelScope.launchIO {
+            val allMangaIds =
+                _similarScreenState.value.allDisplayManga.values
+                    .flatMap { it.map { displayManga -> displayManga.mangaId } }
+                    .distinct()
+
+            val fetchedMangas =
+                allMangaIds
+                    .chunked(900)
+                    .flatMap { chunk -> db.getMangas(chunk).executeOnIO() }
+                    .associateBy { it.id }
+
             val newDisplayManga =
                 _similarScreenState.value.allDisplayManga
                     .map { entry ->
@@ -255,15 +266,20 @@ class SimilarViewModel(val mangaUUID: String) : ViewModel() {
                             entry.key,
                             entry.value
                                 .map {
-                                    val dbManga = db.getManga(it.mangaId).executeOnIO()!!
-                                    it.copy(
-                                        currentArtwork =
-                                            it.currentArtwork.copy(
-                                                cover = dbManga.user_cover ?: "",
-                                                originalCover =
-                                                    dbManga.thumbnail_url ?: MdConstants.noCoverUrl,
-                                            )
-                                    )
+                                    val dbManga = fetchedMangas[it.mangaId]
+                                    if (dbManga != null) {
+                                        it.copy(
+                                            currentArtwork =
+                                                it.currentArtwork.copy(
+                                                    cover = dbManga.user_cover ?: "",
+                                                    originalCover =
+                                                        dbManga.thumbnail_url
+                                                            ?: MdConstants.noCoverUrl,
+                                                )
+                                        )
+                                    } else {
+                                        it
+                                    }
                                 }
                                 .toPersistentList(),
                         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/similar/SimilarViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/similar/SimilarViewModel.kt
@@ -250,8 +250,11 @@ class SimilarViewModel(val mangaUUID: String) : ViewModel() {
         viewModelScope.launchIO {
             val allMangaIds =
                 _similarScreenState.value.allDisplayManga.values
-                    .flatMap { it.map { displayManga -> displayManga.mangaId } }
+                    .asSequence()
+                    .flatten()
+                    .map { it.mangaId }
                     .distinct()
+                    .toList()
 
             val fetchedMangas =
                 allMangaIds


### PR DESCRIPTION
**What:** Replaces a looping `db.getManga().executeOnIO()` call within a `map { }` collection loop with a chunked bulk database query via `db.getMangas().executeOnIO()`.

**Why:** Because querying the database sequentially for each item creates a severe N+1 problem. This blocks the execution thread with unnecessary overhead and context switching, delaying the rendering of dynamic covers.

**Impact:** Significantly reduced CPU load and background I/O contention, allowing covers in the Similar Manga screen to fetch and populate vastly faster when returning from detail views.

**Measurement:** Execution logic is bounded to O(N/900 + 1) network roundtrips to the DB instance instead of O(N) operations.

Tested via unit tests and standard app compile checks.

---
*PR created automatically by Jules for task [3821354403875106826](https://jules.google.com/task/3821354403875106826) started by @nonproto*