### PR TITLE
ref: remove outdated TODOs in SimilarHandler by implementing missing filtering

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt
@@ -213,13 +213,17 @@ class SimilarHandler {
             return
         }
 
-        val mangaListDto = getMangadexMangaList(idPairs.mapNotNull { it.key }, false)
+        val filteredIdPairs = idPairs.filterKeys { it != dexId }
+        if (filteredIdPairs.isEmpty()) return
+
+        val mangaListDto = getMangadexMangaList(filteredIdPairs.mapNotNull { it.key }, false)
 
         // Convert to lookup array
-        // TODO: Also filter out manga here that are already presented
         val thumbQuality = mangaDexPreferences.coverQuality().get()
         val mangaList =
-            mangaListDto.data.map { it.toRelatedMangaDto(thumbQuality, idPairs[it.id] ?: "") }
+            mangaListDto.data.map {
+                it.toRelatedMangaDto(thumbQuality, filteredIdPairs[it.id] ?: "")
+            }
 
         // update db
         val mangaDb = db.getSimilar(dexId).executeAsBlocking()
@@ -354,13 +358,17 @@ class SimilarHandler {
             return
         }
 
-        val mangaListDto = getMangadexMangaList(idPairs.mapNotNull { it.key }, false)
+        val filteredIdPairs = idPairs.filterKeys { it != dexId }
+        if (filteredIdPairs.isEmpty()) return
+
+        val mangaListDto = getMangadexMangaList(filteredIdPairs.mapNotNull { it.key }, false)
 
         // Convert to lookup array
-        // TODO: Also filter out manga here that are already presented
         val thumbQuality = mangaDexPreferences.coverQuality().get()
         val mangaList =
-            mangaListDto.data.map { it.toRelatedMangaDto(thumbQuality, idPairs[it.id] ?: "") }
+            mangaListDto.data.map {
+                it.toRelatedMangaDto(thumbQuality, filteredIdPairs[it.id] ?: "")
+            }
 
         // update db
         val mangaDb = db.getSimilar(dexId).executeAsBlocking()
@@ -431,13 +439,17 @@ class SimilarHandler {
             return
         }
 
-        val mangaListDto = getMangadexMangaList(idPairs.mapNotNull { it.key }, false)
+        val filteredIdPairs = idPairs.filterKeys { it != dexId }
+        if (filteredIdPairs.isEmpty()) return
+
+        val mangaListDto = getMangadexMangaList(filteredIdPairs.mapNotNull { it.key }, false)
 
         // Convert to lookup array
-        // TODO: Also filter out manga here that are already presented
         val thumbQuality = mangaDexPreferences.coverQuality().get()
         val mangaList =
-            mangaListDto.data.map { it.toRelatedMangaDto(thumbQuality, idPairs[it.id] ?: "") }
+            mangaListDto.data.map {
+                it.toRelatedMangaDto(thumbQuality, filteredIdPairs[it.id] ?: "")
+            }
 
         // update db
         val mangaDb = db.getSimilar(dexId).executeAsBlocking()

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt.orig
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SimilarHandler.kt.orig
@@ -209,6 +209,10 @@ class SimilarHandler {
                     }
                 }
                 .toMap()
+        if (idPairs.isEmpty()) {
+            return
+        }
+
         val filteredIdPairs = idPairs.filterKeys { it != dexId }
         if (filteredIdPairs.isEmpty()) return
 
@@ -350,6 +354,10 @@ class SimilarHandler {
                 val text = it.votes.toString() + " user votes"
                 id to text
             }
+        if (idPairs.isEmpty()) {
+            return
+        }
+
         val filteredIdPairs = idPairs.filterKeys { it != dexId }
         if (filteredIdPairs.isEmpty()) return
 
@@ -427,6 +435,10 @@ class SimilarHandler {
                 val text = "Similar"
                 id to text
             }
+        if (idPairs.isEmpty()) {
+            return
+        }
+
         val filteredIdPairs = idPairs.filterKeys { it != dexId }
         if (filteredIdPairs.isEmpty()) return
 


### PR DESCRIPTION
## 💡 What:
Removed the outdated `// TODO: Also filter out manga here that are already presented` comments and implemented the missing filtering logic in `SimilarHandler.kt`.

## 🎯 Why:
The code had TODOs that indicated filtering should be applied so a manga does not show up in its own "Similar", "Related", or "Recommendations" list. The old code just mapped the `idPairs` which could contain the current `dexId`.

## 🛠️ How:
Added `val filteredIdPairs = idPairs.filterKeys { it != dexId }` to filter out the current manga (`dexId`) from the recommendations list before querying MangaDex and mapping to DTOs. If the filtered list is empty, it returns early.

---
*PR created automatically by Jules for task [14435091484223014191](https://jules.google.com/task/14435091484223014191) started by @nonproto*