### PR TITLE
chore: remove dead code from FollowsHandler

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FollowsHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FollowsHandler.kt
@@ -147,31 +147,6 @@ class FollowsHandler {
 
     suspend fun updateReadingProgress(track: Track): Boolean {
         return true
-        /*return withContext(Dispatchers.IO) {
-            val mangaID = getMangaId(track.tracking_url)
-            val formBody = FormBody.Builder()
-                .add("volume", "0")
-                .add("chapter", track.last_chapter_read.toString())
-            XLog.d("chapter to update %s", track.last_chapter_read.toString())
-            val result = runCatching {
-                network.authClient.newCall(
-                    POST(
-                        "$baseUrl/ajax/actions.ajax.php?function=edit_progress&id=$mangaID",
-                        headers,
-                        formBody.build()
-                    )
-                ).execute()
-            }
-            result.exceptionOrNull()?.let {
-                if (it is EOFException) {
-                    return@withContext true
-                } else {
-                    XLog.e("error updating reading progress", it)
-                    return@withContext false
-                }
-            }
-            return@withContext result.isSuccess
-        }*/
     }
 
     suspend fun updateRating(track: Track): Boolean {


### PR DESCRIPTION
Removed commented out block of dead code from `FollowsHandler.kt` in order to clean up the file and reduce bloat. Verified code formats correctly using `./gradlew ktfmtFormat`.

---
*PR created automatically by Jules for task [8923220972555039291](https://jules.google.com/task/8923220972555039291) started by @nonproto*