### PR TITLE
fix: null catch for deleted uploaders

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/MangaHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/MangaHandler.kt
@@ -293,6 +293,6 @@ class MangaHandler {
             }
             .filter { it.type == MdConstants.Types.uploader }
             .distinctBy { it.id }
-            .associate { it.id to it.attributes!!.username!! }
+            .associate { it.id to (it.attributes?.username ?: "Deleted uploader") }
     }
 }


### PR DESCRIPTION
E.g. One of the `Chapter 1`s in https://mangadex.org/title/5cb822c0-0951-4e04-a357-4c517e43e2fd

this time the correct file