### PR TITLE
perf: Replace N+1 download queries with O(1) Map lookup in allChapterFlow

### DIFF
--- a/.jules/overclock.md
+++ b/.jules/overclock.md
@@ -26,3 +26,6 @@
 ## 2026-04-12 - Fixing N+1 Queries in BackupCreator
 **Learning:** When trying to fix N+1 queries by fetching dependencies for a whole list using `IN (?, ?, ...)`, passing an unbounded list of IDs directly into SQLite queries (e.g. via StorIO) can crash the app due to the `SQLITE_MAX_VARIABLE_NUMBER` limit (999 host parameters on older Android versions). It also causes memory spikes by trying to load massive sets of records at once.
 **Action:** When resolving N+1 queries using an `IN` clause for collections, always process the primary list in manageable chunks (e.g., `mangaList.chunked(500)`) and execute the prefetches iteratively per chunk to stay under SQLite variable limits and reduce OOM risks.
+## 2026-04-13 - [Overclock: Hot Flow Loop Lookup Optimization]
+**Learning:** Calling O(N) list lookups like `downloadManager.getQueuedDownloadOrNull` inside an O(M) mapping loop inside a hot `combine` Flow causes O(N*M) performance degradation, heavily thrashing CPU and memory by repeated iterations on list emissions, which can stutter the UI thread.
+**Action:** Pre-compute an O(1) Map representation of the list using `.associateBy { it.id }` before the loop, and use variables (like `downloadCount > 0`) to completely skip expensive IO/Cache checking functions when unnecessary.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedRepository.kt
@@ -58,7 +58,8 @@ class FeedRepository(
                         val scanlators = chapter.scanlatorList()
                         if (
                             scanlators.fastAny { scanlator -> scanlator in blockedGroups } ||
-                                (chapter.uploader in blockedUploaders && Constants.NO_GROUP in scanlators)
+                                (chapter.uploader in blockedUploaders &&
+                                    Constants.NO_GROUP in scanlators)
                         ) {
                             return@mapNotNull null
                         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -296,6 +296,19 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
      * Architecture: We injected the `mangaFlow` directly into this `combine` operator. By using the
      * emitted `mangaItem` instead of performing a synchronous query, the flow becomes fully
      * reactive and avoids I/O operations on the main flow dispatcher.
+     *
+     * SECOND MACRO-LEVEL PERFORMANCE OPTIMIZATION (Overclock):
+     *
+     * Why: Previously, `allChapterFlow` called `downloadManager.isChapterDownloaded` and
+     * `downloadManager.getQueuedDownloadOrNull` inside an O(N) map loop for every single chapter.
+     * Since `getQueuedDownloadOrNull` iterates over the list of active downloads, this created an
+     * O(N*M) bottleneck where N is chapters and M is queued items. In addition, checking the cache
+     * for downloaded chapters unconditionally causes redundant overhead.
+     *
+     * Architecture: We perform a bulk O(1) hashmap association of the queued downloads before the
+     * loop. We also check if the total `downloadCount` is 0 to completely bypass the O(N)
+     * evaluation of `isChapterDownloaded` on un-downloaded manga, saving thousands of redundant
+     * string allocations and map lookups on large libraries.
      */
     val allChapterFlow =
         combine(
@@ -305,6 +318,12 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                 mangaDexPreferences.blockedUploaders().changes(),
             ) { dbChapters, mangaItem, blockedGroups, blockedUploaders ->
                 val dbManga = mangaItem.toManga()
+
+                // Pre-compute O(1) lookups outside the loop to prevent O(N*M) thrashing
+                val downloadCount = downloadManager.getDownloadCount(dbManga)
+                val queuedDownloadsById =
+                    downloadManager.queueState.value.associateBy { it.chapterItem.id }
+
                 dbChapters.mapNotNull { dbChapter ->
                     dbChapter
                         .toSimpleChapter()
@@ -317,13 +336,13 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                         ?.let { chapter ->
                             val downloadState =
                                 when {
-                                    downloadManager.isChapterDownloaded(
-                                        chapter.toDbChapter(),
-                                        dbManga,
-                                    ) -> Download.State.DOWNLOADED
+                                    downloadCount > 0 &&
+                                        downloadManager.isChapterDownloaded(
+                                            chapter.toDbChapter(),
+                                            dbManga,
+                                        ) -> Download.State.DOWNLOADED
                                     else -> {
-                                        val download =
-                                            downloadManager.getQueuedDownloadOrNull(chapter.id)
+                                        val download = queuedDownloadsById[chapter.id]
                                         when (download == null) {
                                             true -> Download.State.NOT_DOWNLOADED
                                             false -> download.status
@@ -336,10 +355,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                                 downloadState = downloadState,
                                 downloadProgress =
                                     when (downloadState == Download.State.DOWNLOADING) {
-                                        true ->
-                                            downloadManager
-                                                .getQueuedDownloadOrNull(chapter.id)!!
-                                                .progress
+                                        true -> queuedDownloadsById[chapter.id]?.progress ?: 0
                                         false -> 0
                                     },
                             )


### PR DESCRIPTION
💡 What: Refactored `allChapterFlow` in `MangaViewModel.kt` to pre-compute an O(1) hashmap association of queued downloads before mapping over the chapters. Added a fast-path boolean check on the total download count.

🎯 Why: Previously, `allChapterFlow` called `downloadManager.isChapterDownloaded` and `downloadManager.getQueuedDownloadOrNull` inside an O(N) `.mapNotNull` loop for every single chapter. Because `getQueuedDownloadOrNull` sequentially searched the list of active downloads, this created an O(N*M) bottleneck. The `isChapterDownloaded` check also unconditionally invoked cache and file-system checks, causing redundant string allocations and thrashing on un-downloaded manga.

🏗️ Architecture: We now fetch `val downloadCount = downloadManager.getDownloadCount(dbManga)` and create `val queuedDownloadsById = downloadManager.queueState.value.associateBy { it.chapterItem.id }` outside the loop. We short-circuit the downloaded check if `downloadCount == 0`, completely skipping expensive cache/IO calls when unnecessary.

📊 Impact: Massively reduces CPU and memory thrashing when the UI state recalculates for manga with hundreds of chapters, dropping the mapping complexity from O(N*M) down to O(N). Prevents UI thread stuttering during active downloads or sorting.

---
*PR created automatically by Jules for task [14089244907167970978](https://jules.google.com/task/14089244907167970978) started by @nonproto*