### PR TITLE
chore: remove unresolved opt-in compiler warnings in Gradle modules

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -182,3 +182,34 @@ dependencies {
 }
 
 tasks.withType<Test> { useJUnit() }
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        freeCompilerArgs.addAll(listOf("-opt-in=kotlin.Experimental"))
+        freeCompilerArgs.addAll(
+            listOf("-opt-in=androidx.compose.material3.ExperimentalMaterial3Api")
+        )
+        freeCompilerArgs.addAll(listOf("-opt-in=androidx.compose.material.ExperimentalMaterialApi"))
+        freeCompilerArgs.addAll(
+            listOf(
+                "-opt-in=androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi"
+            )
+        )
+        freeCompilerArgs.addAll(
+            listOf("-opt-in=androidx.compose.material3.ExperimentalMaterial3ExpressiveApi")
+        )
+        freeCompilerArgs.addAll(
+            listOf("-opt-in=androidx.compose.animation.graphics.ExperimentalAnimationGraphicsApi")
+        )
+        freeCompilerArgs.addAll(
+            listOf("-opt-in=androidx.compose.foundation.layout.ExperimentalLayoutApi")
+        )
+        freeCompilerArgs.addAll(
+            listOf("-opt-in=androidx.compose.foundation.ExperimentalFoundationApi")
+        )
+        freeCompilerArgs.addAll(listOf("-opt-in=coil3.annotation.ExperimentalCoilApi"))
+        freeCompilerArgs.addAll(
+            listOf("-opt-in=kotlinx.serialization.ExperimentalSerializationApi")
+        )
+    }
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id(androidx.plugins.application.get().pluginId)
     id(kotlinx.plugins.android.get().pluginId)
@@ -183,33 +185,20 @@ dependencies {
 
 tasks.withType<Test> { useJUnit() }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+tasks.withType<KotlinCompile> {
     compilerOptions {
-        freeCompilerArgs.addAll(listOf("-opt-in=kotlin.Experimental"))
-        freeCompilerArgs.addAll(
-            listOf("-opt-in=androidx.compose.material3.ExperimentalMaterial3Api")
-        )
-        freeCompilerArgs.addAll(listOf("-opt-in=androidx.compose.material.ExperimentalMaterialApi"))
         freeCompilerArgs.addAll(
             listOf(
-                "-opt-in=androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi"
+                "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
+                "-opt-in=androidx.compose.material.ExperimentalMaterialApi",
+                "-opt-in=androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi",
+                "-opt-in=androidx.compose.material3.ExperimentalMaterial3ExpressiveApi",
+                "-opt-in=androidx.compose.animation.graphics.ExperimentalAnimationGraphicsApi",
+                "-opt-in=androidx.compose.foundation.layout.ExperimentalLayoutApi",
+                "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
+                "-opt-in=coil3.annotation.ExperimentalCoilApi",
+                "-opt-in=kotlinx.serialization.ExperimentalSerializationApi",
             )
-        )
-        freeCompilerArgs.addAll(
-            listOf("-opt-in=androidx.compose.material3.ExperimentalMaterial3ExpressiveApi")
-        )
-        freeCompilerArgs.addAll(
-            listOf("-opt-in=androidx.compose.animation.graphics.ExperimentalAnimationGraphicsApi")
-        )
-        freeCompilerArgs.addAll(
-            listOf("-opt-in=androidx.compose.foundation.layout.ExperimentalLayoutApi")
-        )
-        freeCompilerArgs.addAll(
-            listOf("-opt-in=androidx.compose.foundation.ExperimentalFoundationApi")
-        )
-        freeCompilerArgs.addAll(listOf("-opt-in=coil3.annotation.ExperimentalCoilApi"))
-        freeCompilerArgs.addAll(
-            listOf("-opt-in=kotlinx.serialization.ExperimentalSerializationApi")
         )
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,23 +28,13 @@ subprojects {
         freeCompilerArgs.addAll(
             listOf(
                 "-Xcontext-parameters",
-                "-opt-in=kotlin.Experimental",
                 "-opt-in=kotlin.RequiresOptIn",
-                "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-                "-opt-in=androidx.compose.material.ExperimentalMaterialApi",
-                "-opt-in=androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi",
-                "-opt-in=androidx.compose.material3.ExperimentalMaterial3ExpressiveApi",
-                "-opt-in=androidx.compose.animation.graphics.ExperimentalAnimationGraphicsApi",
-                "-opt-in=androidx.compose.foundation.layout.ExperimentalLayoutApi",
                 "-opt-in=kotlin.time.ExperimentalTime",
                 "-opt-in=kotlinx.coroutines.DelicateCoroutinesApi",
-                "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
-                "-opt-in=coil3.annotation.ExperimentalCoilApi",
                 "-opt-in=kotlin.ExperimentalStdlibApi",
                 "-opt-in=kotlinx.coroutines.FlowPreview",
                 "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
                 "-opt-in=kotlinx.coroutines.InternalCoroutinesApi",
-                "-opt-in=kotlinx.serialization.ExperimentalSerializationApi",
             )
         )
       }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -24,3 +24,11 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.bundles.firebase)
 }
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            listOf("-opt-in=kotlinx.serialization.ExperimentalSerializationApi")
+        )
+    }
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id(androidx.plugins.library.get().pluginId)
     id(kotlinx.plugins.android.get().pluginId)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     implementation(libs.bundles.firebase)
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+tasks.withType<KotlinCompile> {
     compilerOptions {
         freeCompilerArgs.addAll(
             listOf("-opt-in=kotlinx.serialization.ExperimentalSerializationApi")


### PR DESCRIPTION
💡 What:
Removed Compose-specific and Serialization-specific opt-in flags out of the root `build.gradle.kts` and placed them into the specific modules that actually need them (`app` and `core`).

🎯 Why:
To prevent Kotlin compiler warnings about unresolved opt-in requirement markers in modules like `constants` that do not depend on Jetpack Compose or Kotlinx Serialization. This correctly isolates module dependencies and clears up terminal warnings during builds.

---
*PR created automatically by Jules for task [3894625879531855744](https://jules.google.com/task/3894625879531855744) started by @nonproto*