### PR TITLE
ref: extract date formatting preferences into GetDateFormatUseCase

### DIFF
--- a/.jules/distiller.md
+++ b/.jules/distiller.md
@@ -7,3 +7,6 @@
 ## 2026-04-13 - Extracting MarkPreviousChaptersUseCase
 **Learning:** When trying to instantiate data classes like `Chapter` or `ChapterItem` for unit testing, the implementation classes (`ChapterImpl`) can be cumbersome. The instruction "Use Mockk" implies that we should create mocks via MockK (`mockk<Chapter>()`) instead of manually instantiating or using `apply`.
 **Action:** When asked to "use MockK" for unit tests on domain layer extractions, mock the entity directly using `mockk<Type>()` and stub the fields using `every { field } returns ...` rather than spending cycles trying to find the appropriate `Impl.create().apply {}` equivalent.
+## 2026-04-13 - Extracting GetDateFormatUseCase
+**Learning:** Injekt binds components directly to the Use Case implementations using `addSingletonFactory { MyUseCase(get()) }`. Note that mocking objects correctly with MockK for unit testing requires careful attention to matching the precise signature expected by the actual class, especially when default parameters are at play, otherwise `NullPointerException` or similar mock errors will be raised.
+**Action:** When extracting Use Cases that fetch preferences with default values, be cautious about testing them without proper mock signatures and default arguments unless explicitly told to skip tests.

--- a/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
@@ -58,6 +58,7 @@ import org.nekomanga.usecases.chapters.CalculateChapterFilterUseCase
 import org.nekomanga.usecases.chapters.ChapterUseCases
 import org.nekomanga.usecases.library.FilterLibraryMangaUseCase
 import org.nekomanga.usecases.manga.MangaUseCases
+import org.nekomanga.usecases.preferences.GetDateFormatUseCase
 import org.nekomanga.usecases.tracking.TrackUseCases
 import tachiyomi.core.preference.AndroidPreferenceStore
 import tachiyomi.core.preference.PreferenceStore
@@ -217,5 +218,6 @@ class PreferenceModule(val application: Application) : InjektModule {
         addSingletonFactory { MangaDexPreferences(get()) }
 
         addSingletonFactory { PreferencesHelper(context = application, preferenceStore = get()) }
+        addSingletonFactory { GetDateFormatUseCase(get<PreferencesHelper>()) }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/feed/FeedRepository.kt
@@ -58,7 +58,8 @@ class FeedRepository(
                         val scanlators = chapter.scanlatorList()
                         if (
                             scanlators.fastAny { scanlator -> scanlator in blockedGroups } ||
-                                (chapter.uploader in blockedUploaders && Constants.NO_GROUP in scanlators)
+                                (chapter.uploader in blockedUploaders &&
+                                    Constants.NO_GROUP in scanlators)
                         ) {
                             return@mapNotNull null
                         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -56,6 +56,7 @@ import eu.kanade.tachiyomi.util.system.launchNonCancellable
 import eu.kanade.tachiyomi.util.system.launchUI
 import eu.kanade.tachiyomi.util.system.openInWebView
 import eu.kanade.tachiyomi.util.system.withIOContext
+import java.text.DateFormat
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentSet
@@ -125,6 +126,7 @@ import org.nekomanga.usecases.chapters.ChapterUseCases
 import org.nekomanga.usecases.chapters.GetChapterFilterText
 import org.nekomanga.usecases.manga.MangaUseCases
 import org.nekomanga.usecases.manga.MergeMangaUseCases
+import org.nekomanga.usecases.preferences.GetDateFormatUseCase
 import tachiyomi.core.util.storage.DiskUtil
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -142,8 +144,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
     }
 
     private val preferences: PreferencesHelper = Injekt.get()
-    private val getDateFormatUseCase: org.nekomanga.usecases.preferences.GetDateFormatUseCase =
-        Injekt.get()
+    private val getDateFormatUseCase: GetDateFormatUseCase = Injekt.get()
     private val mangaDexPreferences: MangaDexPreferences = Injekt.get()
     val libraryPreferences: LibraryPreferences = Injekt.get()
     val securityPreferences: SecurityPreferences = Injekt.get()
@@ -2439,7 +2440,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
         }
     }
 
-    fun getDateFormat(): java.text.DateFormat {
+    fun getDateFormat(): DateFormat {
         return getDateFormatUseCase()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -141,7 +141,9 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
         private const val DYNAMIC_COVER_UPDATE_DELAY_MS = 1000L
     }
 
-    val preferences: PreferencesHelper = Injekt.get()
+    private val preferences: PreferencesHelper = Injekt.get()
+    private val getDateFormatUseCase: org.nekomanga.usecases.preferences.GetDateFormatUseCase =
+        Injekt.get()
     private val mangaDexPreferences: MangaDexPreferences = Injekt.get()
     val libraryPreferences: LibraryPreferences = Injekt.get()
     val securityPreferences: SecurityPreferences = Injekt.get()
@@ -2435,6 +2437,10 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
             val dbManga = effectiveManga.copy(dynamicCover = url).toManga()
             db.insertManga(dbManga).executeOnIO()
         }
+    }
+
+    fun getDateFormat(): java.text.DateFormat {
+        return getDateFormatUseCase()
     }
 }
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
@@ -185,7 +185,7 @@ fun MangaScreen(
             }
         },
         onToggleFavorite = mangaViewModel::toggleFavorite,
-        dateFormat = mangaViewModel.getDateFormat(),
+        dateFormat = remember { mangaViewModel.getDateFormat() },
         trackActions =
             TrackActions(
                 statusChange = { statusIndex, trackAndService ->

--- a/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
@@ -185,7 +185,7 @@ fun MangaScreen(
             }
         },
         onToggleFavorite = mangaViewModel::toggleFavorite,
-        dateFormat = mangaViewModel.preferences.dateFormat(),
+        dateFormat = mangaViewModel.getDateFormat(),
         trackActions =
             TrackActions(
                 statusChange = { statusIndex, trackAndService ->

--- a/app/src/main/java/org/nekomanga/usecases/preferences/GetDateFormatUseCase.kt
+++ b/app/src/main/java/org/nekomanga/usecases/preferences/GetDateFormatUseCase.kt
@@ -1,0 +1,10 @@
+package org.nekomanga.usecases.preferences
+
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import java.text.DateFormat
+
+class GetDateFormatUseCase(private val preferences: PreferencesHelper) {
+    operator fun invoke(): DateFormat {
+        return preferences.dateFormat()
+    }
+}


### PR DESCRIPTION
💡 What: Extracted `preferences.dateFormat()` logic into a dedicated `GetDateFormatUseCase`. Updated `MangaViewModel` and `MangaScreen` to utilize the new Use Case rather than accessing preferences directly. Registered the new Use Case in `AppModule.kt`. 

🎯 Why: To enforce the Single Responsibility Principle, removing raw preference data reads from the UI layer and isolating domain logic into dedicated, reusable Use Cases.

---
*PR created automatically by Jules for task [12883460886429636339](https://jules.google.com/task/12883460886429636339) started by @nonproto*