### PR TITLE
ref: extract hardcoded dimensions to theme in MangaGridView

### DIFF
--- a/.jules/artisan.md
+++ b/.jules/artisan.md
@@ -1,0 +1,1 @@
+## 2024-05-24 - MangaGridView Hardcoded Value **Learning:** `MangaGridView.kt` contained a hardcoded `2.dp` padding that did not align with the AppTheme. **Action:** Next time, scan for hardcoded DP values using `grep` or similar tooling before assuming UI components are fully utilizing `Size` design tokens like `Size.extraTiny`.

--- a/app/src/main/java/org/nekomanga/presentation/components/MangaGridView.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/MangaGridView.kt
@@ -210,7 +210,7 @@ fun MangaGridItem(
         }
 
     Box(modifier = modifier) {
-        Box(modifier = Modifier.padding(start = 2.dp, top = 2.dp)) {
+        Box(modifier = Modifier.padding(start = Size.extraTiny, top = Size.extraTiny)) {
             Box(
                 modifier =
                     Modifier.clip(RoundedCornerShape(Shapes.coverRadius))


### PR DESCRIPTION
💡 What: Extracted a hardcoded `2.dp` dimension for `start` and `top` padding in `MangaGridView.kt` to instead use the application's central design token `Size.extraTiny`.
🎯 Why: To standardize styling and ensure Compose DSL remains clean according to the Artisan guidelines.
📍 Visual/Accessibility Impacts: No visual change, strict architectural refactoring.

---
*PR created automatically by Jules for task [15814880063480999523](https://jules.google.com/task/15814880063480999523) started by @nonproto*