### PR TITLE
perf: remove intermediate list allocation in allSelected computation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@ Action: Always append `.distinctUntilChanged()` after `combine()` blocks that ag
 ## 2026-03-31 - [Filter-Map Chain Optimization]
 **Learning:** Chaining `.filterNot { ... }` with `.mapNotNull { ... }` generates an intermediate List allocation in memory before mapping. Using `.asSequence()` works but adds overhead.
 **Action:** Replace `list.filterNot { cond }.mapNotNull { transform(it) }` with a single pass `list.mapNotNull { if(cond) null else transform(it) }` for small-to-medium lists to save allocations and GC churn without the sequence overhead.
+## 2026-04-03 - [Avoid Intermediate Lists with all]
+**Learning:** Chaining `.map { ... }.all { ... }` creates an intermediate list of transformed elements, which adds memory allocation and garbage collection overhead. This is especially true for list iteration within Compose state changes (`derivedStateOf`, `remember` triggers).
+**Action:** Replace `.map { ... }.all { ... }` with a single `.all { transformedElement -> ... }` to avoid the intermediate list creation and improve iteration performance, particularly in frequently recomposed UI areas.

--- a/app/src/main/java/org/nekomanga/presentation/screens/library/HorizontalCategoriesPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/library/HorizontalCategoriesPage.kt
@@ -160,9 +160,9 @@ fun HorizontalCategoriesPage(
                     remember(selectionMode, selectedIds) {
                         mutableStateOf(
                             item.libraryItems.isNotEmpty() &&
-                                item.libraryItems
-                                    .map { it.displayManga.mangaId }
-                                    .all { id -> id in selectedIds }
+                                item.libraryItems.all { libraryItem ->
+                                    libraryItem.displayManga.mangaId in selectedIds
+                                }
                         )
                     }
                 when (libraryScreenState.libraryDisplayMode) {

--- a/app/src/main/java/org/nekomanga/presentation/screens/library/VerticalCategoriesPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/library/VerticalCategoriesPage.kt
@@ -122,9 +122,9 @@ fun VerticalCategoriesPage(
                     selectionMode = selectionMode,
                     allSelected =
                         item.libraryItems.isNotEmpty() &&
-                            item.libraryItems
-                                .map { it.displayManga.mangaId }
-                                .all { id -> id in selectedIds },
+                            item.libraryItems.all { libraryItem ->
+                                libraryItem.displayManga.mangaId in selectedIds
+                            },
                     isCollapsible = collapsible,
                     categoryItemClick = {
                         if (selectionMode) {

--- a/app/src/main/java/org/nekomanga/presentation/screens/library/VerticalCategoriesPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/library/VerticalCategoriesPage.kt
@@ -121,10 +121,12 @@ fun VerticalCategoriesPage(
                     isRefreshing = item.isRefreshing,
                     selectionMode = selectionMode,
                     allSelected =
-                        item.libraryItems.isNotEmpty() &&
-                            item.libraryItems.all { libraryItem ->
-                                libraryItem.displayManga.mangaId in selectedIds
-                            },
+                        remember(item.libraryItems, selectedIds) {
+                            item.libraryItems.isNotEmpty() &&
+                                item.libraryItems.all { libraryItem ->
+                                    libraryItem.displayManga.mangaId in selectedIds
+                                }
+                        },
                     isCollapsible = collapsible,
                     categoryItemClick = {
                         if (selectionMode) {


### PR DESCRIPTION
By replacing `.map { it.displayManga.mangaId }.all { id -> id in selectedIds }` with a single `.all { libraryItem -> libraryItem.displayManga.mangaId in selectedIds }` in both `HorizontalCategoriesPage.kt` and `VerticalCategoriesPage.kt`, we avoid creating a completely new list every time `allSelected` is calculated during recompositions.

💡 What:
Replaced chained `.map { ... }.all { ... }` list operations with a single `.all { ... }` block.

🎯 Why:
To prevent allocating intermediate List collections on the heap just to check if all values exist in a set, which generates unnecessary GC overhead and worsens performance during scroll or selection changes.

📈 Impact:
O(1) allocation vs O(N) allocation per evaluation. Reduces Garbage Collection pauses.

📊 Measurement:
Logical deduction. Intermediate collection allocations inside Compose `remember` triggers add GC overhead on scroll/recompositions. By eliminating them, the memory heap grows slower.

---
*PR created automatically by Jules for task [1162395528595189057](https://jules.google.com/task/1162395528595189057) started by @nonproto*