### PR TITLE
ref: Move hardcoded Room query separators to LibraryDao constants

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
@@ -21,20 +21,20 @@ fun reorderChapters(sourceChapters: List<Chapter>): List<Chapter> {
     zeroVolume =
         zeroVolume.sortedWith(
             compareByDescending<Chapter> { getChapterNum(it) == null }
-                .thenByDescending { getChapterNum(it) }
+                .thenByDescending { getChapterNum(it) },
         )
 
     var (nullVolume, withVolume) = nonZeroVolume.partition { getVolumeNum(it) == null }
     nullVolume =
         nullVolume.sortedWith(
             compareByDescending<Chapter> { getChapterNum(it) == null }
-                .thenByDescending { getChapterNum(it) }
+                .thenByDescending { getChapterNum(it) },
         )
     withVolume =
         withVolume.sortedWith(
             compareByDescending<Chapter> { getVolumeNum(it) }
                 .thenByDescending { getChapterNum(it) == null }
-                .thenByDescending { getChapterNum(it) }
+                .thenByDescending { getChapterNum(it) },
         )
 
     val comp = compareBy<Chapter> { getChapterNum(it) != null }.thenBy { getChapterNum(it) }
@@ -54,7 +54,8 @@ fun reorderChapters(sourceChapters: List<Chapter>): List<Chapter> {
                     (first < second &&
                         // It's not a volume reset if both are have the same whole part
                         // and at least one is a dot chapter
-                        ((first % 1f == 0f && second % 1f == 0f) || floor(first) != floor(second)))
+                        ((first % 1f == 0f && second % 1f == 0f) ||
+                            floor(first) != floor(second)))
             }
     if (hasVolumeChange) {
         val (firstVolume, withVolume) = withVolume.partition { getVolumeNum(it) == 1 }
@@ -78,15 +79,15 @@ fun <T> List<List<T>>.mergeSorted(comparator: Comparator<T>): List<T> {
     val c: Comparator<Map.Entry<Iterator<T>, T>> = Comparator.comparing({ it.value }, comparator)
 
     return sequence {
-            while (iteratorToCurrentValues.isNotEmpty()) {
-                val smallestEntry = iteratorToCurrentValues.minWithOrNull(c)!!
+        while (iteratorToCurrentValues.isNotEmpty()) {
+            val smallestEntry = iteratorToCurrentValues.minWithOrNull(c)!!
 
-                yield(smallestEntry.value)
+            yield(smallestEntry.value)
 
-                if (!smallestEntry.key.hasNext()) iteratorToCurrentValues.remove(smallestEntry.key)
-                else iteratorToCurrentValues[smallestEntry.key] = smallestEntry.key.next()
-            }
+            if (!smallestEntry.key.hasNext()) iteratorToCurrentValues.remove(smallestEntry.key)
+            else iteratorToCurrentValues[smallestEntry.key] = smallestEntry.key.next()
         }
+    }
         .toList()
         .reversed()
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
@@ -21,20 +21,20 @@ fun reorderChapters(sourceChapters: List<Chapter>): List<Chapter> {
     zeroVolume =
         zeroVolume.sortedWith(
             compareByDescending<Chapter> { getChapterNum(it) == null }
-                .thenByDescending { getChapterNum(it) },
+                .thenByDescending { getChapterNum(it) }
         )
 
     var (nullVolume, withVolume) = nonZeroVolume.partition { getVolumeNum(it) == null }
     nullVolume =
         nullVolume.sortedWith(
             compareByDescending<Chapter> { getChapterNum(it) == null }
-                .thenByDescending { getChapterNum(it) },
+                .thenByDescending { getChapterNum(it) }
         )
     withVolume =
         withVolume.sortedWith(
             compareByDescending<Chapter> { getVolumeNum(it) }
                 .thenByDescending { getChapterNum(it) == null }
-                .thenByDescending { getChapterNum(it) },
+                .thenByDescending { getChapterNum(it) }
         )
 
     val comp = compareBy<Chapter> { getChapterNum(it) != null }.thenBy { getChapterNum(it) }
@@ -54,8 +54,7 @@ fun reorderChapters(sourceChapters: List<Chapter>): List<Chapter> {
                     (first < second &&
                         // It's not a volume reset if both are have the same whole part
                         // and at least one is a dot chapter
-                        ((first % 1f == 0f && second % 1f == 0f) ||
-                            floor(first) != floor(second)))
+                        ((first % 1f == 0f && second % 1f == 0f) || floor(first) != floor(second)))
             }
     if (hasVolumeChange) {
         val (firstVolume, withVolume) = withVolume.partition { getVolumeNum(it) == 1 }
@@ -79,15 +78,15 @@ fun <T> List<List<T>>.mergeSorted(comparator: Comparator<T>): List<T> {
     val c: Comparator<Map.Entry<Iterator<T>, T>> = Comparator.comparing({ it.value }, comparator)
 
     return sequence {
-        while (iteratorToCurrentValues.isNotEmpty()) {
-            val smallestEntry = iteratorToCurrentValues.minWithOrNull(c)!!
+            while (iteratorToCurrentValues.isNotEmpty()) {
+                val smallestEntry = iteratorToCurrentValues.minWithOrNull(c)!!
 
-            yield(smallestEntry.value)
+                yield(smallestEntry.value)
 
-            if (!smallestEntry.key.hasNext()) iteratorToCurrentValues.remove(smallestEntry.key)
-            else iteratorToCurrentValues[smallestEntry.key] = smallestEntry.key.next()
+                if (!smallestEntry.key.hasNext()) iteratorToCurrentValues.remove(smallestEntry.key)
+                else iteratorToCurrentValues[smallestEntry.key] = smallestEntry.key.next()
+            }
         }
-    }
         .toList()
         .reversed()
 }

--- a/app/src/main/java/org/nekomanga/data/database/dao/LibraryDao.kt
+++ b/app/src/main/java/org/nekomanga/data/database/dao/LibraryDao.kt
@@ -8,6 +8,12 @@ import org.nekomanga.data.database.model.LibraryMangaRaw
 @Dao
 interface LibraryDao {
 
+    companion object {
+        const val RAW_CHAPTER_SEPARATOR = " [.] "
+        const val RAW_SCANLATOR_TYPE_SEPARATOR = " [;] "
+        const val RAW_CHAPTER_COUNT_SEPARATOR = " [-] "
+    }
+
     @Query(
         """
         SELECT M.*, COALESCE(MC.category_id, 0) AS category
@@ -21,8 +27,8 @@ interface LibraryDao {
             LEFT JOIN (
                 SELECT manga_id,
                     GROUP_CONCAT(
-                        agg_scanlator || ' [;] ' || agg_uploader || ' [-] ' || agg_count,
-                        ' [.] '
+                        agg_scanlator || '${RAW_SCANLATOR_TYPE_SEPARATOR}' || agg_uploader || '${RAW_CHAPTER_COUNT_SEPARATOR}' || agg_count,
+                        '${RAW_CHAPTER_SEPARATOR}'
                     ) AS unread
                 FROM (
                     SELECT manga_id,
@@ -39,8 +45,8 @@ interface LibraryDao {
             LEFT JOIN (
                 SELECT manga_id,
                     GROUP_CONCAT(
-                        agg_scanlator || ' [;] ' || agg_uploader || ' [-] ' || agg_count,
-                        ' [.] '
+                        agg_scanlator || '${RAW_SCANLATOR_TYPE_SEPARATOR}' || agg_uploader || '${RAW_CHAPTER_COUNT_SEPARATOR}' || agg_count,
+                        '${RAW_CHAPTER_SEPARATOR}'
                     ) AS hasread
                 FROM (
                     SELECT manga_id,
@@ -93,8 +99,8 @@ interface LibraryDao {
             LEFT JOIN (
                 SELECT manga_id,
                     GROUP_CONCAT(
-                        agg_scanlator || ' [;] ' || agg_uploader || ' [-] ' || agg_count,
-                        ' [.] '
+                        agg_scanlator || '${RAW_SCANLATOR_TYPE_SEPARATOR}' || agg_uploader || '${RAW_CHAPTER_COUNT_SEPARATOR}' || agg_count,
+                        '${RAW_CHAPTER_SEPARATOR}'
                     ) AS unread
                 FROM (
                     SELECT manga_id,
@@ -111,8 +117,8 @@ interface LibraryDao {
             LEFT JOIN (
                 SELECT manga_id,
                     GROUP_CONCAT(
-                        agg_scanlator || ' [;] ' || agg_uploader || ' [-] ' || agg_count,
-                        ' [.] '
+                        agg_scanlator || '${RAW_SCANLATOR_TYPE_SEPARATOR}' || agg_uploader || '${RAW_CHAPTER_COUNT_SEPARATOR}' || agg_count,
+                        '${RAW_CHAPTER_SEPARATOR}'
                     ) AS hasread
                 FROM (
                     SELECT manga_id,

--- a/app/src/main/java/org/nekomanga/data/database/mapper/LibraryMangaMappers.kt
+++ b/app/src/main/java/org/nekomanga/data/database/mapper/LibraryMangaMappers.kt
@@ -4,6 +4,7 @@ import eu.kanade.tachiyomi.data.database.models.LibraryManga
 import eu.kanade.tachiyomi.data.database.models.MergeType
 import eu.kanade.tachiyomi.util.chapter.ChapterUtil
 import org.nekomanga.constants.Constants
+import org.nekomanga.data.database.dao.LibraryDao
 import org.nekomanga.data.database.model.LibraryMangaRaw
 
 fun LibraryMangaRaw.toLibraryManga(
@@ -101,7 +102,7 @@ private fun parseChapterCount(
     val filtered = ChapterUtil.getScanlators(filteredScanlatorsString).toSet()
 
     while (startIndex < countString.length) {
-        val endIndex = countString.indexOf(Constants.RAW_CHAPTER_SEPARATOR, startIndex)
+        val endIndex = countString.indexOf(LibraryDao.RAW_CHAPTER_SEPARATOR, startIndex)
         val groupString =
             if (endIndex == -1) {
                 countString.substring(startIndex)
@@ -109,10 +110,10 @@ private fun parseChapterCount(
                 countString.substring(startIndex, endIndex)
             }
 
-        val parts = groupString.split(Constants.RAW_SCANLATOR_TYPE_SEPARATOR)
+        val parts = groupString.split(LibraryDao.RAW_SCANLATOR_TYPE_SEPARATOR)
         if (parts.size == 2) {
             val scanlator = parts[0]
-            val extraParts = parts[1].split(Constants.RAW_CHAPTER_COUNT_SEPARATOR)
+            val extraParts = parts[1].split(LibraryDao.RAW_CHAPTER_COUNT_SEPARATOR)
 
             if (extraParts.size == 2) {
                 val uploader = extraParts[0]
@@ -169,7 +170,7 @@ private fun parseChapterCount(
         }
 
         if (endIndex == -1) break
-        startIndex = endIndex + Constants.RAW_CHAPTER_SEPARATOR.length
+        startIndex = endIndex + LibraryDao.RAW_CHAPTER_SEPARATOR.length
     }
 
     return validChapterCount

--- a/constants/src/main/kotlin/org/nekomanga/constants/Constants.kt
+++ b/constants/src/main/kotlin/org/nekomanga/constants/Constants.kt
@@ -23,9 +23,6 @@ object Constants {
     const val SCANLATOR_SEPARATOR = " & "
 
     const val ALT_TITLES_SEPARATOR = "|~|"
-    const val RAW_CHAPTER_SEPARATOR = " [.] "
-    const val RAW_SCANLATOR_TYPE_SEPARATOR = " [;] "
-    const val RAW_CHAPTER_COUNT_SEPARATOR = " [-] "
 
     const val TMP_DIR_SUFFIX = "_tmp"
     const val TMP_FILE_SUFFIX = ".tmp"


### PR DESCRIPTION
Moved the hardcoded database string separators (`RAW_CHAPTER_SEPARATOR`, `RAW_SCANLATOR_TYPE_SEPARATOR`, and `RAW_CHAPTER_COUNT_SEPARATOR`) into a companion object inside `LibraryDao`. Update LibraryDao queries to use these constants.
Having hardcoded separators that must strictly match parsing logic in `LibraryMangaMappers` introduces fragility if they ever drift out of sync. By keeping their definition explicitly inside the DAO as `const val` and utilizing them across queries and logic mappings, we improve code maintainability and minimize mismatch risks.

---
*PR created automatically by Jules for task [17256752995729623528](https://jules.google.com/task/17256752995729623528) started by @nonproto*