### PR TITLE
perf: optimize History stats aggregation with native SQL Tuple grouping

### DIFF
--- a/.jules/dba.md
+++ b/.jules/dba.md
@@ -1,0 +1,4 @@
+
+## 2026-04-22 - Tuple Aggregation
+**Learning:** Returning targeted Tuples (`MangaHistoryStats`) directly from Room queries using SQL aggregation (`SUM`, `MIN`) instead of loading full Entities is much faster and reduces memory overhead.
+**Action:** Use SQL aggregation and chunked queries (`chunked(500)`) over collection-based Kotlin mapping in ViewModels to avoid hitting SQLite parameter limits and prevent the N+1 problem.

--- a/app/src/main/java/org/nekomanga/data/database/dao/HistoryDao.kt
+++ b/app/src/main/java/org/nekomanga/data/database/dao/HistoryDao.kt
@@ -8,6 +8,7 @@ import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 import org.nekomanga.data.database.entity.HistoryEntity
 import org.nekomanga.data.database.model.MangaChapterHistory
+import org.nekomanga.data.database.model.MangaHistoryStats
 
 @Dao
 interface HistoryDao {
@@ -357,6 +358,19 @@ interface HistoryDao {
     """
     )
     suspend fun getHistoryByChapterUrl(chapterUrl: String): HistoryEntity?
+
+    @Query(
+        """
+        SELECT chapters.manga_id,
+               SUM(history.time_read) AS read_duration,
+               MIN(CASE WHEN history.last_read > 0 THEN history.last_read ELSE NULL END) AS oldest_read_date
+        FROM history
+        JOIN chapters ON history.chapter_id = chapters.id
+        WHERE chapters.manga_id IN (:mangaIds)
+        GROUP BY chapters.manga_id
+        """
+    )
+    suspend fun getHistoryStatsForMangaIds(mangaIds: List<Long>): List<MangaHistoryStats>
 
     @Query("SELECT SUM(time_read) FROM history") suspend fun getTotalReadDuration(): Long
 

--- a/app/src/main/java/org/nekomanga/data/database/model/MangaHistoryStats.kt
+++ b/app/src/main/java/org/nekomanga/data/database/model/MangaHistoryStats.kt
@@ -1,0 +1,13 @@
+package org.nekomanga.data.database.model
+
+import androidx.room.ColumnInfo
+
+/**
+ * Targeted Tuple to safely select and aggregate history stats for stats screen without fetching
+ * heavy, unused columns into memory.
+ */
+data class MangaHistoryStats(
+    @ColumnInfo(name = "manga_id") val mangaId: Long,
+    @ColumnInfo(name = "read_duration") val readDuration: Long,
+    @ColumnInfo(name = "oldest_read_date") val oldestReadDate: Long?,
+)

--- a/app/src/main/java/org/nekomanga/data/database/repository/HistoryRepository.kt
+++ b/app/src/main/java/org/nekomanga/data/database/repository/HistoryRepository.kt
@@ -4,6 +4,7 @@ import eu.kanade.tachiyomi.data.database.models.History
 import eu.kanade.tachiyomi.data.database.models.MangaChapterHistory as LegacyMangaChapterHistory
 import kotlinx.coroutines.flow.Flow
 import org.nekomanga.data.database.model.MangaChapterHistory
+import org.nekomanga.data.database.model.MangaHistoryStats
 
 interface HistoryRepository {
 
@@ -59,6 +60,8 @@ interface HistoryRepository {
     suspend fun getHistoryByMangaIds(mangaIds: List<Long>): List<History>
 
     suspend fun getHistoryByChapterUrl(chapterUrl: String): History?
+
+    suspend fun getHistoryStatsForMangaIds(mangaIds: List<Long>): List<MangaHistoryStats>
 
     suspend fun getTotalReadDuration(): Long
 

--- a/app/src/main/java/org/nekomanga/data/database/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/org/nekomanga/data/database/repository/HistoryRepositoryImpl.kt
@@ -10,6 +10,7 @@ import org.nekomanga.data.database.mapper.toEntity
 import org.nekomanga.data.database.mapper.toHistory
 import org.nekomanga.data.database.mapper.toManga
 import org.nekomanga.data.database.model.MangaChapterHistory
+import org.nekomanga.data.database.model.MangaHistoryStats
 
 class HistoryRepositoryImpl(private val historyDao: HistoryDao) : HistoryRepository {
 
@@ -135,6 +136,10 @@ class HistoryRepositoryImpl(private val historyDao: HistoryDao) : HistoryReposit
 
     override suspend fun getHistoryByChapterUrl(chapterUrl: String): History? {
         return historyDao.getHistoryByChapterUrl(chapterUrl)?.toHistory()
+    }
+
+    override suspend fun getHistoryStatsForMangaIds(mangaIds: List<Long>): List<MangaHistoryStats> {
+        return mangaIds.chunked(500).flatMap { historyDao.getHistoryStatsForMangaIds(it) }
     }
 
     override suspend fun getTotalReadDuration(): Long {

--- a/app/src/main/java/org/nekomanga/data/database/repository/TrackRepositoryImpl.kt
+++ b/app/src/main/java/org/nekomanga/data/database/repository/TrackRepositoryImpl.kt
@@ -24,7 +24,10 @@ class TrackRepositoryImpl(private val trackDao: TrackDao) : TrackRepository {
     }
 
     override suspend fun getTracksForMangaByIds(mangaIds: List<Long>): List<Track> {
-        return trackDao.getTracksForMangaByIds(mangaIds).map { it.toTrack() }
+        return mangaIds
+            .chunked(500)
+            .flatMap { trackDao.getTracksForMangaByIds(it) }
+            .map { it.toTrack() }
     }
 
     override fun observeAllTracks(): Flow<List<Track>> {

--- a/app/src/main/java/org/nekomanga/presentation/screens/stats/StatsViewModel.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/stats/StatsViewModel.kt
@@ -2,7 +2,6 @@ package org.nekomanga.presentation.screens.stats
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import eu.kanade.tachiyomi.data.database.models.History
 import eu.kanade.tachiyomi.data.database.models.LibraryManga
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.database.models.Track
@@ -143,12 +142,20 @@ class StatsViewModel() : ViewModel() {
         viewModelScope.launchIO {
             val libraryList = getLibrary()
             if (libraryList.isNotEmpty()) {
+                val historyStatsMap =
+                    historyRepository
+                        .getHistoryStatsForMangaIds(libraryList.mapNotNull { it.id })
+                        .associateBy { it.mangaId }
+
+                val allTracks = getTracks(libraryList)
+                val tracksByMangaId = allTracks.groupBy { it.manga_id }
+
                 val detailedStatMangaList =
                     libraryList
                         .map {
                             async {
-                                val history = historyRepository.getHistoryByMangaId(it.id!!)
-                                val tracks = getTracks(it)
+                                val stats = historyStatsMap[it.id]
+                                val tracks = tracksByMangaId[it.id] ?: emptyList()
 
                                 DetailedStatManga(
                                     id = it.id!!,
@@ -161,8 +168,8 @@ class StatsViewModel() : ViewModel() {
                                     readChapters = it.read,
                                     bookmarkedChapters = it.bookmarkCount,
                                     unavailableChapters = it.unavailableCount,
-                                    readDuration = getReadDurationFromHistory(history),
-                                    startYear = getStartYear(history),
+                                    readDuration = stats?.readDuration ?: 0L,
+                                    startYear = getStartYear(stats?.oldestReadDate),
                                     rating = it.rating?.toDoubleOrNull()?.roundToTwoDecimal(),
                                     tags = (it.getGenres() ?: emptyList()).toPersistentList(),
                                     userScore = getUserScore(tracks),
@@ -345,12 +352,7 @@ class StatsViewModel() : ViewModel() {
         return chaptersTime.getReadDuration(prefs.context.getString(R.string.none))
     }
 
-    private fun getReadDurationFromHistory(history: List<History>): Long {
-        return history.sumOf { it.time_read }
-    }
-
-    private fun getStartYear(history: List<History>): Int? {
-        val oldestDate = history.filter { it.last_read > 0 }.minOfOrNull { it.last_read }
+    private fun getStartYear(oldestDate: Long?): Int? {
         if (oldestDate == null || oldestDate <= 0L) {
             return null
         } else {


### PR DESCRIPTION
Extract targeted `MangaHistoryStats` Tuple data class to return only needed columns from `HistoryDao.getHistoryStatsForMangaIds`, leveraging SQLite's native `SUM` and `MIN` operations and avoiding `SELECT *` from generating memory overhead. Changed `StatsViewModel` to use a chunked batch pre-fetch and native aggregations over the expensive loop of single queries + Kotlin collection filters.

---
*PR created automatically by Jules for task [11178724542584091052](https://jules.google.com/task/11178724542584091052) started by @nonproto*