### PR TITLE
test: ModifyCategoryUseCase test coverage

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -7,3 +7,6 @@
 ## 2025-04-04 - Testing MarkChaptersRemote skipSync edge case
 **Learning:** MangaDexPreferences nested method mocking requires explicit returns. When using MockK to mock a use case that might skip execution conditionally, using `coVerify(exactly = 0)` cleanly asserts that external dependencies (like `StatusHandler`) are bypassed correctly.
 **Action:** When testing conditional skips, mock all preferences normally and use exactly = 0 for the verification step on the external calls.
+## 2024-05-24 - Testing ModifyCategoryUseCase Preferences
+**Learning:** When writing unit tests involving nested preference structures like `LibraryPreferences` in Nekomanga, setting values requires explicit MockK chains (e.g., `every { libraryPreferences.sortAscending().set(any()) } just runs`) because methods like `sortAscending()` return a generic `Preference` object instead of a direct primitive value.
+**Action:** Always mock the intermediate `Preference` object and its `.set()` or `.get()` methods individually when testing domain logic that alters App preferences to prevent runtime test crashes.

--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -7,6 +7,6 @@
 ## 2025-04-04 - Testing MarkChaptersRemote skipSync edge case
 **Learning:** MangaDexPreferences nested method mocking requires explicit returns. When using MockK to mock a use case that might skip execution conditionally, using `coVerify(exactly = 0)` cleanly asserts that external dependencies (like `StatusHandler`) are bypassed correctly.
 **Action:** When testing conditional skips, mock all preferences normally and use exactly = 0 for the verification step on the external calls.
-## 2024-05-24 - Testing ModifyCategoryUseCase Preferences
+## 2026-04-27 - Testing ModifyCategoryUseCase Preferences
 **Learning:** When writing unit tests involving nested preference structures like `LibraryPreferences` in Nekomanga, setting values requires explicit MockK chains (e.g., `every { libraryPreferences.sortAscending().set(any()) } just runs`) because methods like `sortAscending()` return a generic `Preference` object instead of a direct primitive value.
 **Action:** Always mock the intermediate `Preference` object and its `.set()` or `.get()` methods individually when testing domain logic that alters App preferences to prevent runtime test crashes.

--- a/app/src/test/java/org/nekomanga/usecases/category/ModifyCategoryUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/category/ModifyCategoryUseCaseTest.kt
@@ -111,7 +111,12 @@ class ModifyCategoryUseCaseTest {
 
             // Assert
             coVerify(exactly = 1) {
-                categoryRepository.insertCategory(match { it.name == "Regular" })
+                categoryRepository.insertCategory(
+                    match { insertedCategory ->
+                        insertedCategory.name == "Regular" &&
+                            insertedCategory.mangaSort == LibrarySort.Title.categoryValueDescending
+                    }
+                )
             }
         }
 
@@ -181,7 +186,12 @@ class ModifyCategoryUseCaseTest {
 
             // Assert
             coVerify(exactly = 1) {
-                categoryRepository.insertCategory(match { it.name == "Regular" })
+                categoryRepository.insertCategory(
+                    match { insertedCategory ->
+                        insertedCategory.name == "Regular" &&
+                            insertedCategory.mangaSort == LibrarySort.DateAdded.categoryValue
+                    }
+                )
             }
         }
 }

--- a/app/src/test/java/org/nekomanga/usecases/category/ModifyCategoryUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/category/ModifyCategoryUseCaseTest.kt
@@ -1,0 +1,187 @@
+package org.nekomanga.usecases.category
+
+import eu.kanade.tachiyomi.ui.library.LibrarySort
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.nekomanga.data.database.repository.CategoryRepository
+import org.nekomanga.data.database.repository.MangaRepository
+import org.nekomanga.domain.category.CategoryItem
+import org.nekomanga.domain.library.LibraryPreferences
+import tachiyomi.core.preference.Preference
+
+class ModifyCategoryUseCaseTest {
+
+    private lateinit var categoryRepository: CategoryRepository
+    private lateinit var mangaRepository: MangaRepository
+    private lateinit var libraryPreferences: LibraryPreferences
+    private lateinit var useCase: ModifyCategoryUseCase
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        categoryRepository = mockk()
+        mangaRepository = mockk()
+        libraryPreferences = mockk()
+        useCase = ModifyCategoryUseCase(categoryRepository, mangaRepository, libraryPreferences)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `given dynamic category when updating sort ascending then library preferences sort is inverted`() =
+        runTest {
+            // Arrange
+            val category =
+                CategoryItem(
+                    id = -1,
+                    name = "Dynamic",
+                    sortOrder = LibrarySort.Title,
+                    isAscending = true,
+                    isDynamic = true,
+                )
+            val mockSortAscendingPref = mockk<Preference<Boolean>>()
+            every { libraryPreferences.sortAscending() } returns mockSortAscendingPref
+            every { mockSortAscendingPref.set(any()) } just runs
+
+            // Act
+            useCase.updateCategorySortAscending(category)
+
+            // Assert
+            verify(exactly = 1) { mockSortAscendingPref.set(false) }
+        }
+
+    @Test
+    fun `given system category when updating sort ascending then library preferences sort is inverted`() =
+        runTest {
+            // Arrange
+            val category =
+                CategoryItem(
+                    id = 0,
+                    name = CategoryItem.SYSTEM_CATEGORY,
+                    sortOrder = LibrarySort.Title,
+                    isAscending = false,
+                    isSystemCategory = true,
+                )
+            val mockSortAscendingPref = mockk<Preference<Boolean>>()
+            every { libraryPreferences.sortAscending() } returns mockSortAscendingPref
+            every { mockSortAscendingPref.set(any()) } just runs
+
+            // Act
+            useCase.updateCategorySortAscending(category)
+
+            // Assert
+            verify(exactly = 1) { mockSortAscendingPref.set(true) }
+        }
+
+    @Test
+    fun `given regular category when updating sort ascending then category is updated in database`() =
+        runTest {
+            // Arrange
+            val category =
+                CategoryItem(
+                    id = 1,
+                    name = "Regular",
+                    sortOrder = LibrarySort.Title,
+                    isAscending = true,
+                    isDynamic = false,
+                    isSystemCategory = false,
+                )
+            coEvery { categoryRepository.insertCategory(any()) } returns 1
+
+            // Act
+            useCase.updateCategorySortAscending(category)
+
+            // Assert
+            coVerify(exactly = 1) {
+                categoryRepository.insertCategory(match { it.name == "Regular" })
+            }
+        }
+
+    @Test
+    fun `given dynamic category when updating library sort then library preferences sort mode is updated`() =
+        runTest {
+            // Arrange
+            val category =
+                CategoryItem(
+                    id = -1,
+                    name = "Dynamic",
+                    sortOrder = LibrarySort.Title,
+                    isAscending = true,
+                    isDynamic = true,
+                )
+            val mockSortingModePref = mockk<Preference<Int>>()
+            every { libraryPreferences.sortingMode() } returns mockSortingModePref
+            every { mockSortingModePref.set(any()) } just runs
+
+            // Act
+            useCase.updateCategoryLibrarySort(category, LibrarySort.LastRead)
+
+            // Assert
+            verify(exactly = 1) { mockSortingModePref.set(LibrarySort.LastRead.mainValue) }
+        }
+
+    @Test
+    fun `given system category when updating library sort then library preferences sort mode is updated`() =
+        runTest {
+            // Arrange
+            val category =
+                CategoryItem(
+                    id = 0,
+                    name = CategoryItem.SYSTEM_CATEGORY,
+                    sortOrder = LibrarySort.Title,
+                    isAscending = true,
+                    isSystemCategory = true,
+                )
+            val mockSortingModePref = mockk<Preference<Int>>()
+            every { libraryPreferences.sortingMode() } returns mockSortingModePref
+            every { mockSortingModePref.set(any()) } just runs
+
+            // Act
+            useCase.updateCategoryLibrarySort(category, LibrarySort.Unread)
+
+            // Assert
+            verify(exactly = 1) { mockSortingModePref.set(LibrarySort.Unread.mainValue) }
+        }
+
+    @Test
+    fun `given regular category when updating library sort then category sort order is updated in database`() =
+        runTest {
+            // Arrange
+            val category =
+                CategoryItem(
+                    id = 1,
+                    name = "Regular",
+                    sortOrder = LibrarySort.Title,
+                    isAscending = true,
+                    isDynamic = false,
+                    isSystemCategory = false,
+                )
+            coEvery { categoryRepository.insertCategory(any()) } returns 1
+
+            // Act
+            useCase.updateCategoryLibrarySort(category, LibrarySort.DateAdded)
+
+            // Assert
+            coVerify(exactly = 1) {
+                categoryRepository.insertCategory(match { it.name == "Regular" })
+            }
+        }
+}


### PR DESCRIPTION
💡 What: Added `ModifyCategoryUseCaseTest.kt` to cover `updateCategorySortAscending` and `updateCategoryLibrarySort` behavior.

🎯 Why: To ensure that system and dynamic categories correctly update nested library preferences, while regular customized categories trigger the correct repository inserts. This acts as a safeguard against future regression when handling these complex branching paths.

---
*PR created automatically by Jules for task [9696657681333527843](https://jules.google.com/task/9696657681333527843) started by @nonproto*