### PR TITLE
fix: resolve duplicate library and faulty inserts when pulling MangaDex follows

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/jobs/follows/FollowsSyncProcessor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jobs/follows/FollowsSyncProcessor.kt
@@ -109,15 +109,14 @@ class FollowsSyncProcessor {
 
                             mangaRepository.updateManga(dbManga)
 
+                            val mangaId = dbManga.id ?: return@mapNotNull null
+
                             if (defaultCategory != null) {
                                 val mc = MangaCategory.create(dbManga, defaultCategory)
-                                categoryRepository.setMangaCategories(
-                                    listOf(mc),
-                                    listOf(dbManga.id!!),
-                                )
+                                categoryRepository.setMangaCategories(listOf(mc), listOf(mangaId))
                             }
 
-                            return@mapNotNull dbManga.id
+                            return@mapNotNull mangaId
                         }
                         return@mapNotNull null
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/jobs/follows/FollowsSyncProcessor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jobs/follows/FollowsSyncProcessor.kt
@@ -89,6 +89,17 @@ class FollowsSyncProcessor {
                                     sourceManager.mangaDex.id,
                                 )
                             dbManga.date_added = Date().time
+                            dbManga.favorite = true
+
+                            countOfAdded.incrementAndGet()
+                            val id = mangaRepository.insertManga(dbManga)
+                            dbManga.id = id
+
+                            if (defaultCategory != null) {
+                                val mc = MangaCategory.create(dbManga, defaultCategory)
+                                categoryRepository.setMangaCategories(listOf(mc), listOf(id))
+                            }
+                            return@mapNotNull id
                         }
 
                         // Increment and update if it is not already favorited
@@ -98,21 +109,15 @@ class FollowsSyncProcessor {
 
                             mangaRepository.updateManga(dbManga)
 
-                            dbManga =
-                                mangaRepository.getMangaByUrlAndSource(
-                                    networkManga.url,
-                                    sourceManager.mangaDex.id,
-                                )
-
                             if (defaultCategory != null) {
-                                val mc = MangaCategory.create(dbManga!!, defaultCategory)
+                                val mc = MangaCategory.create(dbManga, defaultCategory)
                                 categoryRepository.setMangaCategories(
                                     listOf(mc),
                                     listOf(dbManga.id!!),
                                 )
                             }
 
-                            return@mapNotNull dbManga?.id
+                            return@mapNotNull dbManga.id
                         }
                         return@mapNotNull null
                     }

--- a/app/src/main/java/org/nekomanga/data/database/repository/MangaRepositoryImpl.kt
+++ b/app/src/main/java/org/nekomanga/data/database/repository/MangaRepositoryImpl.kt
@@ -76,13 +76,52 @@ class MangaRepositoryImpl(
     override suspend fun getMangaByIds(ids: List<Long>): List<Manga> =
         mangaDao.getMangaByIds(ids).map { it.toManga() }
 
-    override suspend fun getMangaByUrlAndSource(url: String, sourceId: Long): Manga? =
-        mangaDao.getMangaByUrlAndSourceSync(url, sourceId)?.toManga()
+    override suspend fun getMangaByUrlAndSource(url: String, sourceId: Long): Manga? {
+        var manga = mangaDao.getMangaByUrlAndSourceSync(url, sourceId)
+        if (manga == null) {
+            val altUrl =
+                if (url.startsWith("/title/")) {
+                    url.replaceFirst("/title/", "/manga/")
+                } else if (url.startsWith("/manga/")) {
+                    url.replaceFirst("/manga/", "/title/")
+                } else null
 
-    override suspend fun getMangaByUrls(urls: List<String>): List<Manga> =
-        mangaDao.getMangaByUrls(urls).map { it.toManga() }
+            if (altUrl != null) {
+                manga = mangaDao.getMangaByUrlAndSourceSync(altUrl, sourceId)
+            }
+        }
+        return manga?.toManga()
+    }
 
-    override suspend fun getMangaByUrl(url: String): Manga? = mangaDao.getMangaByUrl(url)?.toManga()
+    override suspend fun getMangaByUrls(urls: List<String>): List<Manga> {
+        val allUrls = urls.flatMap { url ->
+            val altUrl =
+                if (url.startsWith("/title/")) {
+                    url.replaceFirst("/title/", "/manga/")
+                } else if (url.startsWith("/manga/")) {
+                    url.replaceFirst("/manga/", "/title/")
+                } else null
+            if (altUrl != null) listOf(url, altUrl) else listOf(url)
+        }
+        return mangaDao.getMangaByUrls(allUrls).map { it.toManga() }
+    }
+
+    override suspend fun getMangaByUrl(url: String): Manga? {
+        var manga = mangaDao.getMangaByUrl(url)
+        if (manga == null) {
+            val altUrl =
+                if (url.startsWith("/title/")) {
+                    url.replaceFirst("/title/", "/manga/")
+                } else if (url.startsWith("/manga/")) {
+                    url.replaceFirst("/manga/", "/title/")
+                } else null
+
+            if (altUrl != null) {
+                manga = mangaDao.getMangaByUrl(altUrl)
+            }
+        }
+        return manga?.toManga()
+    }
 
     override suspend fun getMangaById(id: Long): Manga? = mangaDao.getMangaById(id)?.toManga()
 

--- a/app/src/main/java/org/nekomanga/data/database/repository/MangaRepositoryImpl.kt
+++ b/app/src/main/java/org/nekomanga/data/database/repository/MangaRepositoryImpl.kt
@@ -77,50 +77,30 @@ class MangaRepositoryImpl(
         mangaDao.getMangaByIds(ids).map { it.toManga() }
 
     override suspend fun getMangaByUrlAndSource(url: String, sourceId: Long): Manga? {
-        var manga = mangaDao.getMangaByUrlAndSourceSync(url, sourceId)
-        if (manga == null) {
-            val altUrl =
-                if (url.startsWith("/title/")) {
-                    url.replaceFirst("/title/", "/manga/")
-                } else if (url.startsWith("/manga/")) {
-                    url.replaceFirst("/manga/", "/title/")
-                } else null
-
-            if (altUrl != null) {
-                manga = mangaDao.getMangaByUrlAndSourceSync(altUrl, sourceId)
-            }
-        }
+        val altUrl = getAltUrl(url)
+        val manga =
+            mangaDao.getMangaByUrlAndSourceSync(url, sourceId)
+                ?: altUrl?.let { mangaDao.getMangaByUrlAndSourceSync(it, sourceId) }
         return manga?.toManga()
     }
 
     override suspend fun getMangaByUrls(urls: List<String>): List<Manga> {
-        val allUrls = urls.flatMap { url ->
-            val altUrl =
-                if (url.startsWith("/title/")) {
-                    url.replaceFirst("/title/", "/manga/")
-                } else if (url.startsWith("/manga/")) {
-                    url.replaceFirst("/manga/", "/title/")
-                } else null
-            if (altUrl != null) listOf(url, altUrl) else listOf(url)
-        }
+        val allUrls = urls.flatMap { url -> listOfNotNull(url, getAltUrl(url)) }
         return mangaDao.getMangaByUrls(allUrls).map { it.toManga() }
     }
 
     override suspend fun getMangaByUrl(url: String): Manga? {
-        var manga = mangaDao.getMangaByUrl(url)
-        if (manga == null) {
-            val altUrl =
-                if (url.startsWith("/title/")) {
-                    url.replaceFirst("/title/", "/manga/")
-                } else if (url.startsWith("/manga/")) {
-                    url.replaceFirst("/manga/", "/title/")
-                } else null
-
-            if (altUrl != null) {
-                manga = mangaDao.getMangaByUrl(altUrl)
-            }
-        }
+        val altUrl = getAltUrl(url)
+        val manga = mangaDao.getMangaByUrl(url) ?: altUrl?.let { mangaDao.getMangaByUrl(it) }
         return manga?.toManga()
+    }
+
+    private fun getAltUrl(url: String): String? {
+        return when {
+            url.startsWith("/title/") -> url.replaceFirst("/title/", "/manga/")
+            url.startsWith("/manga/") -> url.replaceFirst("/manga/", "/title/")
+            else -> null
+        }
     }
 
     override suspend fun getMangaById(id: Long): Manga? = mangaDao.getMangaById(id)?.toManga()


### PR DESCRIPTION
💡 What:
- Updated `MangaRepositoryImpl.kt` lookup functions (`getMangaByUrlAndSource`, `getMangaByUrls`, `getMangaByUrl`) to seamlessly match both legacy `/manga/UUID` and the newer `/title/UUID` prefixes.
- Updated `FollowsSyncProcessor.kt` to properly invoke `insertManga(dbManga)` when pulling a new title that does not exist locally.

🎯 Why:
Users reported that pulling their MangaDex follows duplicated hundreds of titles in their local library. This occurred because legacy local entries were tracked under `/manga/`, while MangaDex APIs and mapping returned `/title/`. The lookup failed, forcing the SyncProcessor to instantiate a redundant instance. Additionally, the fallback insertion logic was broken—using `@Update` against an unstored object—meaning completely new items fetched via follows sync were not being fully processed or generated crashes. These two changes comprehensively resolve the duplication cycle and correctly insert missing valid entries.

---
*PR created automatically by Jules for task [8806155813688428661](https://jules.google.com/task/8806155813688428661) started by @nonproto*