### PR TITLE
fix: [Disable app updater] disable app updater in debug build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ android {
     buildTypes {
         getByName("debug") {
             applicationIdSuffix = ".debug"
+            buildConfigField("Boolean", "INCLUDE_UPDATER", "false")
             manifestPlaceholders["mangadexAuthRedirectUri"] = "mangadex-auth-debug"
             proguardFiles("proguard-android-optimize.txt", "proguard-rules.pro")
         }


### PR DESCRIPTION
💡 What: Explicitly sets INCLUDE_UPDATER to false in the debug buildType in app/build.gradle.kts.
🎯 Why: The app update checker was improperly triggering update notifications in debug builds because the standard product flavor's setting was overriding the default config setting for the debug build. Explicitly setting it in the debug buildType solves this.

---
*PR created automatically by Jules for task [15594108260049904974](https://jules.google.com/task/15594108260049904974) started by @nonproto*