### PR TITLE
perf: defer fastscroller offset reads and avoid intermediate list allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,11 @@ Action: Always append `.distinctUntilChanged()` after `combine()` blocks that ag
 ## 2026-04-03 - [Avoid Intermediate Lists with all]
 **Learning:** Chaining `.map { ... }.all { ... }` creates an intermediate list of transformed elements, which adds memory allocation and garbage collection overhead. This is especially true for list iteration within Compose state changes (`derivedStateOf`, `remember` triggers).
 **Action:** Replace `.map { ... }.all { ... }` with a single `.all { transformedElement -> ... }` to avoid the intermediate list creation and improve iteration performance, particularly in frequently recomposed UI areas.
+
+## 2026-04-28 - [Avoid Intermediate Lists with asSequence]
+**Learning:** Chaining `.filter {}.sortedWith {}.take {}.map {}` on active chapters creates multiple intermediate lists in memory, which increases GC overhead and reduces performance on chapter lists.
+**Action:** Add `.asSequence()` to large list operations before chaining multiple operators like `filter`, `sortedWith`, `take`, and `map`, finishing with `.toList()` to avoid unnecessary memory allocations.
+
+## 2026-04-28 - [Avoid FastScroller Recomposition on Scroll]
+**Learning:** Passing `state.firstVisibleItemScrollOffset` or referencing changing bounds like `visibleItemsInfo` inside a layout block without deferring causes continuous recomposition on every scroll frame (due to effect parameters/variables being evaluated during composition).
+**Action:** Move frequently changing scroll state evaluations into a `snapshotFlow { ... }.collectLatest { ... }` block within a parameterless `LaunchedEffect(state)`. Read properties directly from `state.layoutInfo` inside the collector, and capture external composition scope variables safely via `rememberUpdatedState()`.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -1016,12 +1016,16 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                 is DownloadAction.DownloadNextUnread -> {
                     val filteredChapters =
                         mangaDetailScreenState.value.chapters.activeChapters
+                            // Use asSequence to avoid intermediate memory allocations during
+                            // multiple list operations
+                            .asSequence()
                             .filter {
                                 !it.chapter.read && it.isNotDownloaded && !it.chapter.isUnavailable
                             }
                             .sortedWith(chapterSort.sortComparator(dbManga, true))
                             .take(downloadAction.numberToDownload)
                             .map { it.chapter.toDbChapter() }
+                            .toList()
                     downloadManager.downloadChapters(dbManga, filteredChapters)
                 }
                 is DownloadAction.DownloadUnread -> {

--- a/app/src/main/java/org/nekomanga/presentation/components/FastScroller.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/FastScroller.kt
@@ -29,7 +29,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
@@ -141,8 +143,51 @@ fun VerticalFastScroller(
 
                     if (maxRemainingSections < 0.5) return@subcompose
 
+                    // Defer Compose state read using snapshotFlow instead of triggering
+                    // LaunchedEffect on every scroll tick
+                    val isThumbDraggedState by rememberUpdatedState(isThumbDragged)
+                    val maxRemainingSectionsState by rememberUpdatedState(maxRemainingSections)
+                    val trackHeightPxState by rememberUpdatedState(trackHeightPx)
+                    val thumbTopPaddingState by rememberUpdatedState(thumbTopPadding)
+                    val stableScrollInProgressState by rememberUpdatedState(stableScrollInProgress)
+                    val scrollHeightPxState by rememberUpdatedState(scrollHeightPx)
+
+                    LaunchedEffect(listState) {
+                        snapshotFlow { listState.firstVisibleItemScrollOffset }
+                            .collectLatest {
+                                if (
+                                    listState.layoutInfo.totalItemsCount != 0 &&
+                                        !isThumbDraggedState
+                                ) {
+                                    val visibleItems = listState.layoutInfo.visibleItemsInfo
+                                    val topItem =
+                                        visibleItems.fastFirstOrNull { it.bottom >= 0 }
+                                            ?: visibleItems.firstOrNull()
+                                            ?: return@collectLatest
+                                    val bottomItemInner =
+                                        visibleItems.fastLastOrNull {
+                                            it.top <= scrollHeightPxState
+                                        } ?: visibleItems.lastOrNull() ?: return@collectLatest
+                                    val topHiddenProportion =
+                                        -1f * topItem.top / topItem.size.coerceAtLeast(1)
+                                    val bottomHiddenProportion =
+                                        (bottomItemInner.bottom - scrollHeightPxState) /
+                                            bottomItemInner.size.coerceAtLeast(1)
+                                    val remainingSectionsLocal =
+                                        bottomHiddenProportion +
+                                            (listState.layoutInfo.totalItemsCount -
+                                                (bottomItemInner.index + 1))
+                                    val proportion =
+                                        1f - remainingSectionsLocal / maxRemainingSectionsState
+                                    thumbOffsetY =
+                                        trackHeightPxState * proportion + thumbTopPaddingState
+                                    if (stableScrollInProgressState) scrolled.tryEmit(Unit)
+                                }
+                            }
+                    }
+
                     LaunchedEffect(thumbOffsetY) {
-                        if (layoutInfo.totalItemsCount == 0 || !isThumbDragged)
+                        if (listState.layoutInfo.totalItemsCount == 0 || !isThumbDragged)
                             return@LaunchedEffect
                         val thumbProportion = (thumbOffsetY - thumbTopPadding) / trackHeightPx
                         if (thumbProportion <= 0.001f) {
@@ -152,32 +197,33 @@ fun VerticalFastScroller(
                             return@LaunchedEffect
                         }
                         val scrollRemainingSections = (1f - thumbProportion) * maxRemainingSections
-                        val currentSection = layoutInfo.totalItemsCount - scrollRemainingSections
+                        val currentSection =
+                            listState.layoutInfo.totalItemsCount - scrollRemainingSections
                         val scrollSectionIndex =
-                            currentSection.toInt().coerceAtMost(layoutInfo.totalItemsCount)
+                            currentSection
+                                .toInt()
+                                .coerceAtMost(listState.layoutInfo.totalItemsCount)
                         val expectedScrollItem =
-                            visibleItems.find { it.index == scrollSectionIndex }
-                                ?: visibleItems.first()
+                            listState.layoutInfo.visibleItemsInfo.find {
+                                it.index == scrollSectionIndex
+                            }
+                                ?: listState.layoutInfo.visibleItemsInfo.firstOrNull()
+                                ?: return@LaunchedEffect
                         val scrollRelativeOffset =
                             expectedScrollItem.size * (currentSection - scrollSectionIndex)
                         val scrollSectionOffset =
                             (scrollRelativeOffset - scrollHeightPx).roundToInt()
                         val scrollItemIndex =
-                            scrollSectionIndex.coerceIn(0, layoutInfo.totalItemsCount - 1)
+                            scrollSectionIndex.coerceIn(0, listState.layoutInfo.totalItemsCount - 1)
                         val scrollItemOffset =
                             scrollSectionOffset +
-                                (scrollSectionIndex - scrollItemIndex) * bottomItem.size
+                                (scrollSectionIndex - scrollItemIndex) *
+                                    (listState.layoutInfo.visibleItemsInfo.lastOrNull()?.size ?: 0)
                         listState.scrollToItem(
                             index = scrollItemIndex,
                             scrollOffset = scrollItemOffset,
                         )
                         scrolled.tryEmit(Unit)
-                    }
-
-                    if (layoutInfo.totalItemsCount != 0 && !isThumbDragged) {
-                        val proportion = 1f - remainingSections / maxRemainingSections
-                        thumbOffsetY = trackHeightPx * proportion + thumbTopPadding
-                        if (stableScrollInProgress) scrolled.tryEmit(Unit)
                     }
 
                     val alpha = remember { Animatable(0f) }
@@ -360,16 +406,35 @@ fun VerticalGridFastScroller(
                         scrolled.tryEmit(Unit)
                     }
 
-                    LaunchedEffect(state.firstVisibleItemScrollOffset) {
-                        if (state.layoutInfo.totalItemsCount == 0 || isThumbDragged)
-                            return@LaunchedEffect
-                        val scrollOffset =
-                            computeGridScrollOffset(state = state, columnCount = columnCount)
-                        val extraScrollRange = (scrollRange.toFloat() - heightPx).coerceAtLeast(1f)
-                        val proportion =
-                            (scrollOffset.toFloat() / extraScrollRange).coerceAtMost(1f)
-                        thumbOffsetY = trackHeightPx * proportion + thumbTopPadding
-                        scrolled.tryEmit(Unit)
+                    // Defer Compose state read using snapshotFlow instead of triggering
+                    // LaunchedEffect on every scroll tick
+                    val heightPxState by rememberUpdatedState(heightPx)
+                    val trackHeightPxGridState by rememberUpdatedState(trackHeightPx)
+                    val thumbTopPaddingGridState by rememberUpdatedState(thumbTopPadding)
+                    val scrollRangeState by rememberUpdatedState(scrollRange)
+                    val columnCountState by rememberUpdatedState(columnCount)
+                    val isThumbDraggedGridState by rememberUpdatedState(isThumbDragged)
+
+                    LaunchedEffect(state) {
+                        snapshotFlow { state.firstVisibleItemScrollOffset }
+                            .collectLatest {
+                                if (
+                                    state.layoutInfo.totalItemsCount == 0 || isThumbDraggedGridState
+                                )
+                                    return@collectLatest
+                                val scrollOffset =
+                                    computeGridScrollOffset(
+                                        state = state,
+                                        columnCount = columnCountState,
+                                    )
+                                val extraScrollRange =
+                                    (scrollRangeState.toFloat() - heightPxState).coerceAtLeast(1f)
+                                val proportion =
+                                    (scrollOffset.toFloat() / extraScrollRange).coerceAtMost(1f)
+                                thumbOffsetY =
+                                    trackHeightPxGridState * proportion + thumbTopPaddingGridState
+                                scrolled.tryEmit(Unit)
+                            }
                     }
 
                     val alpha = remember { Animatable(0f) }


### PR DESCRIPTION
FastScroller performance was bottlenecked because `state.firstVisibleItemScrollOffset` and the `layoutInfo` state objects were read directly during the composition phase. This triggered unnecessary recompositions on every scroll pixel. By wrapping this read inside `snapshotFlow` and using `rememberUpdatedState` for dynamically changing layout variables, we defer the state calculation strictly to the coroutine phase.

Additionally, added `.asSequence()` to a high-overhead list filter/sort/map pipeline in `MangaViewModel.kt`'s `DownloadNextUnread` action, avoiding multiple large intermediate list allocations in memory.

---
*PR created automatically by Jules for task [2824986546605442803](https://jules.google.com/task/2824986546605442803) started by @nonproto*