### PR TITLE
fix: don't sign user out of MangaDex on transient refresh failures

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/network/MangaDexTokenAuthenticator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/MangaDexTokenAuthenticator.kt
@@ -38,11 +38,9 @@ class MangaDexTokenAuthenticator(private val loginHelper: MangaDexLoginHelper) :
                         TimberKt.i { "$tag Token is invalid trying to refresh" }
                         validated = loginHelper.refreshSessionToken()
                     }
-
-                    if (!validated) {
-                        TimberKt.i { "$tag Unable to refresh token user will need to relogin" }
-                        loginHelper.invalidate()
-                    }
+                    // refreshSessionToken handles invalidation on persistent failures
+                    // and intentionally preserves tokens on transient failures so that
+                    // a later 401 can naturally retry the refresh.
                 } else {
                     validated = false
                     loginHelper.invalidate()

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelper.kt
@@ -7,16 +7,20 @@ import eu.kanade.tachiyomi.source.online.models.dto.LoginResponseDto
 import eu.kanade.tachiyomi.source.online.utils.MdUtil
 import eu.kanade.tachiyomi.util.system.launchUI
 import eu.kanade.tachiyomi.util.system.toast
+import java.io.IOException
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import okhttp3.FormBody
 import okhttp3.Headers
+import okhttp3.Response
 import org.nekomanga.constants.MdConstants
 import org.nekomanga.core.network.POST
 import org.nekomanga.domain.site.MangaDexPreferences
 import org.nekomanga.logging.TimberKt
+import tachiyomi.core.network.HttpException
 import tachiyomi.core.network.await
 import tachiyomi.core.network.parseAs
 import uy.kohesive.injekt.Injekt
@@ -50,9 +54,39 @@ class MangaDexLoginHelper {
         if (refreshToken.isEmpty()) {
             TimberKt.i { "$tag refresh token is null can't extend session" }
             toast("Refresh token null, logged out of MangaDex")
-            invalidate()
+            unexpectedInvalidate()
             return false
         }
+
+        repeat(MAX_REFRESH_ATTEMPTS) { attempt ->
+            when (val outcome = attemptRefresh(refreshToken)) {
+                is RefreshOutcome.Success -> {
+                    preferences.setTokens(outcome.refreshToken, outcome.accessToken)
+                    preferences.unexpectedLogout().set(false)
+                    return true
+                }
+                is RefreshOutcome.Persistent -> {
+                    TimberKt.e(outcome.cause) { "$tag refresh rejected by MangaDex" }
+                    toast("Unable to refresh token, logged out of MangaDex")
+                    unexpectedInvalidate()
+                    return false
+                }
+                is RefreshOutcome.Transient -> {
+                    TimberKt.w(outcome.cause) {
+                        "$tag transient failure refreshing token (attempt ${attempt + 1}/$MAX_REFRESH_ATTEMPTS)"
+                    }
+                    if (attempt < MAX_REFRESH_ATTEMPTS - 1) {
+                        delay(RETRY_BACKOFF_MILLIS)
+                    }
+                }
+            }
+        }
+
+        TimberKt.w { "$tag transient failures exhausted refreshing token; leaving session intact" }
+        return false
+    }
+
+    private suspend fun attemptRefresh(refreshToken: String): RefreshOutcome {
         val formBody =
             FormBody.Builder()
                 .add("client_id", MdConstants.Login.clientId)
@@ -61,33 +95,33 @@ class MangaDexLoginHelper {
                 .add("code_verifier", preferences.codeVerifier().get())
                 .add("redirect_uri", MdConstants.Login.redirectUri)
                 .build()
-        val error =
-            kotlin
-                .runCatching {
-                    with(MdUtil.jsonParser) {
-                        val data =
-                            networkHelper.client
-                                .newCall(
-                                    POST(
-                                        url = MdConstants.Api.baseAuthUrl + MdConstants.Api.token,
-                                        body = formBody,
-                                    )
-                                )
-                                .await()
-                                .parseAs<LoginResponseDto>()
-                        preferences.setTokens(data.refreshToken, data.accessToken)
-                    }
-                }
-                .exceptionOrNull()
+        val request =
+            POST(url = MdConstants.Api.baseAuthUrl + MdConstants.Api.token, body = formBody)
 
-        return when (error == null) {
-            true -> true
-            false -> {
-                TimberKt.e(error) { "Error refreshing token" }
-                toast("Unable to refresh token, logged out of MangaDex")
-                invalidate()
-                false
+        val response =
+            try {
+                networkHelper.client.newCall(request).await()
+            } catch (e: IOException) {
+                return RefreshOutcome.Transient(e)
             }
+
+        return response.use { resp -> classifyResponse(resp) }
+    }
+
+    private fun classifyResponse(response: Response): RefreshOutcome {
+        return when {
+            response.isSuccessful ->
+                runCatching { with(MdUtil.jsonParser) { response.parseAs<LoginResponseDto>() } }
+                    .fold(
+                        onSuccess = {
+                            RefreshOutcome.Success(
+                                refreshToken = it.refreshToken,
+                                accessToken = it.accessToken,
+                            )
+                        },
+                        onFailure = { RefreshOutcome.Persistent(it) },
+                    )
+            else -> classifyHttpFailure(response.code)
         }
     }
 
@@ -118,6 +152,7 @@ class MangaDexLoginHelper {
                                 .await()
                                 .parseAs<LoginResponseDto>()
                         preferences.setTokens(data.refreshToken, data.accessToken)
+                        preferences.unexpectedLogout().set(false)
                     }
                 }
                 .exceptionOrNull()
@@ -141,6 +176,7 @@ class MangaDexLoginHelper {
         val refreshToken = preferences.refreshToken().get()
         if (refreshToken.isEmpty() || sessionToken.isEmpty()) {
             invalidate()
+            preferences.unexpectedLogout().set(false)
             return true
         }
 
@@ -167,6 +203,7 @@ class MangaDexLoginHelper {
                         )
                         .await()
                     invalidate()
+                    preferences.unexpectedLogout().set(false)
                 }
                 .exceptionOrNull()
 
@@ -183,6 +220,17 @@ class MangaDexLoginHelper {
     fun invalidate() {
         preferences.removeMangaDexUserName()
         preferences.removeTokens()
+    }
+
+    /**
+     * Marks the user as unexpectedly logged out (only if they were actually logged in) and clears
+     * the session and refresh tokens. The flag is observed by UI surfaces that notify the user.
+     */
+    fun unexpectedInvalidate() {
+        if (isLoggedIn()) {
+            preferences.unexpectedLogout().set(true)
+        }
+        invalidate()
     }
 
     fun isLoggedIn(): Boolean {
@@ -206,5 +254,26 @@ class MangaDexLoginHelper {
 
     fun refreshToken(): String {
         return preferences.refreshToken().get()
+    }
+
+    sealed interface RefreshOutcome {
+        data class Success(val refreshToken: String, val accessToken: String) : RefreshOutcome
+
+        data class Transient(val cause: Throwable) : RefreshOutcome
+
+        data class Persistent(val cause: Throwable) : RefreshOutcome
+    }
+
+    companion object {
+        private const val MAX_REFRESH_ATTEMPTS = 2
+        private const val RETRY_BACKOFF_MILLIS = 500L
+
+        internal fun classifyHttpFailure(code: Int): RefreshOutcome {
+            return if (code in 500..599) {
+                RefreshOutcome.Transient(HttpException(code))
+            } else {
+                RefreshOutcome.Persistent(HttpException(code))
+            }
+        }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelper.kt
@@ -111,7 +111,7 @@ class MangaDexLoginHelper {
     private fun classifyResponse(response: Response): RefreshOutcome {
         return when {
             response.isSuccessful ->
-                runCatching { with(MdUtil.jsonParser) { response.parseAs<LoginResponseDto>() } }
+                runCatching { response.parseAs<LoginResponseDto>(MdUtil.jsonParser) }
                     .fold(
                         onSuccess = {
                             RefreshOutcome.Success(

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelper.kt
@@ -111,7 +111,7 @@ class MangaDexLoginHelper {
     private fun classifyResponse(response: Response): RefreshOutcome {
         return when {
             response.isSuccessful ->
-                runCatching { response.parseAs<LoginResponseDto>(MdUtil.jsonParser) }
+                runCatching { with(MdUtil.jsonParser) { response.parseAs<LoginResponseDto>() } }
                     .fold(
                         onSuccess = {
                             RefreshOutcome.Success(
@@ -269,10 +269,11 @@ class MangaDexLoginHelper {
         private const val RETRY_BACKOFF_MILLIS = 500L
 
         internal fun classifyHttpFailure(code: Int): RefreshOutcome {
-            return if (code in 500..599 || code == 429) {
-                RefreshOutcome.Transient(HttpException(code))
-            } else {
-                RefreshOutcome.Persistent(HttpException(code))
+            val cause = HttpException(code)
+            return when (code) {
+                in 500..599,
+                429 -> RefreshOutcome.Transient(cause)
+                else -> RefreshOutcome.Persistent(cause)
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelper.kt
@@ -269,7 +269,7 @@ class MangaDexLoginHelper {
         private const val RETRY_BACKOFF_MILLIS = 500L
 
         internal fun classifyHttpFailure(code: Int): RefreshOutcome {
-            return if (code in 500..599) {
+            return if (code in 500..599 || code == 429) {
                 RefreshOutcome.Transient(HttpException(code))
             } else {
                 RefreshOutcome.Persistent(HttpException(code))

--- a/app/src/main/java/org/nekomanga/domain/site/MangaDexPreferences.kt
+++ b/app/src/main/java/org/nekomanga/domain/site/MangaDexPreferences.kt
@@ -48,6 +48,8 @@ class MangaDexPreferences(private val preferenceStore: PreferenceStore) {
 
     fun lastRefreshTime() = this.preferenceStore.getLong("mangadex_refresh_token_time", 0)
 
+    fun unexpectedLogout() = this.preferenceStore.getBoolean("mangadex_unexpected_logout", false)
+
     fun removeTokens() {
         sessionToken().delete()
         refreshToken().delete()

--- a/app/src/test/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelperTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelperTest.kt
@@ -1,0 +1,73 @@
+package eu.kanade.tachiyomi.source.online
+
+import eu.kanade.tachiyomi.source.online.MangaDexLoginHelper.Companion.classifyHttpFailure
+import eu.kanade.tachiyomi.source.online.MangaDexLoginHelper.RefreshOutcome
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+import tachiyomi.core.network.HttpException
+
+class MangaDexLoginHelperTest {
+
+    @Test
+    fun `HTTP 400 classifies as persistent`() {
+        val outcome = classifyHttpFailure(400)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Persistent>()
+        (outcome.cause as HttpException).code shouldBeEq 400
+    }
+
+    @Test
+    fun `HTTP 401 classifies as persistent`() {
+        val outcome = classifyHttpFailure(401)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Persistent>()
+    }
+
+    @Test
+    fun `HTTP 403 classifies as persistent`() {
+        val outcome = classifyHttpFailure(403)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Persistent>()
+    }
+
+    @Test
+    fun `HTTP 500 classifies as transient`() {
+        val outcome = classifyHttpFailure(500)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Transient>()
+        (outcome.cause as HttpException).code shouldBeEq 500
+    }
+
+    @Test
+    fun `HTTP 502 classifies as transient`() {
+        val outcome = classifyHttpFailure(502)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Transient>()
+    }
+
+    @Test
+    fun `HTTP 503 classifies as transient`() {
+        val outcome = classifyHttpFailure(503)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Transient>()
+    }
+
+    @Test
+    fun `HTTP 599 classifies as transient`() {
+        val outcome = classifyHttpFailure(599)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Transient>()
+    }
+
+    @Test
+    fun `HTTP 600 classifies as persistent`() {
+        // Out of the 5xx range; treat as protocol error.
+        val outcome = classifyHttpFailure(600)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Persistent>()
+    }
+
+    private infix fun Int.shouldBeEq(expected: Int) {
+        org.junit.Assert.assertEquals(expected, this)
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelperTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelperTest.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.source.online
 
 import eu.kanade.tachiyomi.source.online.MangaDexLoginHelper.Companion.classifyHttpFailure
 import eu.kanade.tachiyomi.source.online.MangaDexLoginHelper.RefreshOutcome
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.Test
 import tachiyomi.core.network.HttpException
@@ -13,7 +14,7 @@ class MangaDexLoginHelperTest {
         val outcome = classifyHttpFailure(400)
 
         outcome.shouldBeInstanceOf<RefreshOutcome.Persistent>()
-        (outcome.cause as HttpException).code shouldBeEq 400
+        (outcome.cause as HttpException).code shouldBe 400
     }
 
     @Test
@@ -35,7 +36,7 @@ class MangaDexLoginHelperTest {
         val outcome = classifyHttpFailure(500)
 
         outcome.shouldBeInstanceOf<RefreshOutcome.Transient>()
-        (outcome.cause as HttpException).code shouldBeEq 500
+        (outcome.cause as HttpException).code shouldBe 500
     }
 
     @Test
@@ -60,14 +61,18 @@ class MangaDexLoginHelperTest {
     }
 
     @Test
+    fun `HTTP 429 classifies as transient`() {
+        val outcome = classifyHttpFailure(429)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Transient>()
+        (outcome.cause as HttpException).code shouldBe 429
+    }
+
+    @Test
     fun `HTTP 600 classifies as persistent`() {
         // Out of the 5xx range; treat as protocol error.
         val outcome = classifyHttpFailure(600)
 
         outcome.shouldBeInstanceOf<RefreshOutcome.Persistent>()
-    }
-
-    private infix fun Int.shouldBeEq(expected: Int) {
-        org.junit.Assert.assertEquals(expected, this)
     }
 }


### PR DESCRIPTION
## Why

When the MangaDex session token needs refreshing, `MangaDexLoginHelper.refreshSessionToken()` catches *any* exception and invalidates the session — including transient network failures (timeouts, 5xx responses). The user is silently logged out and loses library/read-state syncing until they notice and sign in again.

A valid, non-expired refresh token should not be discarded just because the auth endpoint was momentarily unreachable.

## What

1. **Classify refresh outcomes:**
   - `IOException` (network) → transient
   - HTTP 5xx → transient
   - HTTP 4xx + body-parse failures → persistent (refresh token rejected)
   - HTTP 2xx with valid body → success
2. **Bounded retry:** up to 2 attempts (1 retry) with a 500 ms backoff for transient failures. Worst-case wait inside OkHttp's `Authenticator.authenticate()` thread stays under 500 ms.
3. **Persistent failure:** clear tokens, mark `unexpectedLogout = true`. Same as today, minus the spurious-on-network-error case.
4. **Transient exhaustion:** leave tokens intact. The next authenticated request that hits a 401 will naturally trigger another refresh attempt via `MangaDexTokenAuthenticator`.
5. **Clear `unexpectedLogout`** on successful login, successful refresh, and manual logout.
6. **Remove the redundant fallback `invalidate()`** in `MangaDexTokenAuthenticator`: `refreshSessionToken` now owns the invalidate-on-persistent-failure decision, and invalidating unconditionally would undo the transient-preserving logic.

The existing toasts are kept as-is — they're the only auth-error surface that shows over the immersive reader.

## Foundation for follow-ups

The new `MangaDexPreferences.unexpectedLogout` flag has no UI consumer in this PR. Two follow-ups will subscribe to it:

- A system tray notification (Option A)
- An in-app banner on the main scaffold (Option B)

Each is a separate PR so you can pick A, B, both, or neither.

## Tests

Unit tests cover the HTTP failure classifier (4xx → persistent, 5xx → transient, out-of-range → persistent). End-to-end retry/flag-setting tests would need MockWebServer plumbing that doesn't currently exist in this codebase's test infra, so they're scoped out of this PR.

## Test plan

- [x] \`./gradlew testDebugUnitTest\` — green
- [x] \`./gradlew assembleDebug\` — green
- [ ] Manual: trigger a transient failure (airplane mode, then re-enable network) while a sync runs — session should survive and recover on the next request
- [ ] Manual: trigger a persistent failure (revoke refresh token server-side) — session should be cleared, toast shown, \`unexpectedLogout\` flag set

🤖 Generated with [Claude Code](https://claude.com/claude-code)