### PR TITLE
feat(mangadex): in-app banner on unexpected sign-out

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/network/MangaDexTokenAuthenticator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/MangaDexTokenAuthenticator.kt
@@ -38,11 +38,9 @@ class MangaDexTokenAuthenticator(private val loginHelper: MangaDexLoginHelper) :
                         TimberKt.i { "$tag Token is invalid trying to refresh" }
                         validated = loginHelper.refreshSessionToken()
                     }
-
-                    if (!validated) {
-                        TimberKt.i { "$tag Unable to refresh token user will need to relogin" }
-                        loginHelper.invalidate()
-                    }
+                    // refreshSessionToken handles invalidation on persistent failures
+                    // and intentionally preserves tokens on transient failures so that
+                    // a later 401 can naturally retry the refresh.
                 } else {
                     validated = false
                     loginHelper.invalidate()

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelper.kt
@@ -7,16 +7,20 @@ import eu.kanade.tachiyomi.source.online.models.dto.LoginResponseDto
 import eu.kanade.tachiyomi.source.online.utils.MdUtil
 import eu.kanade.tachiyomi.util.system.launchUI
 import eu.kanade.tachiyomi.util.system.toast
+import java.io.IOException
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import okhttp3.FormBody
 import okhttp3.Headers
+import okhttp3.Response
 import org.nekomanga.constants.MdConstants
 import org.nekomanga.core.network.POST
 import org.nekomanga.domain.site.MangaDexPreferences
 import org.nekomanga.logging.TimberKt
+import tachiyomi.core.network.HttpException
 import tachiyomi.core.network.await
 import tachiyomi.core.network.parseAs
 import uy.kohesive.injekt.Injekt
@@ -50,9 +54,39 @@ class MangaDexLoginHelper {
         if (refreshToken.isEmpty()) {
             TimberKt.i { "$tag refresh token is null can't extend session" }
             toast("Refresh token null, logged out of MangaDex")
-            invalidate()
+            unexpectedInvalidate()
             return false
         }
+
+        repeat(MAX_REFRESH_ATTEMPTS) { attempt ->
+            when (val outcome = attemptRefresh(refreshToken)) {
+                is RefreshOutcome.Success -> {
+                    preferences.setTokens(outcome.refreshToken, outcome.accessToken)
+                    preferences.unexpectedLogout().set(false)
+                    return true
+                }
+                is RefreshOutcome.Persistent -> {
+                    TimberKt.e(outcome.cause) { "$tag refresh rejected by MangaDex" }
+                    toast("Unable to refresh token, logged out of MangaDex")
+                    unexpectedInvalidate()
+                    return false
+                }
+                is RefreshOutcome.Transient -> {
+                    TimberKt.w(outcome.cause) {
+                        "$tag transient failure refreshing token (attempt ${attempt + 1}/$MAX_REFRESH_ATTEMPTS)"
+                    }
+                    if (attempt < MAX_REFRESH_ATTEMPTS - 1) {
+                        delay(RETRY_BACKOFF_MILLIS)
+                    }
+                }
+            }
+        }
+
+        TimberKt.w { "$tag transient failures exhausted refreshing token; leaving session intact" }
+        return false
+    }
+
+    private suspend fun attemptRefresh(refreshToken: String): RefreshOutcome {
         val formBody =
             FormBody.Builder()
                 .add("client_id", MdConstants.Login.clientId)
@@ -61,33 +95,33 @@ class MangaDexLoginHelper {
                 .add("code_verifier", preferences.codeVerifier().get())
                 .add("redirect_uri", MdConstants.Login.redirectUri)
                 .build()
-        val error =
-            kotlin
-                .runCatching {
-                    with(MdUtil.jsonParser) {
-                        val data =
-                            networkHelper.client
-                                .newCall(
-                                    POST(
-                                        url = MdConstants.Api.baseAuthUrl + MdConstants.Api.token,
-                                        body = formBody,
-                                    )
-                                )
-                                .await()
-                                .parseAs<LoginResponseDto>()
-                        preferences.setTokens(data.refreshToken, data.accessToken)
-                    }
-                }
-                .exceptionOrNull()
+        val request =
+            POST(url = MdConstants.Api.baseAuthUrl + MdConstants.Api.token, body = formBody)
 
-        return when (error == null) {
-            true -> true
-            false -> {
-                TimberKt.e(error) { "Error refreshing token" }
-                toast("Unable to refresh token, logged out of MangaDex")
-                invalidate()
-                false
+        val response =
+            try {
+                networkHelper.client.newCall(request).await()
+            } catch (e: IOException) {
+                return RefreshOutcome.Transient(e)
             }
+
+        return response.use { resp -> classifyResponse(resp) }
+    }
+
+    private fun classifyResponse(response: Response): RefreshOutcome {
+        return when {
+            response.isSuccessful ->
+                runCatching { with(MdUtil.jsonParser) { response.parseAs<LoginResponseDto>() } }
+                    .fold(
+                        onSuccess = {
+                            RefreshOutcome.Success(
+                                refreshToken = it.refreshToken,
+                                accessToken = it.accessToken,
+                            )
+                        },
+                        onFailure = { RefreshOutcome.Persistent(it) },
+                    )
+            else -> classifyHttpFailure(response.code)
         }
     }
 
@@ -118,6 +152,7 @@ class MangaDexLoginHelper {
                                 .await()
                                 .parseAs<LoginResponseDto>()
                         preferences.setTokens(data.refreshToken, data.accessToken)
+                        preferences.unexpectedLogout().set(false)
                     }
                 }
                 .exceptionOrNull()
@@ -141,6 +176,7 @@ class MangaDexLoginHelper {
         val refreshToken = preferences.refreshToken().get()
         if (refreshToken.isEmpty() || sessionToken.isEmpty()) {
             invalidate()
+            preferences.unexpectedLogout().set(false)
             return true
         }
 
@@ -167,6 +203,7 @@ class MangaDexLoginHelper {
                         )
                         .await()
                     invalidate()
+                    preferences.unexpectedLogout().set(false)
                 }
                 .exceptionOrNull()
 
@@ -183,6 +220,17 @@ class MangaDexLoginHelper {
     fun invalidate() {
         preferences.removeMangaDexUserName()
         preferences.removeTokens()
+    }
+
+    /**
+     * Marks the user as unexpectedly logged out (only if they were actually logged in) and clears
+     * the session and refresh tokens. The flag is observed by UI surfaces that notify the user.
+     */
+    fun unexpectedInvalidate() {
+        if (isLoggedIn()) {
+            preferences.unexpectedLogout().set(true)
+        }
+        invalidate()
     }
 
     fun isLoggedIn(): Boolean {
@@ -206,5 +254,26 @@ class MangaDexLoginHelper {
 
     fun refreshToken(): String {
         return preferences.refreshToken().get()
+    }
+
+    sealed interface RefreshOutcome {
+        data class Success(val refreshToken: String, val accessToken: String) : RefreshOutcome
+
+        data class Transient(val cause: Throwable) : RefreshOutcome
+
+        data class Persistent(val cause: Throwable) : RefreshOutcome
+    }
+
+    companion object {
+        private const val MAX_REFRESH_ATTEMPTS = 2
+        private const val RETRY_BACKOFF_MILLIS = 500L
+
+        internal fun classifyHttpFailure(code: Int): RefreshOutcome {
+            return if (code in 500..599) {
+                RefreshOutcome.Transient(HttpException(code))
+            } else {
+                RefreshOutcome.Persistent(HttpException(code))
+            }
+        }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelper.kt
@@ -108,7 +108,7 @@ class MangaDexLoginHelper {
         return response.use { resp -> classifyResponse(resp) }
     }
 
-    private fun classifyResponse(response: Response): RefreshOutcome {
+    private suspend fun classifyResponse(response: Response): RefreshOutcome {
         return when {
             response.isSuccessful ->
                 runCatching { with(MdUtil.jsonParser) { response.parseAs<LoginResponseDto>() } }

--- a/app/src/main/java/org/nekomanga/domain/site/MangaDexPreferences.kt
+++ b/app/src/main/java/org/nekomanga/domain/site/MangaDexPreferences.kt
@@ -48,6 +48,8 @@ class MangaDexPreferences(private val preferenceStore: PreferenceStore) {
 
     fun lastRefreshTime() = this.preferenceStore.getLong("mangadex_refresh_token_time", 0)
 
+    fun unexpectedLogout() = this.preferenceStore.getBoolean("mangadex_unexpected_logout", false)
+
     fun removeTokens() {
         sessionToken().delete()
         refreshToken().delete()

--- a/app/src/main/java/org/nekomanga/presentation/components/MangaDexLogoutBanner.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/MangaDexLogoutBanner.kt
@@ -1,0 +1,89 @@
+package org.nekomanga.presentation.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.nekomanga.R
+import org.nekomanga.domain.site.MangaDexPreferences
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * Slim, error-themed bar shown at the top of the main app scaffold whenever the user has been
+ * unexpectedly signed out of MangaDex (auth refresh rejected). Renders nothing while signed in or
+ * after a manual sign-out.
+ *
+ * Intentionally not rendered inside [eu.kanade.tachiyomi.ui.reader.ReaderActivity] — the immersive
+ * reader has its own UI surface, and the in-helper toast covers the in-reader case.
+ */
+@Composable
+fun MangaDexLogoutBanner(onSignInClick: () -> Unit, modifier: Modifier = Modifier) {
+    val preferences = remember { Injekt.get<MangaDexPreferences>() }
+    val unexpectedLogout by
+        preferences
+            .unexpectedLogout()
+            .changes()
+            .collectAsStateWithLifecycle(initialValue = preferences.unexpectedLogout().get())
+
+    AnimatedVisibility(
+        visible = unexpectedLogout,
+        enter = expandVertically(),
+        exit = shrinkVertically(),
+        modifier = modifier,
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            color = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        ) {
+            Row(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .windowInsetsPadding(WindowInsets.statusBars)
+                        .padding(start = 16.dp, end = 4.dp, top = 8.dp, bottom = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(imageVector = Icons.Outlined.ErrorOutline, contentDescription = null)
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = stringResource(R.string.mangadex_session_expired_banner),
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                TextButton(onClick = onSignInClick) { Text(stringResource(R.string.sign_in)) }
+                IconButton(onClick = { preferences.unexpectedLogout().set(false) }) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(R.string.close),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/nekomanga/presentation/screens/MainScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MainScreen.kt
@@ -8,8 +8,9 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ import eu.kanade.tachiyomi.ui.source.latest.DisplayViewModel
 import eu.kanade.tachiyomi.ui.source.latest.toSerializable
 import org.nekomanga.logging.TimberKt
 import org.nekomanga.presentation.components.AppBar
+import org.nekomanga.presentation.components.MangaDexLogoutBanner
 import org.nekomanga.presentation.screens.deepLink.DeepLinkScreen
 import org.nekomanga.presentation.screens.deepLink.DeepLinkViewModel
 import org.nekomanga.presentation.screens.similar.SimilarViewModel
@@ -89,8 +91,12 @@ fun MainScreen(
         Unit
     }
 
-    Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
+    Column(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
+        MangaDexLogoutBanner(
+            onSignInClick = { backStack.add(Screens.Settings.Main(Screens.Settings.MangaDex)) }
+        )
         NavDisplay(
+            modifier = Modifier.weight(1f).fillMaxWidth(),
             backStack = backStack,
             onBack = { backStack.removeLastOrNull() },
             entryDecorators =

--- a/app/src/test/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelperTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/source/online/MangaDexLoginHelperTest.kt
@@ -1,0 +1,73 @@
+package eu.kanade.tachiyomi.source.online
+
+import eu.kanade.tachiyomi.source.online.MangaDexLoginHelper.Companion.classifyHttpFailure
+import eu.kanade.tachiyomi.source.online.MangaDexLoginHelper.RefreshOutcome
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+import tachiyomi.core.network.HttpException
+
+class MangaDexLoginHelperTest {
+
+    @Test
+    fun `HTTP 400 classifies as persistent`() {
+        val outcome = classifyHttpFailure(400)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Persistent>()
+        (outcome.cause as HttpException).code shouldBeEq 400
+    }
+
+    @Test
+    fun `HTTP 401 classifies as persistent`() {
+        val outcome = classifyHttpFailure(401)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Persistent>()
+    }
+
+    @Test
+    fun `HTTP 403 classifies as persistent`() {
+        val outcome = classifyHttpFailure(403)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Persistent>()
+    }
+
+    @Test
+    fun `HTTP 500 classifies as transient`() {
+        val outcome = classifyHttpFailure(500)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Transient>()
+        (outcome.cause as HttpException).code shouldBeEq 500
+    }
+
+    @Test
+    fun `HTTP 502 classifies as transient`() {
+        val outcome = classifyHttpFailure(502)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Transient>()
+    }
+
+    @Test
+    fun `HTTP 503 classifies as transient`() {
+        val outcome = classifyHttpFailure(503)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Transient>()
+    }
+
+    @Test
+    fun `HTTP 599 classifies as transient`() {
+        val outcome = classifyHttpFailure(599)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Transient>()
+    }
+
+    @Test
+    fun `HTTP 600 classifies as persistent`() {
+        // Out of the 5xx range; treat as protocol error.
+        val outcome = classifyHttpFailure(600)
+
+        outcome.shouldBeInstanceOf<RefreshOutcome.Persistent>()
+    }
+
+    private infix fun Int.shouldBeEq(expected: Int) {
+        org.junit.Assert.assertEquals(expected, this)
+    }
+}

--- a/constants/src/main/res/values/strings.xml
+++ b/constants/src/main/res/values/strings.xml
@@ -1469,6 +1469,9 @@
     <string name="crash_screen_restart_application">Restart the application</string>
 
 
+    <!-- MangaDex authentication banner -->
+    <string name="mangadex_session_expired_banner">Signed out of MangaDex — your library is no longer syncing.</string>
+
     <!-- Follows -->
     <string name="status_channel">Manga status sync</string>
     <string name="syncing_follows">Begin syncing follows</string>


### PR DESCRIPTION
## Why

Sibling alternative to #3032. Same problem (the original toast for unexpected MangaDex sign-out is nearly invisible and disappears within seconds), different surface.

This PR adds an in-app banner above the main scaffold so the awareness state is visible whenever the user is *inside* the app — regardless of whether they granted notification permission.

## What

- New \`MangaDexLogoutBanner\` composable in \`org.nekomanga.presentation.components\`.
  - Subscribes to \`MangaDexPreferences.unexpectedLogout\` (added in #3031).
  - Slim error-themed bar at the top of the screen with a "Sign in" action and a "✕" dismiss button.
  - Animated expand/shrink — zero layout impact while hidden.
  - "Sign in" navigates to MangaDex settings (\`Screens.Settings.Main(Screens.Settings.MangaDex)\`).
  - "✕" clears the flag without signing in (user chose to acknowledge).
- Inserted into \`MainScreen\` above \`NavDisplay\`. Visible on Library, Feed, Browse, Manga, Settings, and other top-level screens.
- **Not** rendered inside \`ReaderActivity\` — the reader is a separate Activity outside the \`NavDisplay\` tree. The immersive reader is covered by the existing toasts in \`MangaDexLoginHelper\`.

## Out of scope

- A system-tray notification covering the *backgrounded* case: that's the sibling PR #3032, independent of this one. The maintainer can pick A, B, both, or neither.

## Depends on

#3031 — the \`unexpectedLogout\` flag this PR subscribes to lives there.

## Test plan

- [x] \`./gradlew testDebugUnitTest\` — green
- [x] \`./gradlew assembleDebug\` — green
- [ ] Manual: simulate persistent failure (revoke refresh token server-side) → banner appears at top of Library / Feed / Browse / Settings
- [ ] Manual: tap "Sign in" → MangaDex settings screen opens; back button returns to original screen
- [ ] Manual: complete sign-in → banner disappears
- [ ] Manual: tap "✕" → banner disappears, flag cleared, sign-in screen still reachable manually
- [ ] Manual: open the reader → banner is *not* present; toast is still shown when sign-out happens mid-read
- [ ] Manual: rotate / process death — banner state survives if flag still set

🤖 Generated with [Claude Code](https://claude.com/claude-code)