### PR TITLE
feat: Syncing read status now updates the read history on MangaDex

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -301,6 +301,7 @@ class NotificationReceiver : BroadcastReceiver() {
                 statusHandler.markChaptersStatus(
                     mangaId.toString(),
                     nonMergedChapters.map { it.mangadex_chapter_id },
+                    updateHistory = true,
                 )
             }
             if (mergedChapters.isNotEmpty()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/network/services/MangaDexAuthorizedUserService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/services/MangaDexAuthorizedUserService.kt
@@ -65,6 +65,7 @@ interface MangaDexAuthorizedUserService {
     suspend fun markStatusForMultipleChapters(
         @Path("id") mangaId: String,
         @Body markStatusDto: MarkStatusDto,
+        @Query("updateHistory") updateHistory: Boolean,
     ): ApiResponse<ResultDto>
 
     @POST("${MdConstants.Api.manga}/{id}/follow")

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/StatusHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/StatusHandler.kt
@@ -46,6 +46,7 @@ class StatusHandler {
         mangaId: String,
         chapterIds: List<String>,
         read: Boolean = true,
+        updateHistory: Boolean = false,
     ) {
         withIOContext {
             val dto =
@@ -53,7 +54,7 @@ class StatusHandler {
                     true -> MarkStatusDto(chapterIdsRead = chapterIds)
                     false -> MarkStatusDto(chapterIdsUnread = chapterIds)
                 }
-            authService.markStatusForMultipleChapters(mangaId, dto).onFailure {
+            authService.markStatusForMultipleChapters(mangaId, dto, updateHistory).onFailure {
                 this.log("trying to mark chapters read=$read")
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1099,6 +1099,7 @@ constructor(
                 statusHandler.markChaptersStatus(
                     manga!!.uuid(),
                     listOf(readerChapter.chapter.mangadex_chapter_id),
+                    updateHistory = true,
                 )
             }
         } else {

--- a/app/src/main/java/org/nekomanga/usecases/chapters/MarkChaptersRemote.kt
+++ b/app/src/main/java/org/nekomanga/usecases/chapters/MarkChaptersRemote.kt
@@ -36,6 +36,7 @@ class MarkChaptersRemote(
                         mangaUuid,
                         nonMergedChapters.map { it.mangaDexChapterId },
                         syncRead,
+                        updateHistory = syncRead,
                     )
                 }
                 if (mergedChapters.isNotEmpty()) {


### PR DESCRIPTION
## Summary
- Adds the optional `?updateHistory=true` query parameter when POSTing read markers to `/manga/{id}/read`, so chapters read in the app are recorded in the user's MangaDex reading history feed in addition to the binary read-marker set.
- Live, user-driven read events opt in to `updateHistory=true`: reader auto-mark on completion, mark / mark-previous-as-read from the manga screen, and the download-notification "Mark as read" action. Unread paths and any future bulk-backfill stay at the handler default of `false`.
- Plumbing change (Retrofit method + `StatusHandler.markChaptersStatus` signature) is split from the behaviour change so each commit is reviewable independently.

## Test plan
- [ ] Sign into MangaDex with `Settings → MangaDex → Reading sync` enabled.
- [ ] Read a chapter to completion in the reader; confirm it appears at https://mangadex.org/user/me/history.
- [ ] On a manga screen, "Mark previous as read" on a few chapters; confirm those entries appear in the history feed.
- [ ] Mark a chapter as unread; confirm the request still succeeds and does not generate a history entry.

## Out of scope
- The download-notification "Mark as read" path also has a separate bug (passes the local Room PK as the manga UUID, so the request 4xxs silently). The `updateHistory=true` flag is wired in this PR ahead of that fix; the path itself will be addressed in a follow-up.
- `ChapterSourceSync` calls `markMergedChaptersStatus` with non-merged chapters, which silently no-ops. Also a follow-up.