### PR TITLE
fix: pass MangaDex manga UUID to read-marker push from notification

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -12,6 +12,7 @@ import eu.kanade.tachiyomi.data.backup.BackupRestoreJob
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.database.models.canDeleteChapter
+import eu.kanade.tachiyomi.data.database.models.uuid
 import eu.kanade.tachiyomi.data.download.DownloadJob
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
@@ -299,7 +300,7 @@ class NotificationReceiver : BroadcastReceiver() {
             if (nonMergedChapters.isNotEmpty()) {
                 val statusHandler: StatusHandler = Injekt.get()
                 statusHandler.markChaptersStatus(
-                    mangaId.toString(),
+                    manga.uuid(),
                     nonMergedChapters.map { it.mangadex_chapter_id },
                 )
             }


### PR DESCRIPTION
## Summary
- The download-notification "Mark as read" action was passing the local Room primary key (`Long`) to MangaDex's `/manga/{id}/read` endpoint instead of the manga UUID, so the request 4xx'd. The failure is swallowed by `StatusHandler.markChaptersStatus`'s `onFailure` logger, so chapters marked read this way silently never reached MangaDex.
- The `Manga` is already loaded a few lines above via `mangaRepository.getMangaById(mangaId)`; the fix replaces `mangaId.toString()` with `manga.uuid()` at the call site in `NotificationReceiver.markAsRead`.

## Test plan
- [ ] Install a debug build, sign into MangaDex, enable `Settings → MangaDex → Reading sync`.
- [ ] Queue a chapter download for a library manga; wait for the "chapter downloaded" notification.
- [ ] Tap **Mark as read** on the notification.
- [ ] Confirm on mangadex.org that the chapter is now in the read-marker set for that manga (e.g. via the manga page on the website, or `GET /manga/{id}/read`).

## Notes
- Independent of #3035; the two PRs edit adjacent lines in the same `markChaptersStatus` call (UUID arg vs. `updateHistory = true` arg) and merge cleanly in either order. Once both land, the notification path will both succeed *and* register in the user's MangaDex history feed.
- A defensive `isDigitsOnly()` guard in `StatusHandler.markChaptersStatus` (mirroring the one already in `getReadChapterIds`) was considered and skipped — adding it would replace a logged 4xx with a silent no-op, masking future call-site bugs rather than surfacing them.