### PR TITLE
fix: sort library titles case-insensitively

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryMangaItemComparator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryMangaItemComparator.kt
@@ -44,11 +44,13 @@ fun libraryMangaItemComparator(
 }
 
 private fun compareByTitle(removeArticles: Boolean): Comparator<LibraryMangaItem> {
-    return compareBy {
-        when (removeArticles) {
-            true -> it.titleWithoutArticles.lowercase()
-            false -> it.displayManga.getTitle().lowercase()
+    return Comparator { item1, item2 ->
+        val (title1, title2) = if (removeArticles) {
+            item1.titleWithoutArticles to item2.titleWithoutArticles
+        } else {
+            item1.displayManga.getTitle() to item2.displayManga.getTitle()
         }
+        title1.compareTo(title2, ignoreCase = true)
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryMangaItemComparator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryMangaItemComparator.kt
@@ -46,8 +46,8 @@ fun libraryMangaItemComparator(
 private fun compareByTitle(removeArticles: Boolean): Comparator<LibraryMangaItem> {
     return compareBy {
         when (removeArticles) {
-            true -> it.titleWithoutArticles
-            false -> it.displayManga.getTitle()
+            true -> it.titleWithoutArticles.lowercase()
+            false -> it.displayManga.getTitle().lowercase()
         }
     }
 }


### PR DESCRIPTION
Noticed this while debugging #3039, in the recording attached to that issue you can see that "BOFURI" gets listed before every other title starting with "B" because the second letter is uppercase.

## Summary

- `compareByTitle()` in `LibraryMangaItemComparator` was using Kotlin's default
  `compareBy {}` string ordering, which is case-sensitive (uppercase before lowercase).
  This caused titles starting with uppercase letters to sort before all
  lowercase-starting titles regardless of alphabetical order.
- Added `.lowercase()` to both the `removeArticles` and plain-title paths so
  comparisons are case-insensitive. Both paths are fixed: the primary title sort and
  the secondary title tiebreaker applied when sorting by other criteria.

## Test plan

- [ ] Open library, sort by Title ascending — verify mixed-case titles sort correctly
      (e.g. "alpha", "Beta", "gamma" interleave alphabetically)
- [ ] Sort by Title descending — verify order is correct reverse
- [ ] Enable "Remove articles" — verify same case-insensitive behaviour
- [ ] Sort by another criterion (e.g. Last Read) — verify the title tiebreaker also
      sorts case-insensitively

🤖 Generated with [Claude Code](https://claude.com/claude-code)