### PR TITLE
ref: extract hardcoded dimensions to AppTheme Size

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/InLibrary.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/InLibrary.kt
@@ -47,7 +47,7 @@ fun InLibraryIcon(offset: Dp, outline: Boolean) {
             imageVector = Icons.Default.Favorite,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.size(20.dp),
+            modifier = Modifier.size(Size.mediumLarge),
         )
     }
 }

--- a/app/src/main/java/org/nekomanga/presentation/components/MangaGridView.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/MangaGridView.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.cheonjaeung.compose.grid.SimpleGridCells
 import com.cheonjaeung.compose.grid.VerticalGrid
 import kotlinx.collections.immutable.ImmutableMap
@@ -267,7 +266,7 @@ fun MangaGridItem(
 
         if (displayManga.inLibrary) {
             Box(modifier = Modifier.clearAndSetSemantics {}) {
-                InLibraryBadge(shouldOutlineCover, offset = 0.dp)
+                InLibraryBadge(shouldOutlineCover, offset = Size.none)
             }
         }
         if ((showUnreadBadge && unreadCount > 0) || (showDownloadBadge && downloadCount > 0)) {
@@ -278,7 +277,7 @@ fun MangaGridItem(
                     unreadCount = unreadCount,
                     showDownloads = showDownloadBadge,
                     downloadCount = downloadCount,
-                    offset = 0.dp,
+                    offset = Size.none,
                 )
             }
         }

--- a/app/src/main/java/org/nekomanga/presentation/components/MangaListView.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/MangaListView.kt
@@ -216,7 +216,7 @@ fun MangaRow(
             if ((showUnreadBadge && unreadCount > 0) || (showDownloadBadge && downloadCount > 0)) {
                 Gap(Size.tiny)
                 DownloadUnreadBadge(
-                    offset = 0.dp,
+                    offset = Size.none,
                     outline = shouldOutlineCover,
                     showUnread = showUnreadBadge,
                     showDownloads = showDownloadBadge,


### PR DESCRIPTION
💡 What:
Replaced hardcoded `0.dp` and `20.dp` values in `InLibrary.kt`, `MangaGridView.kt`, and `MangaListView.kt` with their respective centralized design tokens (`Size.none` and `Size.mediumLarge`).

🎯 Why:
To ensure the UI layout strictly relies on the central `AppTheme` tokens as defined in `Size` (inside `Constants.kt`) and to maintain structural consistency across Jetpack Compose components.

---
*PR created automatically by Jules for task [7484891281706375334](https://jules.google.com/task/7484891281706375334) started by @nonproto*