### PR TITLE
ref: Move Feed components to presentation

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
@@ -33,7 +33,6 @@ import eu.kanade.tachiyomi.source.online.handlers.external.ComikeyHandler
 import eu.kanade.tachiyomi.source.online.handlers.external.MangaHotHandler
 import eu.kanade.tachiyomi.source.online.handlers.external.MangaPlusHandler
 import eu.kanade.tachiyomi.source.online.handlers.external.NamiComiHandler
-import eu.kanade.tachiyomi.ui.feed.FeedRepository
 import eu.kanade.tachiyomi.ui.main.AppSnackbarManager
 import eu.kanade.tachiyomi.ui.manga.MangaUpdateCoordinator
 import eu.kanade.tachiyomi.ui.source.browse.BrowseRepository
@@ -80,6 +79,7 @@ import org.nekomanga.domain.storage.StorageManager
 import org.nekomanga.domain.storage.StoragePreferences
 import org.nekomanga.domain.track.store.DelayedTrackingStore
 import org.nekomanga.logging.TimberKt
+import org.nekomanga.presentation.screens.feed.FeedRepository
 import org.nekomanga.presentation.screens.similar.SimilarRepo
 import org.nekomanga.usecases.chapters.CalculateChapterFilterUseCase
 import org.nekomanga.usecases.chapters.ChapterUseCases

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -9,14 +9,14 @@ import eu.kanade.tachiyomi.data.track.TrackService
 import eu.kanade.tachiyomi.data.updater.AppDownloadInstallJob
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.online.merged.suwayomi.LoginMode
-import eu.kanade.tachiyomi.ui.feed.FeedHistoryGroup
-import eu.kanade.tachiyomi.ui.feed.FeedScreenType
 import eu.kanade.tachiyomi.ui.main.states.SideNavAlignment
 import eu.kanade.tachiyomi.ui.main.states.SideNavMode
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.Locale
 import org.nekomanga.constants.MdConstants
+import org.nekomanga.presentation.screens.feed.FeedHistoryGroup
+import org.nekomanga.presentation.screens.feed.FeedScreenType
 import org.nekomanga.presentation.theme.Themes
 import tachiyomi.core.preference.Preference
 import tachiyomi.core.preference.PreferenceStore

--- a/app/src/main/java/eu/kanade/tachiyomi/jobs/follows/FollowsSyncProcessor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jobs/follows/FollowsSyncProcessor.kt
@@ -191,11 +191,10 @@ class FollowsSyncProcessor {
                         val mangaId = manga.id ?: return@forEach
                         try {
                             val readMdChapters =
-                                chapterRepository.getChaptersForManga(mangaId)
-                                    .mapNotNull {
-                                        if (!it.read || it.isMergedChapter()) return@mapNotNull null
-                                        it.toSimpleChapter()?.toChapterItem()
-                                    }
+                                chapterRepository.getChaptersForManga(mangaId).mapNotNull {
+                                    if (!it.read || it.isMergedChapter()) return@mapNotNull null
+                                    it.toSimpleChapter()?.toChapterItem()
+                                }
 
                             if (readMdChapters.isNotEmpty()) {
                                 chapterUseCases.markChaptersRemote(
@@ -208,7 +207,6 @@ class FollowsSyncProcessor {
                             TimberKt.e(e) { "Failed to sync read chapters for '${manga.title}'" }
                         }
                     }
-
                 }
             completeNotification(countNew.get())
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryMangaItemComparator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryMangaItemComparator.kt
@@ -45,11 +45,12 @@ fun libraryMangaItemComparator(
 
 private fun compareByTitle(removeArticles: Boolean): Comparator<LibraryMangaItem> {
     return Comparator { item1, item2 ->
-        val (title1, title2) = if (removeArticles) {
-            item1.titleWithoutArticles to item2.titleWithoutArticles
-        } else {
-            item1.displayManga.getTitle() to item2.displayManga.getTitle()
-        }
+        val (title1, title2) =
+            if (removeArticles) {
+                item1.titleWithoutArticles to item2.titleWithoutArticles
+            } else {
+                item1.displayManga.getTitle() to item2.displayManga.getTitle()
+            }
         title1.compareTo(title2, ignoreCase = true)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaConstants.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaConstants.kt
@@ -146,20 +146,17 @@ object MangaConstants {
         val matchesGlobalDefaults: Boolean = true,
     )
 
-    @Immutable
-    data class SortOption(val sortState: SortState, val sortType: SortType)
+    @Immutable data class SortOption(val sortState: SortState, val sortType: SortType)
 
     @Immutable
     data class ScanlatorFilter(val scanlators: PersistentList<ScanlatorOption> = persistentListOf())
 
-    @Immutable
-    data class ScanlatorOption(val name: String, val disabled: Boolean = false)
+    @Immutable data class ScanlatorOption(val name: String, val disabled: Boolean = false)
 
     @Immutable
     data class LanguageFilter(val languages: PersistentList<LanguageOption> = persistentListOf())
 
-    @Immutable
-    data class LanguageOption(val name: String, val disabled: Boolean = false)
+    @Immutable data class LanguageOption(val name: String, val disabled: Boolean = false)
 
     @Immutable
     data class ChapterDisplay(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -281,10 +281,12 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                 MangaConstants.CategoriesData(
                     all = allCategories.map { it.toCategoryItem() }.toPersistentList(),
                     current =
-                        allCategories.mapNotNull {
-                            if (it.id != null && it.id in mangaCategorySet) it.toCategoryItem()
-                            else null
-                        }.toPersistentList(),
+                        allCategories
+                            .mapNotNull {
+                                if (it.id != null && it.id in mangaCategorySet) it.toCategoryItem()
+                                else null
+                            }
+                            .toPersistentList(),
                 )
             }
             .distinctUntilChanged()

--- a/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaShortcutManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaShortcutManager.kt
@@ -12,7 +12,6 @@ import coil3.toBitmap
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.source.SourceManager
-import eu.kanade.tachiyomi.ui.feed.FeedRepository
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import kotlin.math.min
 import kotlinx.coroutines.CoroutineDispatcher
@@ -20,6 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.nekomanga.R
 import org.nekomanga.logging.TimberKt
+import org.nekomanga.presentation.screens.feed.FeedRepository
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 

--- a/app/src/main/java/org/nekomanga/App.kt
+++ b/app/src/main/java/org/nekomanga/App.kt
@@ -31,7 +31,6 @@ import eu.kanade.tachiyomi.crash.GlobalExceptionHandler
 import eu.kanade.tachiyomi.data.coil.coilImageLoader
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
-import eu.kanade.tachiyomi.ui.feed.FeedViewModel
 import eu.kanade.tachiyomi.ui.library.LibraryViewModel
 import eu.kanade.tachiyomi.ui.security.SecureActivityDelegate
 import eu.kanade.tachiyomi.util.manga.MangaCoverMetadata
@@ -48,6 +47,7 @@ import org.nekomanga.core.security.SecurityPreferences
 import org.nekomanga.logging.CrashReportingTree
 import org.nekomanga.logging.DebugReportingTree
 import org.nekomanga.logging.TimberKt
+import org.nekomanga.presentation.screens.feed.FeedViewModel
 import tachiyomi.core.util.system.WebViewUtil
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.injectLazy

--- a/app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt
@@ -38,15 +38,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
-import eu.kanade.tachiyomi.ui.feed.DownloadScreenActions
-import eu.kanade.tachiyomi.ui.feed.FeedScreenActions
-import eu.kanade.tachiyomi.ui.feed.FeedScreenState
-import eu.kanade.tachiyomi.ui.feed.FeedScreenType
-import eu.kanade.tachiyomi.ui.feed.FeedSettingActions
-import eu.kanade.tachiyomi.ui.feed.FeedViewModel
-import eu.kanade.tachiyomi.ui.feed.HistoryScreenPagingState
-import eu.kanade.tachiyomi.ui.feed.SummaryScreenPagingState
-import eu.kanade.tachiyomi.ui.feed.UpdatesScreenPagingState
 import eu.kanade.tachiyomi.ui.main.states.RefreshState
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.util.system.toast
@@ -57,10 +48,19 @@ import org.nekomanga.constants.MdConstants
 import org.nekomanga.presentation.components.AppBar
 import org.nekomanga.presentation.components.ButtonGroup
 import org.nekomanga.presentation.components.scaffold.RootScaffold
+import org.nekomanga.presentation.screens.feed.DownloadScreenActions
 import org.nekomanga.presentation.screens.feed.FeedBottomSheet
+import org.nekomanga.presentation.screens.feed.FeedScreenActions
 import org.nekomanga.presentation.screens.feed.FeedScreenContent
 import org.nekomanga.presentation.screens.feed.FeedScreenDialogs
+import org.nekomanga.presentation.screens.feed.FeedScreenState
 import org.nekomanga.presentation.screens.feed.FeedScreenTopBar
+import org.nekomanga.presentation.screens.feed.FeedScreenType
+import org.nekomanga.presentation.screens.feed.FeedSettingActions
+import org.nekomanga.presentation.screens.feed.FeedViewModel
+import org.nekomanga.presentation.screens.feed.HistoryScreenPagingState
+import org.nekomanga.presentation.screens.feed.SummaryScreenPagingState
+import org.nekomanga.presentation.screens.feed.UpdatesScreenPagingState
 import org.nekomanga.presentation.theme.Size
 
 @Composable

--- a/app/src/main/java/org/nekomanga/presentation/screens/MainScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MainScreen.kt
@@ -26,7 +26,6 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
-import eu.kanade.tachiyomi.ui.feed.FeedViewModel
 import eu.kanade.tachiyomi.ui.library.LibraryViewModel
 import eu.kanade.tachiyomi.ui.manga.MangaViewModel
 import eu.kanade.tachiyomi.ui.more.about.AboutViewModel
@@ -37,6 +36,7 @@ import org.nekomanga.logging.TimberKt
 import org.nekomanga.presentation.components.AppBar
 import org.nekomanga.presentation.screens.deepLink.DeepLinkScreen
 import org.nekomanga.presentation.screens.deepLink.DeepLinkViewModel
+import org.nekomanga.presentation.screens.feed.FeedViewModel
 import org.nekomanga.presentation.screens.similar.SimilarViewModel
 import org.nekomanga.presentation.screens.stats.StatsViewModel
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/download/DownloadChapterRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/download/DownloadChapterRow.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import eu.kanade.tachiyomi.data.download.model.Download
-import eu.kanade.tachiyomi.ui.feed.MoveDownloadDirection
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import me.saket.swipe.SwipeAction
@@ -47,6 +46,7 @@ import org.nekomanga.presentation.components.UiText
 import org.nekomanga.presentation.components.dropdown.SimpleDropDownItem
 import org.nekomanga.presentation.components.dropdown.SimpleDropdownMenu
 import org.nekomanga.presentation.components.theme.defaultThemeColorState
+import org.nekomanga.presentation.screens.feed.MoveDownloadDirection
 import org.nekomanga.presentation.theme.Size
 
 @Composable

--- a/app/src/main/java/org/nekomanga/presentation/screens/download/DownloadScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/download/DownloadScreen.kt
@@ -33,8 +33,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import eu.kanade.tachiyomi.data.database.models.MergeType
-import eu.kanade.tachiyomi.ui.feed.DownloadScreenActions
-import eu.kanade.tachiyomi.ui.feed.DownloaderStatus
 import jp.wasabeef.gap.Gap
 import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.R
@@ -42,6 +40,8 @@ import org.nekomanga.constants.MdConstants
 import org.nekomanga.domain.download.DownloadItem
 import org.nekomanga.presentation.components.ToolTipButton
 import org.nekomanga.presentation.components.dialog.ConfirmationDialog
+import org.nekomanga.presentation.screens.feed.DownloadScreenActions
+import org.nekomanga.presentation.screens.feed.DownloaderStatus
 import org.nekomanga.presentation.theme.Size
 import soup.compose.material.motion.MaterialFade
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedBottomSheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedBottomSheet.kt
@@ -26,8 +26,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import eu.kanade.tachiyomi.ui.feed.FeedHistoryGroup
-import eu.kanade.tachiyomi.ui.feed.FeedScreenType
 import jp.wasabeef.gap.Gap
 import org.nekomanga.R
 import org.nekomanga.presentation.components.sheets.BaseSheet

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedPage.kt
@@ -26,11 +26,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import eu.kanade.tachiyomi.source.online.utils.MdLang
-import eu.kanade.tachiyomi.ui.feed.FeedHistoryGroup
-import eu.kanade.tachiyomi.ui.feed.FeedManga
-import eu.kanade.tachiyomi.ui.feed.FeedScreenActions
-import eu.kanade.tachiyomi.ui.feed.FeedScreenType
-import eu.kanade.tachiyomi.ui.feed.SummaryScreenPagingState
 import jp.wasabeef.gap.Gap
 import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.domain.manga.Artwork

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedRepository.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedRepository.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.ui.feed
+package org.nekomanga.presentation.screens.feed
 
 import androidx.compose.ui.util.fastAny
 import com.github.michaelbull.result.Result

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedScreenComposables.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedScreenComposables.kt
@@ -9,13 +9,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import eu.kanade.tachiyomi.ui.feed.DownloadScreenActions
-import eu.kanade.tachiyomi.ui.feed.FeedScreenActions
-import eu.kanade.tachiyomi.ui.feed.FeedScreenState
-import eu.kanade.tachiyomi.ui.feed.FeedScreenType
-import eu.kanade.tachiyomi.ui.feed.HistoryScreenPagingState
-import eu.kanade.tachiyomi.ui.feed.SummaryScreenPagingState
-import eu.kanade.tachiyomi.ui.feed.UpdatesScreenPagingState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.nekomanga.R

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedScreenState.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedScreenState.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.ui.feed
+package org.nekomanga.presentation.screens.feed
 
 import androidx.compose.runtime.Immutable
 import eu.kanade.tachiyomi.ui.manga.MangaConstants

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedScreenTopBar.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedScreenTopBar.kt
@@ -6,9 +6,6 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
-import eu.kanade.tachiyomi.ui.feed.FeedScreenActions
-import eu.kanade.tachiyomi.ui.feed.FeedScreenState
-import eu.kanade.tachiyomi.ui.feed.FeedScreenType
 import org.nekomanga.R
 import org.nekomanga.presentation.components.AppBar
 import org.nekomanga.presentation.components.AppBarActions

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedViewModel.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedViewModel.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.ui.feed
+package org.nekomanga.presentation.screens.feed
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/history/FeedHistoryPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/history/FeedHistoryPage.kt
@@ -17,9 +17,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import eu.kanade.tachiyomi.ui.feed.FeedHistoryGroup
-import eu.kanade.tachiyomi.ui.feed.FeedManga
-import eu.kanade.tachiyomi.ui.feed.FeedScreenActions
 import java.util.Date
 import jp.wasabeef.gap.Gap
 import kotlinx.collections.immutable.PersistentList
@@ -27,6 +24,9 @@ import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.R
 import org.nekomanga.presentation.components.UiText
 import org.nekomanga.presentation.screens.EmptyScreen
+import org.nekomanga.presentation.screens.feed.FeedHistoryGroup
+import org.nekomanga.presentation.screens.feed.FeedManga
+import org.nekomanga.presentation.screens.feed.FeedScreenActions
 import org.nekomanga.presentation.theme.Size
 
 @Composable

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/history/HistoryCard.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/history/HistoryCard.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import eu.kanade.tachiyomi.ui.feed.FeedManga
 import jp.wasabeef.gap.Gap
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
@@ -52,6 +51,7 @@ import org.nekomanga.presentation.components.dropdown.SimpleDropdownMenu
 import org.nekomanga.presentation.components.theme.defaultThemeColorState
 import org.nekomanga.presentation.screens.feed.FeedChapterTitleLine
 import org.nekomanga.presentation.screens.feed.FeedCover
+import org.nekomanga.presentation.screens.feed.FeedManga
 import org.nekomanga.presentation.screens.feed.getReadTextColor
 import org.nekomanga.presentation.theme.Size
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/summary/ContinueReadingCard.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/summary/ContinueReadingCard.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import eu.kanade.tachiyomi.ui.feed.FeedManga
 import jp.wasabeef.gap.Gap
 import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.R
@@ -41,6 +40,7 @@ import org.nekomanga.presentation.components.dropdown.SimpleDropdownMenu
 import org.nekomanga.presentation.components.theme.defaultThemeColorState
 import org.nekomanga.presentation.screens.feed.FeedChapterTitleLine
 import org.nekomanga.presentation.screens.feed.FeedCover
+import org.nekomanga.presentation.screens.feed.FeedManga
 import org.nekomanga.presentation.screens.feed.getReadTextColor
 import org.nekomanga.presentation.screens.feed.history.LastReadLine
 import org.nekomanga.presentation.theme.Size

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/summary/FeedSummaryPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/summary/FeedSummaryPage.kt
@@ -21,8 +21,6 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import eu.kanade.tachiyomi.ui.feed.FeedManga
-import eu.kanade.tachiyomi.ui.feed.FeedScreenActions
 import jp.wasabeef.gap.Gap
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
@@ -31,6 +29,8 @@ import org.nekomanga.presentation.components.UiText
 import org.nekomanga.presentation.components.listcard.ExpressiveListCard
 import org.nekomanga.presentation.components.listcard.ListCardType
 import org.nekomanga.presentation.screens.EmptyScreen
+import org.nekomanga.presentation.screens.feed.FeedManga
+import org.nekomanga.presentation.screens.feed.FeedScreenActions
 import org.nekomanga.presentation.screens.feed.updates.UpdatesCard
 import org.nekomanga.presentation.theme.Size
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/updates/FeedUpdatesPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/updates/FeedUpdatesPage.kt
@@ -17,8 +17,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import eu.kanade.tachiyomi.ui.feed.FeedManga
-import eu.kanade.tachiyomi.ui.feed.FeedScreenActions
 import java.util.Date
 import jp.wasabeef.gap.Gap
 import kotlinx.collections.immutable.PersistentList
@@ -29,6 +27,8 @@ import org.nekomanga.presentation.components.UiText
 import org.nekomanga.presentation.components.listcard.ExpressiveListCard
 import org.nekomanga.presentation.components.listcard.ListCardType
 import org.nekomanga.presentation.screens.EmptyScreen
+import org.nekomanga.presentation.screens.feed.FeedManga
+import org.nekomanga.presentation.screens.feed.FeedScreenActions
 import org.nekomanga.presentation.theme.Size
 
 @Composable


### PR DESCRIPTION
💡 What: Moved `FeedViewModel.kt`, `FeedScreenState.kt`, and `FeedRepository.kt`
🎯 Why: Adherence to Clean Architecture / Feature Modularity. Co-locating distinct feature files (Activity + VM + Repo).
📍 From/To: `eu.kanade.tachiyomi.ui.feed` -> `org.nekomanga.presentation.screens.feed`

---
*PR created automatically by Jules for task [3103740319028159432](https://jules.google.com/task/3103740319028159432) started by @nonproto*