### PR TITLE
fix: show Ungrouped group-by option immediately after backup import

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -50,8 +50,10 @@ import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -608,26 +610,31 @@ class LibraryViewModel() : ViewModel() {
         observeLibraryUpdates()
         preferenceUpdates()
 
-        viewModelScope.launchIO {
-            val groupItems =
-                mutableListOf(
-                    LibraryGroup.ByCategory,
-                    LibraryGroup.ByTag,
-                    LibraryGroup.ByStatus,
-                    LibraryGroup.ByAuthor,
-                    LibraryGroup.ByContent,
-                    LibraryGroup.ByLanguage,
-                )
-            if (loggedServices.isNotEmpty()) {
-                groupItems.add(LibraryGroup.ByTrackStatus)
+        categoryRepository
+            .observeCategories()
+            .map { it.isNotEmpty() }
+            .distinctUntilChanged()
+            .onEach { hasCategories ->
+                val groupItems =
+                    mutableListOf(
+                        LibraryGroup.ByCategory,
+                        LibraryGroup.ByTag,
+                        LibraryGroup.ByStatus,
+                        LibraryGroup.ByAuthor,
+                        LibraryGroup.ByContent,
+                        LibraryGroup.ByLanguage,
+                    )
+                if (loggedServices.isNotEmpty()) {
+                    groupItems.add(LibraryGroup.ByTrackStatus)
+                }
+                if (hasCategories) {
+                    groupItems.add(LibraryGroup.Ungrouped)
+                }
+                _internalLibraryScreenState.update {
+                    it.copy(groupByOptions = groupItems.toPersistentList())
+                }
             }
-            if (categoryRepository.getCategories().isNotEmpty()) {
-                groupItems.add(LibraryGroup.Ungrouped)
-            }
-            _internalLibraryScreenState.update {
-                it.copy(groupByOptions = groupItems.toPersistentList())
-            }
-        }
+            .launchIn(viewModelScope)
     }
 
     fun preferenceUpdates() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -131,9 +131,8 @@ class LibraryViewModel() : ViewModel() {
 
     private val _mangaRefreshingState = MutableStateFlow(emptySet<Long>())
 
-    private val loggedServices by lazy {
-        Injekt.get<TrackManager>().services.values.filter { it.isLogged() || it.isMdList() }
-    }
+    private val loggedServices
+        get() = Injekt.get<TrackManager>().services.values.filter { it.isLogged() || it.isMdList() }
 
     /** Save the current list to speed up loading later */
     override fun onCleared() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -616,20 +616,16 @@ class LibraryViewModel() : ViewModel() {
             .distinctUntilChanged()
             .onEach { hasCategories ->
                 val groupItems =
-                    mutableListOf(
+                    listOfNotNull(
                         LibraryGroup.ByCategory,
                         LibraryGroup.ByTag,
                         LibraryGroup.ByStatus,
                         LibraryGroup.ByAuthor,
                         LibraryGroup.ByContent,
                         LibraryGroup.ByLanguage,
+                        LibraryGroup.ByTrackStatus.takeIf { loggedServices.isNotEmpty() },
+                        LibraryGroup.Ungrouped.takeIf { hasCategories },
                     )
-                if (loggedServices.isNotEmpty()) {
-                    groupItems.add(LibraryGroup.ByTrackStatus)
-                }
-                if (hasCategories) {
-                    groupItems.add(LibraryGroup.Ungrouped)
-                }
                 _internalLibraryScreenState.update {
                     it.copy(groupByOptions = groupItems.toPersistentList())
                 }


### PR DESCRIPTION
## Summary

- After a fresh install + backup import, the library **Group By** sheet was missing the **Ungrouped** option until the app was force-stopped and restarted.
- Root cause: `groupByOptions` (including `Ungrouped`) was computed once in the `init` block via a one-shot `getCategories()` call. On a fresh install the database is empty at that moment, so `Ungrouped` was never added. A backup import later populated the categories table, but nothing re-triggered the computation.
- Fix: replace the fire-and-forget coroutine with an `observeCategories()` flow pipeline so the available group-by options are recomputed reactively whenever category presence changes. `distinctUntilChanged` prevents unnecessary rebuilds when individual categories are added/removed but the emptiness state stays the same.

## Test plan

- [ ] Fresh install → import a backup that contains categories → open library → tap Group By → **Ungrouped** should appear without a restart
- [ ] Fresh install with no backup (no categories) → **Ungrouped** should not appear
- [ ] Delete all categories at runtime → **Ungrouped** should disappear from the sheet
- [ ] All 80 existing unit tests pass (`./gradlew testStandardDebugUnitTest -x processStandardDebugGoogleServices`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)