### PR TITLE
fix: Add A11y support to SearchFooter icons

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/ColumnFooter.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ColumnFooter.kt
@@ -80,7 +80,7 @@ fun ColumnScope.SearchFooter(
             if (isError) {
                 Icon(
                     imageVector = Icons.Default.Warning,
-                    contentDescription = stringResource(id = R.string.unknown_error),
+                    contentDescription = stringResource(id = R.string.warning),
                     tint = MaterialTheme.colorScheme.error,
                 )
             } else if (title.isNotEmpty()) {

--- a/app/src/main/java/org/nekomanga/presentation/components/ColumnFooter.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ColumnFooter.kt
@@ -23,10 +23,12 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import jp.wasabeef.gap.Gap
 import kotlinx.coroutines.launch
+import org.nekomanga.R
 import org.nekomanga.presentation.components.theme.ThemeColorState
 import org.nekomanga.presentation.theme.Size
 
@@ -78,14 +80,14 @@ fun ColumnScope.SearchFooter(
             if (isError) {
                 Icon(
                     imageVector = Icons.Default.Warning,
-                    contentDescription = null,
+                    contentDescription = stringResource(id = R.string.unknown_error),
                     tint = MaterialTheme.colorScheme.error,
                 )
             } else if (title.isNotEmpty()) {
                 IconButton(onClick = { textChanged("") }) {
                     Icon(
                         imageVector = Icons.Default.Cancel,
-                        contentDescription = null,
+                        contentDescription = stringResource(id = R.string.clear),
                         tint = themeColorState.primaryColor,
                     )
                 }


### PR DESCRIPTION
**💡 What:**
Added `R.string.unknown_error` and `R.string.clear` string resources to the `contentDescription` properties of the `Warning` and `Cancel` icons in `ColumnFooter.kt`.

**🎯 Why:**
Previously, these icons had `contentDescription = null`, meaning TalkBack (screen reader) users would skip over them or not receive context about their purpose, degrading the app's accessibility.

**🎨 Visual/Accessibility Impacts:**
No visual changes. Improved TalkBack experience for users relying on screen readers.

---
*PR created automatically by Jules for task [14086557293366594409](https://jules.google.com/task/14086557293366594409) started by @nonproto*