### PR TITLE
fix: open chapter deep links for manga not in library

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -382,25 +382,28 @@ constructor(
             tempManga.copyFrom(networkManga)
             tempManga.title = networkManga.title
 
-            mangaRepository.updateManga(tempManga)
+            if (dbManga == null) {
+                val insertedId = mangaRepository.insertManga(tempManga)
+                tempManga.id = insertedId
+            } else {
+                mangaRepository.updateManga(tempManga)
+            }
             val manga = mangaRepository.getMangaByUrl(tempManga.url)!!
 
             TimberKt.d { "tempManga id ${tempManga.id}" }
             TimberKt.d { "Manga id ${manga.id}" }
 
             if (chapters.isNotEmpty()) {
-                val (newChapters, _) =
-                    syncChaptersWithSource(
-                        appDatabase = appDatabase,
-                        chapterRepository = chapterRepository,
-                        mangaRepository = mangaRepository,
-                        manga = manga,
-                        rawSourceChapters = chapters,
-                    )
-                val currentChapter = newChapters.find {
-                    it.url == MdConstants.chapterSuffix + urlChapterId
-                }
-                if (currentChapter?.id != null) {
+                syncChaptersWithSource(
+                    appDatabase = appDatabase,
+                    chapterRepository = chapterRepository,
+                    mangaRepository = mangaRepository,
+                    manga = manga,
+                    rawSourceChapters = chapters,
+                )
+                val currentChapter =
+                    chapterRepository.getChapterByUrl(MdConstants.chapterSuffix + urlChapterId)
+                if (currentChapter?.id != null && !currentChapter.isUnavailable) {
                     withContext(Dispatchers.Main) { init(manga.id!!, currentChapter.id!!) }
                 } else {
                     throw Exception("Chapter not found")


### PR DESCRIPTION
## Problem

Opening a MangaDex chapter link from another app (browser, Discord, etc.) fails for some chapters: `ReaderActivity` opens briefly showing nothing, closes immediately, and leaves a blank toast on screen. The issue is not random — it consistently affects chapters whose parent manga is not in the user's local library.

**Root cause confirmed by device log (`neko_crash_log-202605090024.txt`):** all three API calls for the failing chapter UUID returned HTTP 200. The crash happened after the network calls completed:

```
E ReaderActivity: Error setting initial chapter
E ReaderActivity: java.lang.NullPointerException
E ReaderActivity:     at eu.kanade.tachiyomi.ui.reader.ReaderViewModel.loadChapterURL(...)
```

`NullPointerException.message` is `null`, so `setInitialChapterError` calls `toast(null)`, which renders as a visible but blank toast.

## Root cause analysis

Both bugs are in `ReaderViewModel.loadChapterURL()`.

### Bug 1 — `updateManga` on an unsaved manga (causes the NPE)

When the chapter's manga is not in the library, `getMangaByUrl` returns `null` and a temporary `MangaImpl` is created with no database ID. After the API calls succeed, the code calls:

```kotlin
mangaRepository.updateManga(tempManga)           // Room @Update with id = 0L → no row matched, silent no-op
val manga = mangaRepository.getMangaByUrl(url)!! // manga was never inserted → null → NullPointerException
```

Room's `@Update` requires an existing row; it does nothing when the primary key is not found. The manga is never written to the database, so the subsequent lookup returns `null` and the `!!` assertion crashes.

Chapters belonging to a manga that *is* already in the library work correctly because in that case `dbManga` is not `null`, `updateManga` finds the existing row, and the lookup succeeds.

### Bug 2 — chapter lookup in `newChapters` after sync

After `syncChaptersWithSource`, the code searched for the target chapter inside the `newChapters` list returned by that function. `newChapters` contains only chapters that were **newly inserted** during the sync (`toAdd`). Chapters that already existed in the database end up in `toChange` and are absent from `newChapters`, causing a spurious "Chapter not found" error even though the chapter is present in the database.

## Fix

**File:** `app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt`

### Fix 1 — use `insertManga` for manga not yet in the database

```kotlin
// Before
mangaRepository.updateManga(tempManga)
val manga = mangaRepository.getMangaByUrl(tempManga.url)!!

// After
if (dbManga == null) {
    val insertedId = mangaRepository.insertManga(tempManga)
    tempManga.id = insertedId
} else {
    mangaRepository.updateManga(tempManga)
}
val manga = mangaRepository.getMangaByUrl(tempManga.url)!!
```

`insertManga` uses `@Insert(onConflict = REPLACE)` and returns the auto-generated row ID, which is assigned back to `tempManga.id` so subsequent operations have a valid reference.

### Fix 2 — query the DB directly after sync instead of reading `newChapters`

```kotlin
// Before
val (newChapters, _) = syncChaptersWithSource(...)
val currentChapter = newChapters.find { it.url == MdConstants.chapterSuffix + urlChapterId }
if (currentChapter?.id != null) { ... }

// After
syncChaptersWithSource(...)
val currentChapter = chapterRepository.getChapterByUrl(MdConstants.chapterSuffix + urlChapterId)
if (currentChapter?.id != null && !currentChapter.isUnavailable) { ... }
```

Querying the database directly finds the chapter regardless of whether it was freshly inserted or already present and merely updated during the sync. The `!currentChapter.isUnavailable` guard preserves the existing filtering that prevents opening removed chapters, consistent with the guard already present in `MangaScreen`.

Fixes #3064.

## Test plan

- [ ] Open a chapter link from another app for a manga **not in the library** — the reader should open and load the chapter.
- [ ] Open a chapter link for a manga **already in the library** — should continue to work as before.
- [ ] Open a chapter link for a chapter marked as unavailable — "Chapter not found" should be shown without opening the reader.
- [ ] `./gradlew testDebugUnitTest` passes with no failures.