### PR TITLE
fix: replace empty error toasts and notifications with "Unknown error" fallback

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
@@ -58,7 +58,7 @@ class BackupNotifier(private val context: Context) {
 
         with(completeNotificationBuilder) {
             setContentTitle(context.getString(R.string.backup_failed))
-            setContentText(error)
+            setContentText(error ?: context.getString(R.string.unknown_error))
 
             show(Notifications.ID_BACKUP_COMPLETE)
         }
@@ -129,7 +129,7 @@ class BackupNotifier(private val context: Context) {
 
         with(completeNotificationBuilder) {
             setContentTitle(context.getString(R.string.restore_error))
-            setContentText(error)
+            setContentText(error ?: context.getString(R.string.unknown_error))
 
             show(Notifications.ID_RESTORE_COMPLETE)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
@@ -58,7 +58,7 @@ class BackupNotifier(private val context: Context) {
 
         with(completeNotificationBuilder) {
             setContentTitle(context.getString(R.string.backup_failed))
-            setContentText(error ?: context.getString(R.string.unknown_error))
+            setContentText(error?.takeIf { it.isNotBlank() } ?: context.getString(R.string.unknown_error))
 
             show(Notifications.ID_BACKUP_COMPLETE)
         }
@@ -129,7 +129,7 @@ class BackupNotifier(private val context: Context) {
 
         with(completeNotificationBuilder) {
             setContentTitle(context.getString(R.string.restore_error))
-            setContentText(error ?: context.getString(R.string.unknown_error))
+            setContentText(error?.takeIf { it.isNotBlank() } ?: context.getString(R.string.unknown_error))
 
             show(Notifications.ID_RESTORE_COMPLETE)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
@@ -6,6 +6,7 @@ import androidx.core.app.NotificationCompat
 import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
 import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.util.lang.orUnknownError
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.contextCompatColor
 import eu.kanade.tachiyomi.util.system.notificationBuilder
@@ -58,9 +59,7 @@ class BackupNotifier(private val context: Context) {
 
         with(completeNotificationBuilder) {
             setContentTitle(context.getString(R.string.backup_failed))
-            setContentText(
-                error?.takeUnless(String::isBlank) ?: context.getString(R.string.unknown_error)
-            )
+            setContentText(error.orUnknownError(context))
 
             show(Notifications.ID_BACKUP_COMPLETE)
         }
@@ -131,9 +130,7 @@ class BackupNotifier(private val context: Context) {
 
         with(completeNotificationBuilder) {
             setContentTitle(context.getString(R.string.restore_error))
-            setContentText(
-                error?.takeUnless(String::isBlank) ?: context.getString(R.string.unknown_error)
-            )
+            setContentText(error.orUnknownError(context))
 
             show(Notifications.ID_RESTORE_COMPLETE)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
@@ -58,7 +58,9 @@ class BackupNotifier(private val context: Context) {
 
         with(completeNotificationBuilder) {
             setContentTitle(context.getString(R.string.backup_failed))
-            setContentText(error?.takeIf { it.isNotBlank() } ?: context.getString(R.string.unknown_error))
+            setContentText(
+                error?.takeUnless(String::isBlank) ?: context.getString(R.string.unknown_error)
+            )
 
             show(Notifications.ID_BACKUP_COMPLETE)
         }
@@ -129,7 +131,9 @@ class BackupNotifier(private val context: Context) {
 
         with(completeNotificationBuilder) {
             setContentTitle(context.getString(R.string.restore_error))
-            setContentText(error?.takeIf { it.isNotBlank() } ?: context.getString(R.string.unknown_error))
+            setContentText(
+                error?.takeUnless(String::isBlank) ?: context.getString(R.string.unknown_error)
+            )
 
             show(Notifications.ID_RESTORE_COMPLETE)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppDownloadInstallJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppDownloadInstallJob.kt
@@ -43,6 +43,7 @@ import okhttp3.Call
 import okhttp3.internal.http2.ErrorCode
 import okhttp3.internal.http2.StreamResetException
 import org.nekomanga.BuildConfig
+import org.nekomanga.R
 import org.nekomanga.core.network.GET
 import org.nekomanga.logging.TimberKt
 import tachiyomi.core.network.ProgressListener
@@ -246,7 +247,9 @@ class AppDownloadInstallJob(private val context: Context, workerParams: WorkerPa
             if (error is CancellationException) throw error
             // Either install package can't be found (probably bots) or there's a security exception
             // with the download manager. Nothing we can workaround.
-            withContext(Dispatchers.Main) { context.toast(error.message ?: context.getString(R.string.unknown_error)) }
+            withContext(Dispatchers.Main) {
+                context.toast(error.message ?: context.getString(R.string.unknown_error))
+            }
             notifier.cancelInstallNotification()
             notifier.onDownloadFinished(file.getUriCompat(context))
             PreferenceManager.getDefaultSharedPreferences(context).edit {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppDownloadInstallJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppDownloadInstallJob.kt
@@ -22,6 +22,7 @@ import androidx.work.WorkerParameters
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.network.NetworkHelper
+import eu.kanade.tachiyomi.util.lang.orUnknownError
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.storage.saveTo
 import eu.kanade.tachiyomi.util.system.connectivityManager
@@ -43,7 +44,6 @@ import okhttp3.Call
 import okhttp3.internal.http2.ErrorCode
 import okhttp3.internal.http2.StreamResetException
 import org.nekomanga.BuildConfig
-import org.nekomanga.R
 import org.nekomanga.core.network.GET
 import org.nekomanga.logging.TimberKt
 import tachiyomi.core.network.ProgressListener
@@ -247,12 +247,7 @@ class AppDownloadInstallJob(private val context: Context, workerParams: WorkerPa
             if (error is CancellationException) throw error
             // Either install package can't be found (probably bots) or there's a security exception
             // with the download manager. Nothing we can workaround.
-            withContext(Dispatchers.Main) {
-                context.toast(
-                    error.message?.takeUnless(String::isBlank)
-                        ?: context.getString(R.string.unknown_error)
-                )
-            }
+            withContext(Dispatchers.Main) { context.toast(error.message.orUnknownError(context)) }
             notifier.cancelInstallNotification()
             notifier.onDownloadFinished(file.getUriCompat(context))
             PreferenceManager.getDefaultSharedPreferences(context).edit {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppDownloadInstallJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppDownloadInstallJob.kt
@@ -248,7 +248,7 @@ class AppDownloadInstallJob(private val context: Context, workerParams: WorkerPa
             // Either install package can't be found (probably bots) or there's a security exception
             // with the download manager. Nothing we can workaround.
             withContext(Dispatchers.Main) {
-                context.toast(error.message ?: context.getString(R.string.unknown_error))
+                context.toast(error.message?.takeIf { it.isNotBlank() } ?: context.getString(R.string.unknown_error))
             }
             notifier.cancelInstallNotification()
             notifier.onDownloadFinished(file.getUriCompat(context))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppDownloadInstallJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppDownloadInstallJob.kt
@@ -246,7 +246,7 @@ class AppDownloadInstallJob(private val context: Context, workerParams: WorkerPa
             if (error is CancellationException) throw error
             // Either install package can't be found (probably bots) or there's a security exception
             // with the download manager. Nothing we can workaround.
-            withContext(Dispatchers.Main) { context.toast(error.message) }
+            withContext(Dispatchers.Main) { context.toast(error.message ?: context.getString(R.string.unknown_error)) }
             notifier.cancelInstallNotification()
             notifier.onDownloadFinished(file.getUriCompat(context))
             PreferenceManager.getDefaultSharedPreferences(context).edit {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppDownloadInstallJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppDownloadInstallJob.kt
@@ -248,7 +248,10 @@ class AppDownloadInstallJob(private val context: Context, workerParams: WorkerPa
             // Either install package can't be found (probably bots) or there's a security exception
             // with the download manager. Nothing we can workaround.
             withContext(Dispatchers.Main) {
-                context.toast(error.message?.takeIf { it.isNotBlank() } ?: context.getString(R.string.unknown_error))
+                context.toast(
+                    error.message?.takeUnless(String::isBlank)
+                        ?: context.getString(R.string.unknown_error)
+                )
             }
             notifier.cancelInstallNotification()
             notifier.onDownloadFinished(file.getUriCompat(context))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1279,7 +1279,7 @@ class ReaderActivity : BaseActivity<ReaderActivityBinding>() {
     fun setInitialChapterError(error: Throwable) {
         TimberKt.e(error) { "Error setting initial chapter" }
         finish()
-        toast(error.message)
+        toast(error.message ?: getString(R.string.unknown_error))
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -83,6 +83,7 @@ import eu.kanade.tachiyomi.ui.reader.viewer.pager.R2LPagerViewer
 import eu.kanade.tachiyomi.ui.reader.viewer.pager.VerticalPagerViewer
 import eu.kanade.tachiyomi.ui.reader.viewer.webtoon.WebtoonViewer
 import eu.kanade.tachiyomi.ui.security.SecureActivityDelegate
+import eu.kanade.tachiyomi.util.lang.orUnknownError
 import eu.kanade.tachiyomi.util.storage.getUriWithAuthority
 import eu.kanade.tachiyomi.util.system.contextCompatColor
 import eu.kanade.tachiyomi.util.system.contextCompatDrawable
@@ -1279,7 +1280,7 @@ class ReaderActivity : BaseActivity<ReaderActivityBinding>() {
     fun setInitialChapterError(error: Throwable) {
         TimberKt.e(error) { "Error setting initial chapter" }
         finish()
-        toast(error.message?.takeUnless(String::isBlank) ?: getString(R.string.unknown_error))
+        toast(error.message.orUnknownError(this))
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1279,7 +1279,7 @@ class ReaderActivity : BaseActivity<ReaderActivityBinding>() {
     fun setInitialChapterError(error: Throwable) {
         TimberKt.e(error) { "Error setting initial chapter" }
         finish()
-        toast(error.message?.takeIf { it.isNotBlank() } ?: getString(R.string.unknown_error))
+        toast(error.message?.takeUnless(String::isBlank) ?: getString(R.string.unknown_error))
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1279,7 +1279,7 @@ class ReaderActivity : BaseActivity<ReaderActivityBinding>() {
     fun setInitialChapterError(error: Throwable) {
         TimberKt.e(error) { "Error setting initial chapter" }
         finish()
-        toast(error.message ?: getString(R.string.unknown_error))
+        toast(error.message?.takeIf { it.isNotBlank() } ?: getString(R.string.unknown_error))
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
@@ -36,6 +36,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
+import eu.kanade.tachiyomi.util.lang.orUnknownError
 import java.io.File
 import kotlin.math.max
 import org.nekomanga.R
@@ -284,7 +285,7 @@ fun Context.openInFirefox(url: String) {
             }
         startActivity(intent)
     } catch (e: Exception) {
-        toast(e.message?.takeUnless(String::isBlank) ?: getString(R.string.unknown_error))
+        toast(e.message.orUnknownError(this))
         openInBrowser(uri)
     }
 }
@@ -308,7 +309,7 @@ fun Context.openInBrowser(uri: Uri, forceDefaultBrowser: Boolean = false) {
             }
         startActivity(intent)
     } catch (e: Exception) {
-        toast(e.message?.takeUnless(String::isBlank) ?: getString(R.string.unknown_error))
+        toast(e.message.orUnknownError(this))
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
@@ -284,7 +284,7 @@ fun Context.openInFirefox(url: String) {
             }
         startActivity(intent)
     } catch (e: Exception) {
-        toast(e.message?.takeIf { it.isNotBlank() } ?: getString(R.string.unknown_error))
+        toast(e.message?.takeUnless(String::isBlank) ?: getString(R.string.unknown_error))
         openInBrowser(uri)
     }
 }
@@ -308,7 +308,7 @@ fun Context.openInBrowser(uri: Uri, forceDefaultBrowser: Boolean = false) {
             }
         startActivity(intent)
     } catch (e: Exception) {
-        toast(e.message?.takeIf { it.isNotBlank() } ?: getString(R.string.unknown_error))
+        toast(e.message?.takeUnless(String::isBlank) ?: getString(R.string.unknown_error))
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
@@ -284,7 +284,7 @@ fun Context.openInFirefox(url: String) {
             }
         startActivity(intent)
     } catch (e: Exception) {
-        toast(e.message ?: getString(R.string.unknown_error))
+        toast(e.message?.takeIf { it.isNotBlank() } ?: getString(R.string.unknown_error))
         openInBrowser(uri)
     }
 }
@@ -308,7 +308,7 @@ fun Context.openInBrowser(uri: Uri, forceDefaultBrowser: Boolean = false) {
             }
         startActivity(intent)
     } catch (e: Exception) {
-        toast(e.message ?: getString(R.string.unknown_error))
+        toast(e.message?.takeIf { it.isNotBlank() } ?: getString(R.string.unknown_error))
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
@@ -284,7 +284,7 @@ fun Context.openInFirefox(url: String) {
             }
         startActivity(intent)
     } catch (e: Exception) {
-        toast(e.message)
+        toast(e.message ?: getString(R.string.unknown_error))
         openInBrowser(uri)
     }
 }
@@ -308,7 +308,7 @@ fun Context.openInBrowser(uri: Uri, forceDefaultBrowser: Boolean = false) {
             }
         startActivity(intent)
     } catch (e: Exception) {
-        toast(e.message)
+        toast(e.message ?: getString(R.string.unknown_error))
     }
 }
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
@@ -247,7 +247,7 @@ fun MangaScreen(
                             Intent.createChooser(intent, context.getString(R.string.share))
                         )
                     } catch (e: Exception) {
-                        context.toast(e.message)
+                        context.toast(e.message ?: context.getString(R.string.unknown_error))
                     }
                 }
             }
@@ -275,7 +275,7 @@ fun MangaScreen(
                                     Intent.createChooser(intent, context.getString(R.string.share))
                                 )
                             } catch (e: Exception) {
-                                context.toast(e.message)
+                                context.toast(e.message ?: context.getString(R.string.unknown_error))
                             }
                         }
                     }

--- a/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
@@ -61,6 +61,7 @@ import eu.kanade.tachiyomi.ui.manga.MangaViewModel
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.ui.source.latest.DisplayScreenType
 import eu.kanade.tachiyomi.util.chapter.isAvailable
+import eu.kanade.tachiyomi.util.lang.orUnknownError
 import eu.kanade.tachiyomi.util.manga.getSlug
 import eu.kanade.tachiyomi.util.storage.getUriWithAuthority
 import eu.kanade.tachiyomi.util.system.getBestColor
@@ -247,10 +248,7 @@ fun MangaScreen(
                             Intent.createChooser(intent, context.getString(R.string.share))
                         )
                     } catch (e: Exception) {
-                        context.toast(
-                            e.message?.takeUnless(String::isBlank)
-                                ?: context.getString(R.string.unknown_error)
-                        )
+                        context.toast(e.message.orUnknownError(context))
                     }
                 }
             }
@@ -278,10 +276,7 @@ fun MangaScreen(
                                     Intent.createChooser(intent, context.getString(R.string.share))
                                 )
                             } catch (e: Exception) {
-                                context.toast(
-                                    e.message?.takeUnless(String::isBlank)
-                                        ?: context.getString(R.string.unknown_error)
-                                )
+                                context.toast(e.message.orUnknownError(context))
                             }
                         }
                     }

--- a/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
@@ -275,7 +275,9 @@ fun MangaScreen(
                                     Intent.createChooser(intent, context.getString(R.string.share))
                                 )
                             } catch (e: Exception) {
-                                context.toast(e.message ?: context.getString(R.string.unknown_error))
+                                context.toast(
+                                    e.message ?: context.getString(R.string.unknown_error)
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
@@ -247,7 +247,10 @@ fun MangaScreen(
                             Intent.createChooser(intent, context.getString(R.string.share))
                         )
                     } catch (e: Exception) {
-                        context.toast(e.message?.takeIf { it.isNotBlank() } ?: context.getString(R.string.unknown_error))
+                        context.toast(
+                            e.message?.takeUnless(String::isBlank)
+                                ?: context.getString(R.string.unknown_error)
+                        )
                     }
                 }
             }
@@ -276,7 +279,8 @@ fun MangaScreen(
                                 )
                             } catch (e: Exception) {
                                 context.toast(
-                                    e.message?.takeIf { it.isNotBlank() } ?: context.getString(R.string.unknown_error)
+                                    e.message?.takeUnless(String::isBlank)
+                                        ?: context.getString(R.string.unknown_error)
                                 )
                             }
                         }

--- a/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
@@ -247,7 +247,7 @@ fun MangaScreen(
                             Intent.createChooser(intent, context.getString(R.string.share))
                         )
                     } catch (e: Exception) {
-                        context.toast(e.message ?: context.getString(R.string.unknown_error))
+                        context.toast(e.message?.takeIf { it.isNotBlank() } ?: context.getString(R.string.unknown_error))
                     }
                 }
             }
@@ -276,7 +276,7 @@ fun MangaScreen(
                                 )
                             } catch (e: Exception) {
                                 context.toast(
-                                    e.message ?: context.getString(R.string.unknown_error)
+                                    e.message?.takeIf { it.isNotBlank() } ?: context.getString(R.string.unknown_error)
                                 )
                             }
                         }

--- a/core/src/main/kotlin/tachiyomi/core/util/lang/StringExtensions.kt
+++ b/core/src/main/kotlin/tachiyomi/core/util/lang/StringExtensions.kt
@@ -170,3 +170,8 @@ fun String.htmlDecode(): String {
 }
 
 fun String.toResultError() = ResultError.Generic(errorString = this)
+
+fun String?.orUnknownError(context: Context): String {
+    if (!isNullOrBlank()) return this
+    return context.getString(R.string.unknown_error)
+}


### PR DESCRIPTION
Throwable.message is nullable in Kotlin. Eight catch blocks passed it directly to toast() or setContentText() without a fallback, producing blank (invisible or unreadable) user-facing messages whenever an exception carried no message string.

Files changed:
- MangaScreen.kt: two share-action catch blocks
- AppDownloadInstallJob.kt: app installation catch block
- ContextExtensions.kt: openInFirefox() and openInBrowser() catch blocks
- ReaderActivity.kt: setInitialChapterError()
- BackupNotifier.kt: showBackupError() and showRestoreError()

Each site now uses `e.message ?: getString(R.string.unknown_error)` so the user always sees a readable message. The existing R.string.unknown_error ("Unknown error") string is reused — no new strings are added.

Derived from #3064.