### PR TITLE
fix: scope download folders by MangaDex UUID to prevent local chapters leaking across same-title entries

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/MangaImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/MangaImpl.kt
@@ -98,7 +98,7 @@ open class MangaImpl : Manga {
                 val downloadManager: DownloadManager by injectLazy()
                 val storageManager: StorageManager by injectLazy()
                 val provider = DownloadProvider(downloadManager.context)
-                provider.renameMangaFolder(oldTitle, title)
+                provider.renameMangaFolder(this, oldTitle)
                 storageManager.renamePagesAndCoverDirectory(oldTitle, title)
                 downloadManager.updateDownloadCacheForManga(this)
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -4,6 +4,7 @@ import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.database.models.MergeType
+import eu.kanade.tachiyomi.data.database.models.uuid
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.model.isMergedChapter
 import eu.kanade.tachiyomi.util.lang.isUUID
@@ -182,15 +183,22 @@ class DownloadCache(
             } ?: return
 
         val mangaRepository: MangaRepository = Injekt.get()
-        // Optimization: Fetch once
         val allManga = mangaRepository.getMangaList()
 
-        // 3. Create lookup map for O(1) access
-        val mangaLookup = allManga.associateBy {
+        // UUID-keyed map for new-format folders ("Title [uuid]")
+        val mangaByUuid = allManga.associateBy { it.uuid().lowercase(Locale.getDefault()) }
+        // Title-keyed map for legacy-format folders ("Title")
+        val mangaByTitle = allManga.associateBy {
             DiskUtil.buildValidFilename(it.displayTitle()).lowercase(Locale.getDefault())
         }
+        // Count per normalised title to detect unambiguous legacy folders eligible for migration
+        val titleCount =
+            allManga
+                .groupBy {
+                    DiskUtil.buildValidFilename(it.displayTitle()).lowercase(Locale.getDefault())
+                }
+                .mapValues { it.value.size }
 
-        // 4. Iterate over the folders on disk
         val newMangaFiles = ConcurrentHashMap<Long, MangaFiles>()
         coroutineScope {
             sourceDir
@@ -199,8 +207,34 @@ class DownloadCache(
                 .map { mangaDir ->
                     async {
                         val dirName = mangaDir.name ?: return@async
+                        val dirLower = dirName.lowercase(Locale.getDefault())
+
+                        val uuidFromSuffix =
+                            dirLower.substringAfterLast("[", "").removeSuffix("]").takeIf {
+                                it.isUUID()
+                            }
+
                         val manga =
-                            mangaLookup[dirName.lowercase(Locale.getDefault())] ?: return@async
+                            if (uuidFromSuffix != null) {
+                                mangaByUuid[uuidFromSuffix]
+                            } else {
+                                // Legacy title-only folder: rename to UUID-based name when
+                                // the title is unambiguous so future cache cycles use the new
+                                // format and avoid the same-title collision.
+                                val legacyManga = mangaByTitle[dirLower]
+                                if (legacyManga != null && titleCount[dirLower] == 1) {
+                                    try {
+                                        mangaDir.renameTo(provider.getMangaDirName(legacyManga))
+                                    } catch (e: Exception) {
+                                        TimberKt.e(e) {
+                                            "Failed to migrate download folder for " +
+                                                legacyManga.displayTitle()
+                                        }
+                                    }
+                                }
+                                return@async
+                            } ?: return@async
+
                         val id = manga.id ?: return@async
 
                         val files =

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -183,7 +183,8 @@ class DownloadCache(
             } ?: return
 
         val mangaRepository: MangaRepository = Injekt.get()
-        val allManga = mangaRepository.getMangaList()
+        val mangaDexId = sourceManager.mangaDex.id
+        val allManga = mangaRepository.getMangaList().filter { it.source == mangaDexId }
 
         // UUID-keyed map for new-format folders ("Title [uuid]")
         val mangaByUuid = allManga.associateBy { it.uuid().lowercase(Locale.getDefault()) }
@@ -231,8 +232,10 @@ class DownloadCache(
                                                 legacyManga.displayTitle()
                                         }
                                     }
+                                    legacyManga
+                                } else {
+                                    null
                                 }
-                                return@async
                             } ?: return@async
 
                         val id = manga.id ?: return@async

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -81,8 +81,9 @@ class DownloadProvider(
      * @param source the source of the manga.
      */
     fun findMangaDir(manga: Manga): UniFile? {
-        val sourceDir = findSourceDir()
-        return sourceDir?.findFile(getMangaDirName(manga))
+        val sourceDir = findSourceDir() ?: return null
+        return sourceDir.findFile(getMangaDirName(manga))
+            ?: sourceDir.findFile(DiskUtil.buildValidFilename(manga.displayTitle()))
     }
 
     /**
@@ -205,11 +206,12 @@ class DownloadProvider(
         }
     }
 
-    fun renameMangaFolder(from: String, to: String) {
-        val sourceDir = findSourceDir()
-        val mangaDir = sourceDir?.findFile(DiskUtil.buildValidFilename(from))
-        val toFileName = DiskUtil.buildValidFilename(to)
-        mangaDir?.renameTo(toFileName)
+    fun renameMangaFolder(manga: Manga, fromTitle: String) {
+        val sourceDir = findSourceDir() ?: return
+        val mangaDir =
+            sourceDir.findFile(DiskUtil.buildValidFilename("$fromTitle [${manga.uuid()}]"))
+                ?: sourceDir.findFile(DiskUtil.buildValidFilename(fromTitle))
+        mangaDir?.renameTo(getMangaDirName(manga))
     }
 
     /**
@@ -242,7 +244,7 @@ class DownloadProvider(
      * @param manga the manga to query.
      */
     fun getMangaDirName(manga: Manga): String {
-        return DiskUtil.buildValidFilename(manga.displayTitle())
+        return DiskUtil.buildValidFilename("${manga.displayTitle()} [${manga.uuid()}]")
     }
 
     /**

--- a/app/src/main/java/org/nekomanga/usecases/manga/ModifyMangaUseCase.kt
+++ b/app/src/main/java/org/nekomanga/usecases/manga/ModifyMangaUseCase.kt
@@ -28,7 +28,7 @@ class ModifyMangaUseCase(
             mangaRepository.updateManga(dbManga)
 
             val provider = DownloadProvider(preferences.context)
-            provider.renameMangaFolder(previousEffectiveTitle, newEffectiveTitle)
+            provider.renameMangaFolder(dbManga, previousEffectiveTitle)
             downloadManager.updateDownloadCacheForManga(dbManga)
             storageManager.renamePagesAndCoverDirectory(previousEffectiveTitle, newEffectiveTitle)
         }

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/DownloadProviderTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/DownloadProviderTest.kt
@@ -1,0 +1,24 @@
+package eu.kanade.tachiyomi.data.download
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.Test
+import tachiyomi.core.util.storage.DiskUtil
+
+class DownloadProviderTest {
+
+    @Test
+    fun `title-only naming collides for duplicate titles`() {
+        val title = "Dragon Ball"
+        DiskUtil.buildValidFilename(title) shouldBe DiskUtil.buildValidFilename(title)
+    }
+
+    @Test
+    fun `uuid-based naming distinguishes manga with same title`() {
+        val title = "Dragon Ball"
+        val uuid1 = "a96676be-9d0c-4a78-9e0b-2d52b9e5cf72"
+        val uuid2 = "b12345ab-1234-5678-abcd-ef1234567890"
+        DiskUtil.buildValidFilename("$title [$uuid1]") shouldNotBe
+            DiskUtil.buildValidFilename("$title [$uuid2]")
+    }
+}

--- a/app/src/test/java/org/nekomanga/usecases/manga/ModifyMangaUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/manga/ModifyMangaUseCaseTest.kt
@@ -108,7 +108,7 @@ class ModifyMangaUseCaseTest {
             assertNotNull(result)
             verify(exactly = 1) { mockManga.user_title = newTitle }
             verify(exactly = 1) {
-                anyConstructed<DownloadProvider>().renameMangaFolder(oldTitle, newTitle)
+                anyConstructed<DownloadProvider>().renameMangaFolder(mockManga, oldTitle)
             }
             verify(exactly = 1) { downloadManager.updateDownloadCacheForManga(mockManga) }
             verify(exactly = 1) { storageManager.renamePagesAndCoverDirectory(oldTitle, newTitle) }


### PR DESCRIPTION
Discovered after re-initializing the app with a backup.

The app maps local or downloaded chapters back to a manga using the directory the chapters are located in matching only on the manga title.

When more than one manga with the same title is present in the library the local or downloaded chapters get duplicated in all manga with that name, creating non existing chapters.

Downloaded chapters are already uniquely identified by appending the chapter's UUID to the generated file.

Updating the directory generation logic and manga decoding logic to use the same pattern will prevent this problem and should also stabilize the directories resolution when the manga changes title (both from the source or the user).

Implementing an automatic fallback and update logic prevent losing already downloaded chapters.

Pre-existing ambiguous directories will not be updated, as there is no way to know to which entries they must be updated to and need to be fixed or re-downloaded manually.