### PR TITLE
perf: add battery constraints to AppUpdateJob

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateJob.kt
@@ -38,7 +38,10 @@ class AppUpdateJob(private val context: Context, workerParams: WorkerParameters)
 
         fun setupTask(context: Context) {
             val constraints =
-                Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .setRequiresBatteryNotLow(true)
+                    .build()
 
             val request =
                 PeriodicWorkRequestBuilder<AppUpdateJob>(2, TimeUnit.DAYS, 3, TimeUnit.HOURS)


### PR DESCRIPTION
💡 What: Added WorkManager Constraints `setRequiresBatteryNotLow(true)` to `AppUpdateJob`.
🎯 Why: Battery efficiency and Doze mode compliance. App updates are a deferrable task and shouldn't run if the device battery is low.

---
*PR created automatically by Jules for task [16068132098054026679](https://jules.google.com/task/16068132098054026679) started by @nonproto*