### PR TITLE
ref: extract chapter block validation into ValidateChapterNotBlockedUseCase

### DIFF
--- a/.jules/distiller.md
+++ b/.jules/distiller.md
@@ -16,3 +16,6 @@
 ## 2026-04-26 - Extracting Formatted Build Time Logic Refinements
 **Learning:** For consistency with the rest of the codebase, view models use `by injectLazy()` for injecting UseCases rather than directly instantiating them using `Injekt.get()`. In domain logic dealing with standard ISO formats, relying on `Locale.US` rather than `Locale.getDefault()` ensures consistency. Additionally, non-null assertions (`!!`) should be avoided in favor of safe calls (`?.`) and fallback error handling (`?: error()`).
 **Action:** Always prefer `by injectLazy()` for ViewModel DI unless told otherwise. Ensure robust date parsing avoiding `!!` by providing safe calls and error fallbacks, and use `Locale.US` for programmatic parsing.
+## 2026-05-11 - Extracting Blocked Chapter Validation
+**Learning:** Pure domain Use Cases are typically registered as singletons in `AppModule.kt` (using `addSingleton()`) and injected via `Injekt`. However, Use Cases that require an Android `Context` should not be singletons; instead, instantiate them directly where needed or pass the `Context` as a function argument to avoid leaks.
+**Action:** When extracting business logic into Use Cases, keep them pure without Android dependencies to make DI simple and safe.

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/comix/ComixSigner.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/comix/ComixSigner.kt
@@ -336,12 +336,12 @@ class ComixSigner {
         /**
          * Walks `window.vm*_*` namespaces and identifies two functions:
          * - `sig`: signer — `fn(path) -> ≥40-char base64url token`
-         * - `inst`: axios installer — `fn(axiosInstance)` registers a request interceptor that signs
-         *   URLs *and* a response interceptor that decrypts `{e:"..."}` bodies. Probed by feeding a
-         *   fake axios and checking whether `interceptors.response.use` was called.
+         * - `inst`: axios installer — `fn(axiosInstance)` registers a request interceptor that
+         *   signs URLs *and* a response interceptor that decrypts `{e:"..."}` bodies. Probed by
+         *   feeding a fake axios and checking whether `interceptors.response.use` was called.
          *
-         * Returns `'sig=window.<ns>.<a>;inst=window.<ns>.<b>'` once both are found, otherwise `''` so
-         * the polling loop tries again.
+         * Returns `'sig=window.<ns>.<a>;inst=window.<ns>.<b>'` once both are found, otherwise `''`
+         * so the polling loop tries again.
          */
         private val PROBE_JS =
             """

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -357,12 +357,13 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                     dbChapter
                         .toSimpleChapter()
                         ?.takeIf { chapter ->
-                            chapterUseCases.validateChapterNotBlocked(
-                                chapter.scanlatorList(),
-                                chapter.uploader,
-                                blockedGroups,
-                                blockedUploaders,
-                            )
+                            (blockedGroups.isEmpty() && blockedUploaders.isEmpty()) ||
+                                chapterUseCases.validateChapterNotBlocked(
+                                    chapter.scanlatorList(),
+                                    chapter.uploader,
+                                    blockedGroups,
+                                    blockedUploaders,
+                                )
                         }
                         ?.let { chapter ->
                             val downloadState =

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -357,10 +357,12 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                     dbChapter
                         .toSimpleChapter()
                         ?.takeIf { chapter ->
-                            val scanlators = chapter.scanlatorList()
-                            scanlators.none { scanlator -> blockedGroups.contains(scanlator) } &&
-                                (Constants.NO_GROUP !in scanlators ||
-                                    chapter.uploader !in blockedUploaders)
+                            chapterUseCases.validateChapterNotBlocked(
+                                chapter.scanlatorList(),
+                                chapter.uploader,
+                                blockedGroups,
+                                blockedUploaders,
+                            )
                         }
                         ?.let { chapter ->
                             val downloadState =

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedRepository.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedRepository.kt
@@ -57,15 +57,15 @@ class FeedRepository(
             chapterHistories
                 .mapNotNull { chpHistory ->
                     val chapter = chpHistory.chapter
-                    if (blockedGroups.isNotEmpty() || blockedUploaders.isNotEmpty()) {
-                        val scanlators = chapter.scanlatorList()
-                        if (
-                            scanlators.fastAny { scanlator -> scanlator in blockedGroups } ||
-                                (chapter.uploader in blockedUploaders &&
-                                    Constants.NO_GROUP in scanlators)
-                        ) {
-                            return@mapNotNull null
-                        }
+                    if (
+                        !chapterUseCases.validateChapterNotBlocked(
+                            chapter.scanlatorList(),
+                            chapter.uploader,
+                            blockedGroups,
+                            blockedUploaders,
+                        )
+                    ) {
+                        return@mapNotNull null
                     }
 
                     chapter.toSimpleChapter(chpHistory.history.last_read)?.toChapterItem()
@@ -492,11 +492,13 @@ class FeedRepository(
                                     false -> it.chapter.date_upload
                                 }
 
-                            val scanlators = chapterItem.chapter.scanlatorList()
                             if (
-                                scanlators.fastAny { scanlator -> scanlator in blockedGroups } ||
-                                    (Constants.NO_GROUP in scanlators &&
-                                        chapterItem.chapter.uploader in blockedUploaders)
+                                !chapterUseCases.validateChapterNotBlocked(
+                                    chapterItem.chapter.scanlatorList(),
+                                    chapterItem.chapter.uploader,
+                                    blockedGroups,
+                                    blockedUploaders,
+                                )
                             ) {
                                 return@mapNotNull null
                             }

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedRepository.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedRepository.kt
@@ -57,15 +57,17 @@ class FeedRepository(
             chapterHistories
                 .mapNotNull { chpHistory ->
                     val chapter = chpHistory.chapter
-                    if (
-                        !chapterUseCases.validateChapterNotBlocked(
-                            chapter.scanlatorList(),
-                            chapter.uploader,
-                            blockedGroups,
-                            blockedUploaders,
-                        )
-                    ) {
-                        return@mapNotNull null
+                    if (blockedGroups.isNotEmpty() || blockedUploaders.isNotEmpty()) {
+                        if (
+                            !chapterUseCases.validateChapterNotBlocked(
+                                chapter.scanlatorList(),
+                                chapter.uploader,
+                                blockedGroups,
+                                blockedUploaders,
+                            )
+                        ) {
+                            return@mapNotNull null
+                        }
                     }
 
                     chapter.toSimpleChapter(chpHistory.history.last_read)?.toChapterItem()
@@ -492,15 +494,17 @@ class FeedRepository(
                                     false -> it.chapter.date_upload
                                 }
 
-                            if (
-                                !chapterUseCases.validateChapterNotBlocked(
-                                    chapterItem.chapter.scanlatorList(),
-                                    chapterItem.chapter.uploader,
-                                    blockedGroups,
-                                    blockedUploaders,
-                                )
-                            ) {
-                                return@mapNotNull null
+                            if (blockedGroups.isNotEmpty() || blockedUploaders.isNotEmpty()) {
+                                if (
+                                    !chapterUseCases.validateChapterNotBlocked(
+                                        chapterItem.chapter.scanlatorList(),
+                                        chapterItem.chapter.uploader,
+                                        blockedGroups,
+                                        blockedUploaders,
+                                    )
+                                ) {
+                                    return@mapNotNull null
+                                }
                             }
 
                             FeedManga(

--- a/app/src/main/java/org/nekomanga/usecases/chapters/ChapterUseCases.kt
+++ b/app/src/main/java/org/nekomanga/usecases/chapters/ChapterUseCases.kt
@@ -17,4 +17,5 @@ class ChapterUseCases(
     val markChaptersRemote = MarkChaptersRemote(statusHandler, mangaDexPreferences)
     val calculateChapterFilter = calculateChapterFilter
     val markPreviousChapters = MarkPreviousChaptersUseCase()
+    val validateChapterNotBlocked = ValidateChapterNotBlockedUseCase()
 }

--- a/app/src/main/java/org/nekomanga/usecases/chapters/ValidateChapterNotBlockedUseCase.kt
+++ b/app/src/main/java/org/nekomanga/usecases/chapters/ValidateChapterNotBlockedUseCase.kt
@@ -11,12 +11,14 @@ class ValidateChapterNotBlockedUseCase {
     ): Boolean {
         if (blockedGroups.isEmpty() && blockedUploaders.isEmpty()) return true
 
-        var hasNoGroup = false
-        for (scanlator in scanlators) {
-            if (scanlator in blockedGroups) return false
-            if (scanlator == Constants.NO_GROUP) hasNoGroup = true
+        val isGroupBlocked = scanlators.any { it in blockedGroups }
+        if (isGroupBlocked) return false
+
+        if (blockedUploaders.isNotEmpty()) {
+            val hasNoGroup = scanlators.any { it == Constants.NO_GROUP }
+            if (hasNoGroup && uploader in blockedUploaders) return false
         }
 
-        return !(hasNoGroup && uploader in blockedUploaders)
+        return true
     }
 }

--- a/app/src/main/java/org/nekomanga/usecases/chapters/ValidateChapterNotBlockedUseCase.kt
+++ b/app/src/main/java/org/nekomanga/usecases/chapters/ValidateChapterNotBlockedUseCase.kt
@@ -11,9 +11,12 @@ class ValidateChapterNotBlockedUseCase {
     ): Boolean {
         if (blockedGroups.isEmpty() && blockedUploaders.isEmpty()) return true
 
-        val hasBlockedGroup = scanlators.any { it in blockedGroups }
-        val hasBlockedUploader = Constants.NO_GROUP in scanlators && uploader in blockedUploaders
+        var hasNoGroup = false
+        for (scanlator in scanlators) {
+            if (scanlator in blockedGroups) return false
+            if (scanlator == Constants.NO_GROUP) hasNoGroup = true
+        }
 
-        return !hasBlockedGroup && !hasBlockedUploader
+        return !(hasNoGroup && uploader in blockedUploaders)
     }
 }

--- a/app/src/main/java/org/nekomanga/usecases/chapters/ValidateChapterNotBlockedUseCase.kt
+++ b/app/src/main/java/org/nekomanga/usecases/chapters/ValidateChapterNotBlockedUseCase.kt
@@ -1,0 +1,19 @@
+package org.nekomanga.usecases.chapters
+
+import org.nekomanga.constants.Constants
+
+class ValidateChapterNotBlockedUseCase {
+    operator fun invoke(
+        scanlators: List<String>,
+        uploader: String?,
+        blockedGroups: Set<String>,
+        blockedUploaders: Set<String>,
+    ): Boolean {
+        if (blockedGroups.isEmpty() && blockedUploaders.isEmpty()) return true
+
+        val hasBlockedGroup = scanlators.any { it in blockedGroups }
+        val hasBlockedUploader = Constants.NO_GROUP in scanlators && uploader in blockedUploaders
+
+        return !hasBlockedGroup && !hasBlockedUploader
+    }
+}

--- a/app/src/test/java/org/nekomanga/usecases/chapters/ValidateChapterNotBlockedUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/chapters/ValidateChapterNotBlockedUseCaseTest.kt
@@ -1,0 +1,95 @@
+package org.nekomanga.usecases.chapters
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.nekomanga.constants.Constants
+
+class ValidateChapterNotBlockedUseCaseTest {
+
+    private val useCase = ValidateChapterNotBlockedUseCase()
+
+    @Test
+    fun `test empty blocked groups and uploaders returns true`() {
+        val result =
+            useCase(
+                scanlators = listOf("Group A"),
+                uploader = "Uploader B",
+                blockedGroups = emptySet(),
+                blockedUploaders = emptySet(),
+            )
+        assertTrue(result)
+    }
+
+    @Test
+    fun `test scanlator in blocked groups returns false`() {
+        val result =
+            useCase(
+                scanlators = listOf("Group A", "Group B"),
+                uploader = "Uploader B",
+                blockedGroups = setOf("Group B"),
+                blockedUploaders = emptySet(),
+            )
+        assertFalse(result)
+    }
+
+    @Test
+    fun `test scanlator not in blocked groups returns true`() {
+        val result =
+            useCase(
+                scanlators = listOf("Group A", "Group B"),
+                uploader = "Uploader B",
+                blockedGroups = setOf("Group C"),
+                blockedUploaders = emptySet(),
+            )
+        assertTrue(result)
+    }
+
+    @Test
+    fun `test blocked uploader with no group returns false`() {
+        val result =
+            useCase(
+                scanlators = listOf(Constants.NO_GROUP),
+                uploader = "Uploader B",
+                blockedGroups = emptySet(),
+                blockedUploaders = setOf("Uploader B"),
+            )
+        assertFalse(result)
+    }
+
+    @Test
+    fun `test blocked uploader with group returns true`() {
+        val result =
+            useCase(
+                scanlators = listOf("Group A"),
+                uploader = "Uploader B",
+                blockedGroups = emptySet(),
+                blockedUploaders = setOf("Uploader B"),
+            )
+        assertTrue(result)
+    }
+
+    @Test
+    fun `test no group but allowed uploader returns true`() {
+        val result =
+            useCase(
+                scanlators = listOf(Constants.NO_GROUP),
+                uploader = "Uploader B",
+                blockedGroups = emptySet(),
+                blockedUploaders = setOf("Uploader C"),
+            )
+        assertTrue(result)
+    }
+
+    @Test
+    fun `test blocked group and blocked uploader returns false`() {
+        val result =
+            useCase(
+                scanlators = listOf("Group A", Constants.NO_GROUP),
+                uploader = "Uploader B",
+                blockedGroups = setOf("Group A"),
+                blockedUploaders = setOf("Uploader B"),
+            )
+        assertFalse(result)
+    }
+}


### PR DESCRIPTION
💡 What: Extracts identical chapter block validation logic from `MangaViewModel.kt` and `FeedRepository.kt` into `ValidateChapterNotBlockedUseCase`.
🎯 Why: To abide by Single Responsibility Principle and adhere to clean architecture by extracting identical validations into highly-testable pure Kotlin use cases.

---
*PR created automatically by Jules for task [5406039564764640952](https://jules.google.com/task/5406039564764640952) started by @nonproto*