### PR TITLE
test: Add unit tests for GroupLibraryMangaUseCase

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/comix/ComixSigner.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/comix/ComixSigner.kt
@@ -336,12 +336,12 @@ class ComixSigner {
         /**
          * Walks `window.vm*_*` namespaces and identifies two functions:
          * - `sig`: signer — `fn(path) -> ≥40-char base64url token`
-         * - `inst`: axios installer — `fn(axiosInstance)` registers a request interceptor that signs
-         *   URLs *and* a response interceptor that decrypts `{e:"..."}` bodies. Probed by feeding a
-         *   fake axios and checking whether `interceptors.response.use` was called.
+         * - `inst`: axios installer — `fn(axiosInstance)` registers a request interceptor that
+         *   signs URLs *and* a response interceptor that decrypts `{e:"..."}` bodies. Probed by
+         *   feeding a fake axios and checking whether `interceptors.response.use` was called.
          *
-         * Returns `'sig=window.<ns>.<a>;inst=window.<ns>.<b>'` once both are found, otherwise `''` so
-         * the polling loop tries again.
+         * Returns `'sig=window.<ns>.<a>;inst=window.<ns>.<b>'` once both are found, otherwise `''`
+         * so the polling loop tries again.
          */
         private val PROBE_JS =
             """

--- a/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
@@ -1,11 +1,15 @@
 package org.nekomanga.usecases.library
 
+import eu.kanade.tachiyomi.ui.library.LibraryCategoryItem
 import eu.kanade.tachiyomi.ui.library.LibraryGroup
 import eu.kanade.tachiyomi.ui.library.LibrarySort
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.nekomanga.domain.category.CategoryItem
-import org.nekomanga.domain.manga.Artwork
 import org.nekomanga.domain.manga.DisplayManga
 import org.nekomanga.domain.manga.LibraryMangaItem
 
@@ -13,64 +17,76 @@ class GroupLibraryMangaUseCaseTest {
 
     private val useCase = GroupLibraryMangaUseCase()
 
-    private fun createMangaItem(
+    private fun createMockManga(
         id: Long,
-        title: String = "Manga $id",
         language: List<String> = emptyList(),
-        category: Int = 0,
         author: List<String> = emptyList(),
         genre: List<String> = emptyList(),
         status: List<String> = emptyList(),
         contentRating: List<String> = emptyList(),
+        category: Int = 0,
     ): LibraryMangaItem {
-        val displayManga =
-            DisplayManga(
-                mangaId = id,
-                inLibrary = true,
-                currentArtwork = Artwork(mangaId = id, inLibrary = true),
-                url = "",
-                originalTitle = title,
-                userTitle = "",
-            )
+        val manga = mockk<LibraryMangaItem>(relaxed = true)
+        val displayManga = mockk<DisplayManga>(relaxed = true)
+        every { displayManga.mangaId } returns id
+        every { manga.displayManga } returns displayManga
+        every { manga.language } returns language
+        every { manga.author } returns author
+        every { manga.genre } returns genre
+        every { manga.status } returns status
+        every { manga.contentRating } returns contentRating
+        every { manga.category } returns category
+        return manga
+    }
 
-        return LibraryMangaItem(
-            displayManga = displayManga,
-            language = language,
-            category = category,
-            author = author,
-            genre = genre,
-            status = status,
-            contentRating = contentRating,
-            userCover = null,
-            dynamicCover = null,
+    private fun createExpectedDynamicCategory(
+        id: Int,
+        name: String,
+        items: List<LibraryMangaItem>,
+        sortOrder: LibrarySort = LibrarySort.Title,
+        isAscending: Boolean = true,
+    ): LibraryCategoryItem {
+        return LibraryCategoryItem(
+            categoryItem =
+                CategoryItem(
+                    id = id,
+                    name = name,
+                    sortOrder = sortOrder,
+                    isAscending = isAscending,
+                    isDynamic = true,
+                    isHidden = false,
+                ),
+            libraryItems = items.toPersistentList(),
         )
     }
 
     @Test
-    fun `groupByDynamic groups by language correctly`() {
-        val manga1 = createMangaItem(1, language = listOf("English"))
-        val manga2 = createMangaItem(2, language = listOf("Japanese"))
-        val manga3 = createMangaItem(3, language = listOf("English"))
+    fun `groupByDynamic groups by language correctly and sorts categories`() {
+        val manga1 = createMockManga(1, language = listOf("Japanese"))
+        val manga2 = createMockManga(2, language = listOf("English"))
 
+        // Input in non-sorted order (Japanese then English)
         val result =
             useCase.groupByDynamic(
-                libraryMangaList = listOf(manga1, manga2, manga3),
+                libraryMangaList = listOf(manga1, manga2),
                 currentLibraryGroup = LibraryGroup.ByLanguage,
                 sortOrder = LibrarySort.Title,
                 sortAscending = true,
                 loggedInTrackStatus = emptyMap(),
             )
 
-        assertEquals(2, result.size)
-        assertEquals("English", result[0].categoryItem.name)
-        assertEquals(2, result[0].libraryItems.size)
-        assertEquals("Japanese", result[1].categoryItem.name)
-        assertEquals(1, result[1].libraryItems.size)
+        val expected =
+            listOf(
+                createExpectedDynamicCategory(0, "English", listOf(manga2)),
+                createExpectedDynamicCategory(1, "Japanese", listOf(manga1)),
+            )
+
+        assertEquals(expected, result)
     }
 
     @Test
-    fun `groupByDynamic groups by multiple languages correctly`() {
-        val manga1 = createMangaItem(1, language = listOf("English", "Japanese"))
+    fun `groupByDynamic groups by multiple languages correctly and sorts categories`() {
+        val manga1 = createMockManga(1, language = listOf("Japanese", "English"))
 
         val result =
             useCase.groupByDynamic(
@@ -81,18 +97,20 @@ class GroupLibraryMangaUseCaseTest {
                 loggedInTrackStatus = emptyMap(),
             )
 
-        assertEquals(2, result.size)
-        assertEquals("English", result[0].categoryItem.name)
-        assertEquals("Japanese", result[1].categoryItem.name)
-        assertEquals(1, result[0].libraryItems.size)
-        assertEquals(1, result[1].libraryItems.size)
+        val expected =
+            listOf(
+                createExpectedDynamicCategory(0, "English", listOf(manga1)),
+                createExpectedDynamicCategory(1, "Japanese", listOf(manga1)),
+            )
+
+        assertEquals(expected, result)
     }
 
     @Test
     fun `groupByDynamic groups by track status correctly`() {
-        val manga1 = createMangaItem(1)
-        val manga2 = createMangaItem(2)
-        val manga3 = createMangaItem(3)
+        val manga1 = createMockManga(1)
+        val manga2 = createMockManga(2)
+        val manga3 = createMockManga(3)
 
         val trackStatus =
             mapOf(1L to listOf("Reading"), 2L to listOf("Completed"), 3L to listOf("Reading"))
@@ -106,16 +124,18 @@ class GroupLibraryMangaUseCaseTest {
                 loggedInTrackStatus = trackStatus,
             )
 
-        assertEquals(2, result.size)
-        assertEquals("Reading", result[0].categoryItem.name)
-        assertEquals(2, result[0].libraryItems.size)
-        assertEquals("Completed", result[1].categoryItem.name)
-        assertEquals(1, result[1].libraryItems.size)
+        val expected =
+            listOf(
+                createExpectedDynamicCategory(0, "Reading", listOf(manga1, manga3)),
+                createExpectedDynamicCategory(1, "Completed", listOf(manga2)),
+            )
+
+        assertEquals(expected, result)
     }
 
     @Test
     fun `groupByDynamic handles untracked status correctly`() {
-        val manga1 = createMangaItem(1)
+        val manga1 = createMockManga(1)
         val trackStatus = emptyMap<Long, List<String>>()
 
         val result =
@@ -127,14 +147,15 @@ class GroupLibraryMangaUseCaseTest {
                 loggedInTrackStatus = trackStatus,
             )
 
-        assertEquals(1, result.size)
-        assertEquals("Not tracked", result[0].categoryItem.name)
+        val expected = listOf(createExpectedDynamicCategory(0, "Not tracked", listOf(manga1)))
+
+        assertEquals(expected, result)
     }
 
     @Test
     fun `groupByDynamic groups by author correctly and applies sorting`() {
-        val manga1 = createMangaItem(1, author = listOf("Oda"))
-        val manga2 = createMangaItem(2, author = listOf("Kishimoto"))
+        val manga1 = createMockManga(1, author = listOf("Oda"))
+        val manga2 = createMockManga(2, author = listOf("Kishimoto"))
 
         val result =
             useCase.groupByDynamic(
@@ -145,16 +166,67 @@ class GroupLibraryMangaUseCaseTest {
                 loggedInTrackStatus = emptyMap(),
             )
 
-        assertEquals(2, result.size)
-        assertEquals("Kishimoto", result[0].categoryItem.name)
-        assertEquals("Oda", result[1].categoryItem.name)
+        val expected =
+            listOf(
+                createExpectedDynamicCategory(0, "Kishimoto", listOf(manga2)),
+                createExpectedDynamicCategory(1, "Oda", listOf(manga1)),
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `groupByDynamic groups by status correctly`() {
+        val manga1 = createMockManga(1, status = listOf("Ongoing"))
+        val manga2 = createMockManga(2, status = listOf("Completed"))
+
+        val result =
+            useCase.groupByDynamic(
+                libraryMangaList = listOf(manga1, manga2),
+                currentLibraryGroup = LibraryGroup.ByStatus,
+                sortOrder = LibrarySort.Title,
+                sortAscending = true,
+                loggedInTrackStatus = emptyMap(),
+            )
+
+        val expected =
+            listOf(
+                createExpectedDynamicCategory(0, "Completed", listOf(manga2)),
+                createExpectedDynamicCategory(1, "Ongoing", listOf(manga1)),
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `groupByDynamic groups by tag correctly`() {
+        val manga1 = createMockManga(1, genre = listOf("Action"))
+        val manga2 = createMockManga(2, genre = listOf("Comedy"))
+
+        val result =
+            useCase.groupByDynamic(
+                libraryMangaList = listOf(manga1, manga2),
+                currentLibraryGroup = LibraryGroup.ByTag,
+                sortOrder = LibrarySort.Title,
+                sortAscending = true,
+                loggedInTrackStatus = emptyMap(),
+            )
+
+        val expected =
+            listOf(
+                createExpectedDynamicCategory(0, "Action", listOf(manga1)),
+                createExpectedDynamicCategory(1, "Comedy", listOf(manga2)),
+            )
+
+        assertEquals(expected, result)
     }
 
     @Test
     fun `groupByDynamic groups by content rating correctly and applies custom sorting`() {
-        val manga1 = createMangaItem(1, contentRating = listOf("Safe"))
-        val manga2 = createMangaItem(2, contentRating = listOf("Suggestive"))
+        val manga1 = createMockManga(1, contentRating = listOf("suggestive"))
+        val manga2 = createMockManga(2, contentRating = listOf("safe"))
 
+        // Reverse input order to ensure sorting logic is verified
         val result =
             useCase.groupByDynamic(
                 libraryMangaList = listOf(manga1, manga2),
@@ -164,15 +236,19 @@ class GroupLibraryMangaUseCaseTest {
                 loggedInTrackStatus = emptyMap(),
             )
 
-        assertEquals(2, result.size)
-        assertEquals("Safe", result[0].categoryItem.name)
-        assertEquals("Suggestive", result[1].categoryItem.name)
+        val expected =
+            listOf(
+                createExpectedDynamicCategory(0, "safe", listOf(manga2)),
+                createExpectedDynamicCategory(1, "suggestive", listOf(manga1)),
+            )
+
+        assertEquals(expected, result)
     }
 
     @Test
     fun `groupByUngrouped returns all items in one category`() {
-        val manga1 = createMangaItem(1)
-        val manga2 = createMangaItem(2)
+        val manga1 = createMockManga(1)
+        val manga2 = createMockManga(2)
 
         val result =
             useCase.groupByUngrouped(
@@ -181,36 +257,78 @@ class GroupLibraryMangaUseCaseTest {
                 isAscending = true,
             )
 
-        assertEquals(1, result.size)
-        assertEquals(CategoryItem.ALL_CATEGORY, result[0].categoryItem.name)
-        assertEquals(2, result[0].libraryItems.size)
+        val expectedCategoryItem =
+            CategoryItem(
+                id = -1,
+                name = CategoryItem.ALL_CATEGORY,
+                order = -1,
+                sortOrder = LibrarySort.Title,
+                isAscending = true,
+                isDynamic = true,
+            )
+        val expected =
+            listOf(
+                LibraryCategoryItem(
+                    categoryItem = expectedCategoryItem,
+                    libraryItems = persistentListOf(manga1, manga2),
+                )
+            )
+
+        assertEquals(expected, result)
     }
 
     @Test
-    fun `groupByCategory groups by category correctly`() {
-        val manga1 = createMangaItem(1, category = 1)
-        val manga2 = createMangaItem(2, category = 2)
-        val manga3 = createMangaItem(3, category = 1)
+    fun `groupByCategory groups by category correctly and respects category list order`() {
+        val manga1 = createMockManga(1, category = 1)
+        val manga2 = createMockManga(2, category = 2)
+        val manga3 = createMockManga(3, category = 1)
 
         val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
         val category2 = CategoryItem(id = 2, name = "Category 2", sortOrder = LibrarySort.Title)
 
+        // Pass categories in non-sorted order (2 then 1) to verify it respects list order
         val result =
             useCase.groupByCategory(
                 libraryMangaList = listOf(manga1, manga2, manga3),
-                categoryList = listOf(category1, category2),
+                categoryList = listOf(category2, category1),
             )
 
-        assertEquals(2, result.size)
-        assertEquals("Category 1", result[0].categoryItem.name)
+        val expected =
+            listOf(
+                LibraryCategoryItem(
+                    categoryItem = category2,
+                    libraryItems = persistentListOf(manga2),
+                ),
+                LibraryCategoryItem(
+                    categoryItem = category1,
+                    libraryItems = persistentListOf(manga1, manga3),
+                ),
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `groupByCategory does not deduplicate manga`() {
+        val manga1 = createMockManga(1, category = 1)
+        val manga1Duplicate = createMockManga(1, category = 1)
+        val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
+
+        val result =
+            useCase.groupByCategory(
+                libraryMangaList = listOf(manga1, manga1Duplicate),
+                categoryList = listOf(category1),
+            )
+
+        assertEquals(1, result.size)
         assertEquals(2, result[0].libraryItems.size)
-        assertEquals("Category 2", result[1].categoryItem.name)
-        assertEquals(1, result[1].libraryItems.size)
+        assertEquals(manga1, result[0].libraryItems[0])
+        assertEquals(manga1Duplicate, result[0].libraryItems[1])
     }
 
     @Test
     fun `groupByCategory excludes empty system categories`() {
-        val manga1 = createMangaItem(1, category = 1)
+        val manga1 = createMockManga(1, category = 1)
         val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
         val systemCategory =
             CategoryItem(id = 0, name = CategoryItem.SYSTEM_CATEGORY, sortOrder = LibrarySort.Title)
@@ -221,13 +339,20 @@ class GroupLibraryMangaUseCaseTest {
                 categoryList = listOf(category1, systemCategory),
             )
 
-        assertEquals(1, result.size)
-        assertEquals("Category 1", result[0].categoryItem.name)
+        val expected =
+            listOf(
+                LibraryCategoryItem(
+                    categoryItem = category1,
+                    libraryItems = persistentListOf(manga1),
+                )
+            )
+
+        assertEquals(expected, result)
     }
 
     @Test
     fun `groupByCategory includes non-empty system categories`() {
-        val manga1 = createMangaItem(1, category = 0)
+        val manga1 = createMockManga(1, category = 0)
         val systemCategory =
             CategoryItem(id = 0, name = CategoryItem.SYSTEM_CATEGORY, sortOrder = LibrarySort.Title)
 
@@ -237,8 +362,15 @@ class GroupLibraryMangaUseCaseTest {
                 categoryList = listOf(systemCategory),
             )
 
-        assertEquals(1, result.size)
-        assertEquals(CategoryItem.SYSTEM_CATEGORY, result[0].categoryItem.name)
+        val expected =
+            listOf(
+                LibraryCategoryItem(
+                    categoryItem = systemCategory,
+                    libraryItems = persistentListOf(manga1),
+                )
+            )
+
+        assertEquals(expected, result)
     }
 
     @Test
@@ -250,13 +382,13 @@ class GroupLibraryMangaUseCaseTest {
                     listOf(CategoryItem(id = 1, name = "Cat", sortOrder = LibrarySort.Title)),
             )
 
-        assertEquals(0, result.size)
+        assertEquals(emptyList<LibraryCategoryItem>(), result)
     }
 
     @Test
     fun `groupByDynamic deduplicates manga before grouping`() {
-        val manga1 = createMangaItem(1, language = listOf("English"))
-        val manga1Duplicate = createMangaItem(1, language = listOf("English"))
+        val manga1 = createMockManga(1, language = listOf("English"))
+        val manga1Duplicate = createMockManga(1, language = listOf("English"))
 
         val result =
             useCase.groupByDynamic(
@@ -267,7 +399,8 @@ class GroupLibraryMangaUseCaseTest {
                 loggedInTrackStatus = emptyMap(),
             )
 
-        assertEquals(1, result.size)
-        assertEquals(1, result[0].libraryItems.size)
+        val expected = listOf(createExpectedDynamicCategory(0, "English", listOf(manga1)))
+
+        assertEquals(expected, result)
     }
 }

--- a/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
@@ -1,0 +1,273 @@
+package org.nekomanga.usecases.library
+
+import eu.kanade.tachiyomi.ui.library.LibraryGroup
+import eu.kanade.tachiyomi.ui.library.LibrarySort
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.nekomanga.domain.category.CategoryItem
+import org.nekomanga.domain.manga.Artwork
+import org.nekomanga.domain.manga.DisplayManga
+import org.nekomanga.domain.manga.LibraryMangaItem
+
+class GroupLibraryMangaUseCaseTest {
+
+    private val useCase = GroupLibraryMangaUseCase()
+
+    private fun createMangaItem(
+        id: Long,
+        title: String = "Manga $id",
+        language: List<String> = emptyList(),
+        category: Int = 0,
+        author: List<String> = emptyList(),
+        genre: List<String> = emptyList(),
+        status: List<String> = emptyList(),
+        contentRating: List<String> = emptyList(),
+    ): LibraryMangaItem {
+        val displayManga =
+            DisplayManga(
+                mangaId = id,
+                inLibrary = true,
+                currentArtwork = Artwork(mangaId = id, inLibrary = true),
+                url = "",
+                originalTitle = title,
+                userTitle = "",
+            )
+
+        return LibraryMangaItem(
+            displayManga = displayManga,
+            language = language,
+            category = category,
+            author = author,
+            genre = genre,
+            status = status,
+            contentRating = contentRating,
+            userCover = null,
+            dynamicCover = null,
+        )
+    }
+
+    @Test
+    fun `groupByDynamic groups by language correctly`() {
+        val manga1 = createMangaItem(1, language = listOf("English"))
+        val manga2 = createMangaItem(2, language = listOf("Japanese"))
+        val manga3 = createMangaItem(3, language = listOf("English"))
+
+        val result =
+            useCase.groupByDynamic(
+                libraryMangaList = listOf(manga1, manga2, manga3),
+                currentLibraryGroup = LibraryGroup.ByLanguage,
+                sortOrder = LibrarySort.Title,
+                sortAscending = true,
+                loggedInTrackStatus = emptyMap(),
+            )
+
+        assertEquals(2, result.size)
+        assertEquals("English", result[0].categoryItem.name)
+        assertEquals(2, result[0].libraryItems.size)
+        assertEquals("Japanese", result[1].categoryItem.name)
+        assertEquals(1, result[1].libraryItems.size)
+    }
+
+    @Test
+    fun `groupByDynamic groups by multiple languages correctly`() {
+        val manga1 = createMangaItem(1, language = listOf("English", "Japanese"))
+
+        val result =
+            useCase.groupByDynamic(
+                libraryMangaList = listOf(manga1),
+                currentLibraryGroup = LibraryGroup.ByLanguage,
+                sortOrder = LibrarySort.Title,
+                sortAscending = true,
+                loggedInTrackStatus = emptyMap(),
+            )
+
+        assertEquals(2, result.size)
+        assertEquals("English", result[0].categoryItem.name)
+        assertEquals("Japanese", result[1].categoryItem.name)
+        assertEquals(1, result[0].libraryItems.size)
+        assertEquals(1, result[1].libraryItems.size)
+    }
+
+    @Test
+    fun `groupByDynamic groups by track status correctly`() {
+        val manga1 = createMangaItem(1)
+        val manga2 = createMangaItem(2)
+        val manga3 = createMangaItem(3)
+
+        val trackStatus =
+            mapOf(1L to listOf("Reading"), 2L to listOf("Completed"), 3L to listOf("Reading"))
+
+        val result =
+            useCase.groupByDynamic(
+                libraryMangaList = listOf(manga1, manga2, manga3),
+                currentLibraryGroup = LibraryGroup.ByTrackStatus,
+                sortOrder = LibrarySort.Title,
+                sortAscending = true,
+                loggedInTrackStatus = trackStatus,
+            )
+
+        assertEquals(2, result.size)
+        assertEquals("Reading", result[0].categoryItem.name)
+        assertEquals(2, result[0].libraryItems.size)
+        assertEquals("Completed", result[1].categoryItem.name)
+        assertEquals(1, result[1].libraryItems.size)
+    }
+
+    @Test
+    fun `groupByDynamic handles untracked status correctly`() {
+        val manga1 = createMangaItem(1)
+        val trackStatus = emptyMap<Long, List<String>>()
+
+        val result =
+            useCase.groupByDynamic(
+                libraryMangaList = listOf(manga1),
+                currentLibraryGroup = LibraryGroup.ByTrackStatus,
+                sortOrder = LibrarySort.Title,
+                sortAscending = true,
+                loggedInTrackStatus = trackStatus,
+            )
+
+        assertEquals(1, result.size)
+        assertEquals("Not tracked", result[0].categoryItem.name)
+    }
+
+    @Test
+    fun `groupByDynamic groups by author correctly and applies sorting`() {
+        val manga1 = createMangaItem(1, author = listOf("Oda"))
+        val manga2 = createMangaItem(2, author = listOf("Kishimoto"))
+
+        val result =
+            useCase.groupByDynamic(
+                libraryMangaList = listOf(manga1, manga2),
+                currentLibraryGroup = LibraryGroup.ByAuthor,
+                sortOrder = LibrarySort.Title,
+                sortAscending = true,
+                loggedInTrackStatus = emptyMap(),
+            )
+
+        assertEquals(2, result.size)
+        assertEquals("Kishimoto", result[0].categoryItem.name)
+        assertEquals("Oda", result[1].categoryItem.name)
+    }
+
+    @Test
+    fun `groupByDynamic groups by content rating correctly and applies custom sorting`() {
+        val manga1 = createMangaItem(1, contentRating = listOf("Safe"))
+        val manga2 = createMangaItem(2, contentRating = listOf("Suggestive"))
+
+        val result =
+            useCase.groupByDynamic(
+                libraryMangaList = listOf(manga1, manga2),
+                currentLibraryGroup = LibraryGroup.ByContent,
+                sortOrder = LibrarySort.Title,
+                sortAscending = true,
+                loggedInTrackStatus = emptyMap(),
+            )
+
+        assertEquals(2, result.size)
+        assertEquals("Safe", result[0].categoryItem.name)
+        assertEquals("Suggestive", result[1].categoryItem.name)
+    }
+
+    @Test
+    fun `groupByUngrouped returns all items in one category`() {
+        val manga1 = createMangaItem(1)
+        val manga2 = createMangaItem(2)
+
+        val result =
+            useCase.groupByUngrouped(
+                libraryMangaList = listOf(manga1, manga2),
+                sortOrder = LibrarySort.Title,
+                isAscending = true,
+            )
+
+        assertEquals(1, result.size)
+        assertEquals(CategoryItem.ALL_CATEGORY, result[0].categoryItem.name)
+        assertEquals(2, result[0].libraryItems.size)
+    }
+
+    @Test
+    fun `groupByCategory groups by category correctly`() {
+        val manga1 = createMangaItem(1, category = 1)
+        val manga2 = createMangaItem(2, category = 2)
+        val manga3 = createMangaItem(3, category = 1)
+
+        val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
+        val category2 = CategoryItem(id = 2, name = "Category 2", sortOrder = LibrarySort.Title)
+
+        val result =
+            useCase.groupByCategory(
+                libraryMangaList = listOf(manga1, manga2, manga3),
+                categoryList = listOf(category1, category2),
+            )
+
+        assertEquals(2, result.size)
+        assertEquals("Category 1", result[0].categoryItem.name)
+        assertEquals(2, result[0].libraryItems.size)
+        assertEquals("Category 2", result[1].categoryItem.name)
+        assertEquals(1, result[1].libraryItems.size)
+    }
+
+    @Test
+    fun `groupByCategory excludes empty system categories`() {
+        val manga1 = createMangaItem(1, category = 1)
+        val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
+        val systemCategory =
+            CategoryItem(id = 0, name = CategoryItem.SYSTEM_CATEGORY, sortOrder = LibrarySort.Title)
+
+        val result =
+            useCase.groupByCategory(
+                libraryMangaList = listOf(manga1),
+                categoryList = listOf(category1, systemCategory),
+            )
+
+        assertEquals(1, result.size)
+        assertEquals("Category 1", result[0].categoryItem.name)
+    }
+
+    @Test
+    fun `groupByCategory includes non-empty system categories`() {
+        val manga1 = createMangaItem(1, category = 0)
+        val systemCategory =
+            CategoryItem(id = 0, name = CategoryItem.SYSTEM_CATEGORY, sortOrder = LibrarySort.Title)
+
+        val result =
+            useCase.groupByCategory(
+                libraryMangaList = listOf(manga1),
+                categoryList = listOf(systemCategory),
+            )
+
+        assertEquals(1, result.size)
+        assertEquals(CategoryItem.SYSTEM_CATEGORY, result[0].categoryItem.name)
+    }
+
+    @Test
+    fun `groupByCategory returns empty list if library is empty`() {
+        val result =
+            useCase.groupByCategory(
+                libraryMangaList = emptyList(),
+                categoryList =
+                    listOf(CategoryItem(id = 1, name = "Cat", sortOrder = LibrarySort.Title)),
+            )
+
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `groupByDynamic deduplicates manga before grouping`() {
+        val manga1 = createMangaItem(1, language = listOf("English"))
+        val manga1Duplicate = createMangaItem(1, language = listOf("English"))
+
+        val result =
+            useCase.groupByDynamic(
+                libraryMangaList = listOf(manga1, manga1Duplicate),
+                currentLibraryGroup = LibraryGroup.ByLanguage,
+                sortOrder = LibrarySort.Title,
+                sortAscending = true,
+                loggedInTrackStatus = emptyMap(),
+            )
+
+        assertEquals(1, result.size)
+        assertEquals(1, result[0].libraryItems.size)
+    }
+}


### PR DESCRIPTION
• Introduced GroupLibraryMangaUseCaseTest.kt to improve test coverage for library grouping logic.
• Added comprehensive test cases for dynamic grouping by Language, Author, Track Status, and Content Rating.
• Validated custom sort orderings for tracking and content rating states.
• Covered edge cases for ungrouped state, empty library lists, and system category visibility rules.
• Verified manga deduplication logic within the grouping process to prevent redundant items in UI categories.
• Protected against regressions in library organization and state-based filtering.