### PR TITLE
fix: fix stream leak in setAsCover

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1041,7 +1041,7 @@ constructor(
             val result =
                 try {
                     if (manga.favorite) {
-                        coverCache.setCustomCoverToCache(manga, stream())
+                        stream().use { coverCache.setCustomCoverToCache(manga, it) }
                         manga.user_cover = "file://chapterPage-" + Random.nextInt(1000)
                         mangaRepository.updateManga(manga)
                         SetAsCoverResult.Success

--- a/app/src/test/java/org/nekomanga/usecases/chapters/ValidateChapterNotBlockedUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/chapters/ValidateChapterNotBlockedUseCaseTest.kt
@@ -1,8 +1,8 @@
 package org.nekomanga.usecases.chapters
 
-import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
 import org.nekomanga.constants.Constants
 
 class ValidateChapterNotBlockedUseCaseTest {


### PR DESCRIPTION
Wrapped stream() call inside setAsCover in ReaderViewModel.kt with a .use { } block to prevent InputStream memory leak.

---
*PR created automatically by Jules for task [12647180078288821061](https://jules.google.com/task/12647180078288821061) started by @nonproto*