### PR TITLE
🐛 Add `getMangaUrl` to Atsumaru

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/atsumaru/Atsumaru.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/atsumaru/Atsumaru.kt
@@ -41,6 +41,8 @@ class Atsumaru : ReducedHttpSource() {
 
     private val json: Json by injectLazy()
 
+    override fun getMangaUrl(url: String): String = "$baseUrl/manga/$url"
+
     override fun getChapterUrl(simpleChapter: SimpleChapter): String {
         val (slug, name) = simpleChapter.url.split("/")
         return "$baseUrl/read/$slug/$name"


### PR DESCRIPTION
### 📝 Description

<!-- Why this pull request? -->

When opening a manga on Atsumaru, it opens a link like `https://atsu.moe3z8l/`.

<!-- Why is this the best solution? -->

The correct link is `https://atsu.moe/manga/3z8l`.

<!-- What you did -->

* Add `getMangaUrl` to `Atsumaru.kt`

### 📓 References

<!-- A list of links to discussions, documentation, issues, pull requests -->

* https://github.com/NatoBoram/Neko/pull/1

### 📸 Screenshots

[![Pull Request CI](https://github.com/NatoBoram/Neko/actions/workflows/pr-ci.yaml/badge.svg?branch=bugfix%2Fatsumeru-getmangaurl)](https://github.com/NatoBoram/Neko/actions/workflows/pr-ci.yaml)

<!-- Show us your work :D -->

|                                           Before                                           |                                           After                                           |
| :----------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------: |
| ![Before](https://github.com/user-attachments/assets/3edc6796-1155-44e7-92af-75cacfef914e) | ![After](https://github.com/user-attachments/assets/2577281b-6225-45a4-af2a-d92e63a53f38) |

