### PR TITLE
fix: log exception when writing error file fails in LibraryUpdateJob

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -825,7 +825,7 @@ class LibraryUpdateJob(private val context: Context, workerParameters: WorkerPar
                 return file
             }
         } catch (e: Exception) {
-            // Empty
+            TimberKt.e(e) { "Error writing error file" }
         }
         return File("")
     }


### PR DESCRIPTION
💡 What: Replaced an empty catch block with a logging statement in `LibraryUpdateJob.kt`.

🎯 Why: The previous implementation silently swallowed any exceptions that occurred when attempting to write the error file. This made it difficult to diagnose issues. By logging the exception using the project's logger (`TimberKt.e(e)`), we improve observability and ensure that failures are visible.

Impact: Prevented silent errors when writing the library update error file.

---
*PR created automatically by Jules for task [654734579573856643](https://jules.google.com/task/654734579573856643) started by @nonproto*