### PR TITLE
fix: add contentDescription to FooterFilterChip icon

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/components/FooterFilterChip.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/FooterFilterChip.kt
@@ -27,7 +27,7 @@ fun FooterFilterChip(
         shape = RoundedCornerShape(100),
         label = {
             when (icon != null) {
-                true -> Icon(imageVector = icon, contentDescription = null)
+                true -> Icon(imageVector = icon, contentDescription = name)
                 false -> {
                     Text(
                         text = name,


### PR DESCRIPTION
💡 What: Replaced `contentDescription = null` with `contentDescription = name` for the Icon in `FooterFilterChip.kt`.
🎯 Why: To improve accessibility (A11y). When a `FooterFilterChip` displays only an icon (e.g. `when (icon != null) -> true`), it previously lacked a content description, making it inaccessible to screen readers like TalkBack.
🖼️ Impact: Screen readers will now announce the name of the chip when focusing on an icon-only `FooterFilterChip`.
✅ Verification: Ran `./gradlew ktfmtFormat`, `./gradlew lintDebug`, and `./gradlew testDebugUnitTest`. All checks pass.

---
*PR created automatically by Jules for task [13770633719676005989](https://jules.google.com/task/13770633719676005989) started by @nonproto*