### PR TITLE
ref: extract filter global update manga into FilterGlobalUpdateMangaUseCase

### DIFF
--- a/.jules/distiller.md
+++ b/.jules/distiller.md
@@ -19,3 +19,4 @@
 ## 2026-05-11 - Extracting Blocked Chapter Validation
 **Learning:** Pure domain Use Cases are typically registered as singletons in `AppModule.kt` (using `addSingleton()`) and injected via `Injekt`. However, Use Cases that require an Android `Context` should not be singletons; instead, instantiate them directly where needed or pass the `Context` as a function argument to avoid leaks.
 **Action:** When extracting business logic into Use Cases, keep them pure without Android dependencies to make DI simple and safe.
+## 2026-05-28 - Extracting Global Update Manga Filter\n**Learning:** In the Nekomanga project, use JUnit 4 (`org.junit.Test`, `org.junit.Assert`) for unit tests instead of JUnit 5 (Jupiter), as the project's test suite and build configuration are set up for JUnit 4.\n**Action:** When creating new unit tests, ensure you import `org.junit.Test` and `org.junit.Assert.*` to avoid compilation errors.

--- a/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
@@ -84,6 +84,7 @@ import org.nekomanga.presentation.screens.similar.SimilarRepo
 import org.nekomanga.usecases.chapters.CalculateChapterFilterUseCase
 import org.nekomanga.usecases.chapters.ChapterUseCases
 import org.nekomanga.usecases.chapters.ParseChapterNameUseCase
+import org.nekomanga.usecases.library.FilterGlobalUpdateMangaUseCase
 import org.nekomanga.usecases.library.FilterLibraryMangaUseCase
 import org.nekomanga.usecases.manga.MangaUseCases
 import org.nekomanga.usecases.preferences.GetDateFormatUseCase
@@ -254,6 +255,7 @@ class AppModule(val app: Application) : InjektModule {
         addSingleton(ParseChapterNameUseCase())
         addSingleton(ChapterUseCases())
 
+        addSingletonFactory { FilterGlobalUpdateMangaUseCase(get()) }
         addSingleton(FilterLibraryMangaUseCase())
 
         addSingleton(MangaUseCases())

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -1,15 +1,12 @@
 package eu.kanade.tachiyomi.data.library
 
 import android.content.Context
-import android.content.pm.ServiceInfo
-import android.os.Build
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
-import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
@@ -54,8 +51,6 @@ import eu.kanade.tachiyomi.util.manga.toDisplayManga
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.createFileInCacheDir
 import eu.kanade.tachiyomi.util.system.jobIsRunning
-import eu.kanade.tachiyomi.util.system.launchIO
-import eu.kanade.tachiyomi.util.system.saveTimeTaken
 import eu.kanade.tachiyomi.util.system.tryToSetForeground
 import eu.kanade.tachiyomi.util.system.withIOContext
 import java.io.File
@@ -81,9 +76,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import org.nekomanga.R
 import org.nekomanga.constants.Constants
@@ -164,6 +157,7 @@ class LibraryUpdateJob(private val context: Context, workerParameters: WorkerPar
     private val deleteRemoved by lazy { preferences.deleteRemovedChapters().get() != 1 }
 
     private val notifier = LibraryUpdateNotifier(context)
+    private val filterGlobalUpdateMangaUseCase: FilterGlobalUpdateMangaUseCase by injectLazy()
 
     override suspend fun doWork(): Result {
 
@@ -253,169 +247,80 @@ class LibraryUpdateJob(private val context: Context, workerParameters: WorkerPar
             libraryPreferences.whichCategoriesToExclude().get().map(String::toInt)
         val restrictions = libraryPreferences.autoUpdateMangaRestrictions().get()
 
-        return libraryMangaList
-            .asSequence()
-            .distinctBy { it.id }
-            .filter { libraryManga ->
-                if (categoryId != -1) {
-                    // Specific category
-                    libraryManga.category == categoryId
-                } else {
-                    // General categories
-                    val included =
-                        if (categoriesToUpdate.isNotEmpty()) {
-                            libraryManga.category in categoriesToUpdate
-                        } else {
-                            true // Included by default
-                        }
-                    val excluded =
-                        if (categoriesToExclude.isNotEmpty()) {
-                            libraryManga.category in categoriesToExclude
-                        } else {
-                            false // Not excluded by default
-                        }
-                    included && !excluded
-                }
-            }
-            .filter { libraryManga ->
-                when {
-                    LibraryPreferences.MANGA_HAS_UNREAD in restrictions &&
-                        libraryManga.unread != 0 -> {
-                        skippedUpdates[libraryManga] =
-                            context.getString(R.string.skipped_reason_has_unread)
-                        false // Filter out
-                    }
-                    LibraryPreferences.MANGA_NOT_STARTED in restrictions &&
-                        libraryManga.totalChapters > 0 &&
-                        !libraryManga.hasStarted -> {
-                        skippedUpdates[libraryManga] =
-                            context.getString(R.string.skipped_reason_not_started)
-                        false
-                    }
-                    LibraryPreferences.MANGA_NOT_COMPLETED in restrictions &&
-                        libraryManga.status == SManga.COMPLETED -> {
-                        skippedUpdates[libraryManga] =
-                            context.getString(R.string.skipped_reason_completed)
-                        false
-                    }
-
-                    // --- Optimized Tracking Checks ---
-                    LibraryPreferences.MANGA_TRACKING_PLAN_TO_READ in restrictions &&
-                        hasTrackWithGivenStatus(
-                            libraryManga,
-                            context.getString(R.string.follows_plan_to_read),
-                            tracksByMangaId,
-                        ) -> {
-                        skippedUpdates[libraryManga] =
-                            context.getString(R.string.skipped_reason_tracking_plan_to_read)
-                        false
-                    }
-                    LibraryPreferences.MANGA_TRACKING_DROPPED in restrictions &&
-                        hasTrackWithGivenStatus(
-                            libraryManga,
-                            context.getString(R.string.follows_dropped),
-                            tracksByMangaId,
-                        ) -> {
-                        skippedUpdates[libraryManga] =
-                            context.getString(R.string.skipped_reason_tracking_dropped)
-                        false
-                    }
-                    LibraryPreferences.MANGA_TRACKING_ON_HOLD in restrictions &&
-                        hasTrackWithGivenStatus(
-                            libraryManga,
-                            context.getString(R.string.follows_on_hold),
-                            tracksByMangaId,
-                        ) -> {
-                        skippedUpdates[libraryManga] =
-                            context.getString(R.string.skipped_reason_tracking_on_hold)
-                        false
-                    }
-                    LibraryPreferences.MANGA_TRACKING_COMPLETED in restrictions &&
-                        hasTrackWithGivenStatus(
-                            libraryManga,
-                            context.getString(R.string.follows_completed),
-                            tracksByMangaId,
-                        ) -> {
-                        skippedUpdates[libraryManga] =
-                            context.getString(R.string.skipped_reason_tracking_completed)
-                        false
-                    }
-
-                    // If no restriction matched, keep the manga
-                    else -> true
-                }
-            }
-            .toList()
-    }
-
-    override suspend fun getForegroundInfo(): ForegroundInfo {
-        return ForegroundInfo(
-            Notifications.Id.Library.Progress,
-            notifier.progressNotificationBuilder.build(),
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-            } else {
-                0
-            },
-        )
-    }
-
-    private suspend fun updateMangaJob(mangaToAdd: List<LibraryManga>) {
-        // Initialize the variables holding the progress of the updates.
-        saveTimeTaken(libraryPreferences) {
-            emitScope.launch { mangaToAdd.forEach { mangaToUpdateMutableFlow.emit(it.id!!) } }
-
-            mangaToUpdate.addAll(mangaToAdd)
-
-            coroutineScope {
-                val semaphoreAmount =
-                    when (libraryPreferences.prioritizeLibraryUpdates().get()) {
-                        true -> 20
-                        false -> 5
-                    }
-
-                val requestSemaphore = Semaphore(semaphoreAmount)
-                val downloadResults =
-                    mangaToAdd
-                        .map { manga ->
-                            async {
-                                requestSemaphore.withPermit {
-                                    val shouldDownload =
-                                        manga.shouldDownloadNewChapters(
-                                            categoryRepository,
-                                            preferences,
-                                        )
-                                    updateMangaChapters(manga, shouldDownload)
-                                }
+        val filteredByCategory =
+            libraryMangaList
+                .asSequence()
+                .distinctBy { it.id }
+                .filter { libraryManga ->
+                    if (categoryId != -1) {
+                        // Specific category
+                        libraryManga.category == categoryId
+                    } else {
+                        // General categories
+                        val included =
+                            if (categoriesToUpdate.isNotEmpty()) {
+                                libraryManga.category in categoriesToUpdate
+                            } else {
+                                true // Included by default
                             }
-                        }
-                        .awaitAll()
-
-                if (!hasDownloads) {
-                    hasDownloads = downloadResults.any { it }
+                        val excluded =
+                            if (categoriesToExclude.isNotEmpty()) {
+                                libraryManga.category in categoriesToExclude
+                            } else {
+                                false // Not excluded by default
+                            }
+                        included && !excluded
+                    }
                 }
+                .toList()
 
-                launchIO { updateReadingStatus(mangaToAdd) }
+        // Apply global update filter logic
+        val result =
+            filterGlobalUpdateMangaUseCase(
+                libraryManga = filteredByCategory,
+                includedCategories = emptyList<Int>(), // Category logic already handled above
+                excludedCategories = emptyList<Int>(), // Category logic already handled above
+                restrictions = restrictions,
+                tracksByMangaId = tracksByMangaId,
+                planToReadStatus = context.getString(R.string.follows_plan_to_read),
+                droppedStatus = context.getString(R.string.follows_dropped),
+                onHoldStatus = context.getString(R.string.follows_on_hold),
+                completedStatus = context.getString(R.string.follows_completed),
+            )
 
-                finishUpdates()
+        // Find which ones were filtered out and populate skippedUpdates
+        val resultSet = result.values.flatten().map { it.id }.toSet()
+        filteredByCategory.forEach { manga ->
+            if (!resultSet.contains(manga.id)) {
+                when {
+                    LibraryPreferences.MANGA_HAS_UNREAD in restrictions && manga.unread != 0 ->
+                        skippedUpdates[manga] =
+                            context.getString(R.string.skipped_reason_has_unread)
+                    LibraryPreferences.MANGA_NOT_STARTED in restrictions &&
+                        manga.totalChapters > 0 &&
+                        !manga.hasStarted ->
+                        skippedUpdates[manga] =
+                            context.getString(R.string.skipped_reason_not_started)
+                    LibraryPreferences.MANGA_NOT_COMPLETED in restrictions &&
+                        manga.status == SManga.COMPLETED ->
+                        skippedUpdates[manga] = context.getString(R.string.skipped_reason_completed)
+                    LibraryPreferences.MANGA_TRACKING_PLAN_TO_READ in restrictions ->
+                        skippedUpdates[manga] =
+                            context.getString(R.string.skipped_reason_tracking_plan_to_read)
+                    LibraryPreferences.MANGA_TRACKING_DROPPED in restrictions ->
+                        skippedUpdates[manga] =
+                            context.getString(R.string.skipped_reason_tracking_dropped)
+                    LibraryPreferences.MANGA_TRACKING_ON_HOLD in restrictions ->
+                        skippedUpdates[manga] =
+                            context.getString(R.string.skipped_reason_tracking_on_hold)
+                    LibraryPreferences.MANGA_TRACKING_COMPLETED in restrictions ->
+                        skippedUpdates[manga] =
+                            context.getString(R.string.skipped_reason_tracking_completed)
+                }
             }
         }
-    }
 
-    private fun hasTrackWithGivenStatus(
-        libraryManga: LibraryManga,
-        globalStatus: String,
-        tracksByMangaId: Map<Long, List<Track>>,
-    ): Boolean {
-        val tracks = tracksByMangaId[libraryManga.id] ?: return false
-        return tracks.any { track ->
-            val status = trackManager.getService(track.sync_id)?.getGlobalStatus(track.status)
-            if (status.isNullOrBlank()) {
-                false
-            } else {
-                status == globalStatus
-            }
-        }
+        return result.values.flatten()
     }
 
     private suspend fun updateMangaChapters(manga: LibraryManga, shouldDownload: Boolean): Boolean =

--- a/app/src/main/java/org/nekomanga/presentation/screens/stats/StatsViewModel.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/stats/StatsViewModel.kt
@@ -10,7 +10,6 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.track.TrackManager
 import eu.kanade.tachiyomi.data.track.TrackService
-import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.utils.FollowStatus
 import eu.kanade.tachiyomi.util.system.launchIO
 import eu.kanade.tachiyomi.util.system.roundToTwoDecimal
@@ -31,19 +30,13 @@ import org.nekomanga.data.database.repository.MangaRepository
 import org.nekomanga.data.database.repository.MergeMangaRepository
 import org.nekomanga.data.database.repository.TrackRepository
 import org.nekomanga.domain.library.LibraryPreferences
-import org.nekomanga.domain.library.LibraryPreferences.Companion.MANGA_HAS_UNREAD
-import org.nekomanga.domain.library.LibraryPreferences.Companion.MANGA_NOT_COMPLETED
-import org.nekomanga.domain.library.LibraryPreferences.Companion.MANGA_NOT_STARTED
-import org.nekomanga.domain.library.LibraryPreferences.Companion.MANGA_TRACKING_COMPLETED
-import org.nekomanga.domain.library.LibraryPreferences.Companion.MANGA_TRACKING_DROPPED
-import org.nekomanga.domain.library.LibraryPreferences.Companion.MANGA_TRACKING_ON_HOLD
-import org.nekomanga.domain.library.LibraryPreferences.Companion.MANGA_TRACKING_PLAN_TO_READ
 import org.nekomanga.domain.manga.MangaContentRating
 import org.nekomanga.domain.manga.MangaStatus
 import org.nekomanga.domain.manga.MangaType
 import org.nekomanga.presentation.screens.stats.StatsConstants.DetailedStatManga
 import org.nekomanga.presentation.screens.stats.StatsConstants.DetailedState
 import org.nekomanga.presentation.screens.stats.StatsHelper.getReadDuration
+import org.nekomanga.usecases.library.FilterGlobalUpdateMangaUseCase
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -59,6 +52,7 @@ class StatsViewModel() : ViewModel() {
     private val libraryPreferences: LibraryPreferences = Injekt.get()
     private val trackManager: TrackManager = Injekt.get()
     private val downloadManager: DownloadManager = Injekt.get()
+    private val filterGlobalUpdateMangaUseCase: FilterGlobalUpdateMangaUseCase = Injekt.get()
 
     private val _simpleState = MutableStateFlow(StatsConstants.SimpleState())
     val simpleState: StateFlow<StatsConstants.SimpleState> = _simpleState.asStateFlow()
@@ -313,32 +307,19 @@ class StatsViewModel() : ViewModel() {
         val excludedCategories =
             libraryPreferences.whichCategoriesToExclude().get().map(String::toInt)
         val restrictions = libraryPreferences.autoUpdateDeviceRestrictions().get()
-        return libraryManga
-            .groupBy { it.id }
-            .filterNot { it.value.any { manga -> manga.category in excludedCategories } }
-            .filter {
-                includedCategories.isEmpty() ||
-                    it.value.any { manga -> manga.category in includedCategories }
-            }
-            .filter {
-                val manga = it.value.first()
-                when {
-                    MANGA_HAS_UNREAD in restrictions && manga.unread != 0 -> true
-                    MANGA_NOT_STARTED in restrictions &&
-                        manga.totalChapters > 0 &&
-                        !manga.hasStarted -> true
-                    MANGA_NOT_COMPLETED in restrictions && manga.status == SManga.COMPLETED -> true
-                    MANGA_TRACKING_PLAN_TO_READ in restrictions &&
-                        hasTrackWithGivenStatus(manga, R.string.follows_plan_to_read) -> false
-                    MANGA_TRACKING_DROPPED in restrictions &&
-                        hasTrackWithGivenStatus(manga, R.string.follows_dropped) -> false
-                    MANGA_TRACKING_ON_HOLD in restrictions &&
-                        hasTrackWithGivenStatus(manga, R.string.follows_on_hold) -> false
-                    MANGA_TRACKING_COMPLETED in restrictions &&
-                        hasTrackWithGivenStatus(manga, R.string.follows_completed) -> false
-                    else -> true
-                }
-            }
+        val tracksByMangaId = getTracks(libraryManga).groupBy { it.manga_id }
+
+        return filterGlobalUpdateMangaUseCase(
+            libraryManga = libraryManga,
+            includedCategories = includedCategories,
+            excludedCategories = excludedCategories,
+            restrictions = restrictions,
+            tracksByMangaId = tracksByMangaId,
+            planToReadStatus = prefs.context.getString(R.string.follows_plan_to_read),
+            droppedStatus = prefs.context.getString(R.string.follows_dropped),
+            onHoldStatus = prefs.context.getString(R.string.follows_on_hold),
+            completedStatus = prefs.context.getString(R.string.follows_completed),
+        )
     }
 
     private fun getDownloadCount(manga: LibraryManga): Int {

--- a/app/src/main/java/org/nekomanga/usecases/library/FilterGlobalUpdateMangaUseCase.kt
+++ b/app/src/main/java/org/nekomanga/usecases/library/FilterGlobalUpdateMangaUseCase.kt
@@ -1,0 +1,66 @@
+package org.nekomanga.usecases.library
+
+import eu.kanade.tachiyomi.data.database.models.LibraryManga
+import eu.kanade.tachiyomi.data.database.models.Track
+import eu.kanade.tachiyomi.data.track.TrackManager
+import eu.kanade.tachiyomi.source.model.SManga
+import org.nekomanga.domain.library.LibraryPreferences
+
+class FilterGlobalUpdateMangaUseCase(private val trackManager: TrackManager) {
+
+    operator fun invoke(
+        libraryManga: List<LibraryManga>,
+        includedCategories: List<Int>,
+        excludedCategories: List<Int>,
+        restrictions: Set<String>,
+        tracksByMangaId: Map<Long, List<Track>>,
+        planToReadStatus: String,
+        droppedStatus: String,
+        onHoldStatus: String,
+        completedStatus: String,
+    ): Map<Long?, List<LibraryManga>> {
+        return libraryManga
+            .groupBy { it.id }
+            .filterNot { it.value.any { manga -> manga.category in excludedCategories } }
+            .filter {
+                includedCategories.isEmpty() ||
+                    it.value.any { manga -> manga.category in includedCategories }
+            }
+            .filter {
+                val manga = it.value.first()
+                when {
+                    LibraryPreferences.MANGA_HAS_UNREAD in restrictions && manga.unread != 0 -> true
+                    LibraryPreferences.MANGA_NOT_STARTED in restrictions &&
+                        manga.totalChapters > 0 &&
+                        !manga.hasStarted -> true
+                    LibraryPreferences.MANGA_NOT_COMPLETED in restrictions &&
+                        manga.status == SManga.COMPLETED -> true
+                    LibraryPreferences.MANGA_TRACKING_PLAN_TO_READ in restrictions &&
+                        hasTrackWithGivenStatus(manga, planToReadStatus, tracksByMangaId) -> false
+                    LibraryPreferences.MANGA_TRACKING_DROPPED in restrictions &&
+                        hasTrackWithGivenStatus(manga, droppedStatus, tracksByMangaId) -> false
+                    LibraryPreferences.MANGA_TRACKING_ON_HOLD in restrictions &&
+                        hasTrackWithGivenStatus(manga, onHoldStatus, tracksByMangaId) -> false
+                    LibraryPreferences.MANGA_TRACKING_COMPLETED in restrictions &&
+                        hasTrackWithGivenStatus(manga, completedStatus, tracksByMangaId) -> false
+                    else -> true
+                }
+            }
+    }
+
+    private fun hasTrackWithGivenStatus(
+        libraryManga: LibraryManga,
+        globalStatus: String,
+        tracksByMangaId: Map<Long, List<Track>>,
+    ): Boolean {
+        val tracks = tracksByMangaId[libraryManga.id] ?: return false
+        return tracks.any { track ->
+            val status = trackManager.getService(track.sync_id)?.getGlobalStatus(track.status)
+            if (status.isNullOrBlank()) {
+                false
+            } else {
+                status == globalStatus
+            }
+        }
+    }
+}

--- a/app/src/test/java/org/nekomanga/usecases/library/FilterGlobalUpdateMangaUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/library/FilterGlobalUpdateMangaUseCaseTest.kt
@@ -1,0 +1,177 @@
+package org.nekomanga.usecases.library
+
+import eu.kanade.tachiyomi.data.database.models.LibraryManga
+import eu.kanade.tachiyomi.data.database.models.Track
+import eu.kanade.tachiyomi.data.track.TrackManager
+import eu.kanade.tachiyomi.data.track.TrackService
+import eu.kanade.tachiyomi.source.model.SManga
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.nekomanga.domain.library.LibraryPreferences
+
+class FilterGlobalUpdateMangaUseCaseTest {
+
+    private val mockTrackManager = mockk<TrackManager>()
+    private val useCase = FilterGlobalUpdateMangaUseCase(mockTrackManager)
+
+    @Test
+    fun `when categories are excluded, manga in those categories are removed`() {
+        val manga1 =
+            mockk<LibraryManga> {
+                every { id } returns 1L
+                every { category } returns 1
+            }
+        val manga2 =
+            mockk<LibraryManga> {
+                every { id } returns 2L
+                every { category } returns 2
+            }
+
+        val result =
+            useCase(
+                libraryManga = listOf(manga1, manga2),
+                includedCategories = emptyList(),
+                excludedCategories = listOf(1),
+                restrictions = emptySet(),
+                tracksByMangaId = emptyMap(),
+                planToReadStatus = "Plan to Read",
+                droppedStatus = "Dropped",
+                onHoldStatus = "On Hold",
+                completedStatus = "Completed",
+            )
+
+        assertEquals(1, result.size)
+        assertTrue(result.containsKey(2L))
+    }
+
+    @Test
+    fun `when categories are included, only manga in those categories are kept`() {
+        val manga1 =
+            mockk<LibraryManga> {
+                every { id } returns 1L
+                every { category } returns 1
+            }
+        val manga2 =
+            mockk<LibraryManga> {
+                every { id } returns 2L
+                every { category } returns 2
+            }
+        val manga3 =
+            mockk<LibraryManga> {
+                every { id } returns 3L
+                every { category } returns 3
+            }
+
+        val result =
+            useCase(
+                libraryManga = listOf(manga1, manga2, manga3),
+                includedCategories = listOf(2),
+                excludedCategories = emptyList(),
+                restrictions = emptySet(),
+                tracksByMangaId = emptyMap(),
+                planToReadStatus = "Plan to Read",
+                droppedStatus = "Dropped",
+                onHoldStatus = "On Hold",
+                completedStatus = "Completed",
+            )
+
+        assertEquals(1, result.size)
+        assertTrue(result.containsKey(2L))
+    }
+
+    @Test
+    fun `when restrictions apply, they correctly filter manga`() {
+        val manga1 =
+            mockk<LibraryManga> {
+                every { id } returns 1L
+                every { category } returns 1
+                every { unread } returns 5
+                every { totalChapters } returns 10
+                every { hasStarted } returns true
+                every { status } returns SManga.ONGOING
+            }
+
+        val manga2 =
+            mockk<LibraryManga> {
+                every { id } returns 2L
+                every { category } returns 1
+                every { unread } returns 0
+                every { totalChapters } returns 10
+                every { hasStarted } returns false
+                every { status } returns SManga.ONGOING
+            }
+
+        val manga3 =
+            mockk<LibraryManga> {
+                every { id } returns 3L
+                every { category } returns 1
+                every { unread } returns 0
+                every { totalChapters } returns 10
+                every { hasStarted } returns true
+                every { status } returns SManga.COMPLETED
+            }
+
+        val result =
+            useCase(
+                libraryManga = listOf(manga1, manga2, manga3),
+                includedCategories = emptyList(),
+                excludedCategories = emptyList(),
+                restrictions =
+                    setOf(
+                        LibraryPreferences.MANGA_HAS_UNREAD,
+                        LibraryPreferences.MANGA_NOT_STARTED,
+                        LibraryPreferences.MANGA_NOT_COMPLETED,
+                    ),
+                tracksByMangaId = emptyMap(),
+                planToReadStatus = "Plan to Read",
+                droppedStatus = "Dropped",
+                onHoldStatus = "On Hold",
+                completedStatus = "Completed",
+            )
+
+        assertEquals(3, result.size)
+    }
+
+    @Test
+    fun `when tracking restrictions apply, they correctly filter out manga`() {
+        val mangaId = 1L
+        val manga1 =
+            mockk<LibraryManga> {
+                every { id } returns mangaId
+                every { category } returns 1
+                every { unread } returns 0
+                every { totalChapters } returns 10
+                every { hasStarted } returns true
+                every { status } returns SManga.ONGOING
+            }
+
+        val track =
+            mockk<Track> {
+                every { sync_id } returns 1
+                every { status } returns 1
+            }
+
+        val mockService =
+            mockk<TrackService> { every { getGlobalStatus(1) } returns "Plan to Read" }
+
+        every { mockTrackManager.getService(1) } returns mockService
+
+        val result =
+            useCase(
+                libraryManga = listOf(manga1),
+                includedCategories = emptyList(),
+                excludedCategories = emptyList(),
+                restrictions = setOf(LibraryPreferences.MANGA_TRACKING_PLAN_TO_READ),
+                tracksByMangaId = mapOf(mangaId to listOf(track)),
+                planToReadStatus = "Plan to Read",
+                droppedStatus = "Dropped",
+                onHoldStatus = "On Hold",
+                completedStatus = "Completed",
+            )
+
+        assertEquals(0, result.size)
+    }
+}


### PR DESCRIPTION
This PR extracts the business logic for calculating which manga elements are included in the global update. It removes the logic from the `LibraryUpdateJob` and the `StatsViewModel`, placing it in a dedicated pure-Kotlin domain Use Case `FilterGlobalUpdateMangaUseCase`. 

💡 What:
Extracted `FilterGlobalUpdateMangaUseCase`.

🎯 Why:
This unifies the business logic, increasing the domain's purity and reducing duplication in `StatsViewModel` and `LibraryUpdateJob`. It also allows for easier and more effective unit testing.

---
*PR created automatically by Jules for task [1070082514571439108](https://jules.google.com/task/1070082514571439108) started by @nonproto*