### PR TITLE
ref: Move AboutViewModel to presentation.screens.about

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/screens/AboutScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/AboutScreen.kt
@@ -40,8 +40,6 @@ import eu.kanade.tachiyomi.data.updater.RELEASE_URL
 import eu.kanade.tachiyomi.data.updater.REPO_URL
 import eu.kanade.tachiyomi.data.updater.Release
 import eu.kanade.tachiyomi.ui.main.ObserveAsEvents
-import eu.kanade.tachiyomi.ui.more.about.AboutScreenState
-import eu.kanade.tachiyomi.ui.more.about.AboutViewModel
 import eu.kanade.tachiyomi.util.CrashLogUtil
 import eu.kanade.tachiyomi.util.system.isOnline
 import kotlinx.coroutines.launch
@@ -57,7 +55,9 @@ import org.nekomanga.presentation.components.listcard.ExpressiveListCard
 import org.nekomanga.presentation.components.listcard.ListCardType
 import org.nekomanga.presentation.components.scaffold.ChildScreenScaffold
 import org.nekomanga.presentation.components.snackbar.NekoSnackbarHost
+import org.nekomanga.presentation.screens.about.AboutScreenState
 import org.nekomanga.presentation.screens.about.AboutTopAppBar
+import org.nekomanga.presentation.screens.about.AboutViewModel
 import org.nekomanga.presentation.screens.settings.widgets.TextPreferenceWidget
 import org.nekomanga.presentation.theme.Size
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/MainScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MainScreen.kt
@@ -28,12 +28,12 @@ import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import eu.kanade.tachiyomi.ui.library.LibraryViewModel
 import eu.kanade.tachiyomi.ui.manga.MangaViewModel
-import eu.kanade.tachiyomi.ui.more.about.AboutViewModel
 import eu.kanade.tachiyomi.ui.source.browse.BrowseViewModel
 import eu.kanade.tachiyomi.ui.source.latest.DisplayViewModel
 import eu.kanade.tachiyomi.ui.source.latest.toSerializable
 import org.nekomanga.logging.TimberKt
 import org.nekomanga.presentation.components.AppBar
+import org.nekomanga.presentation.screens.about.AboutViewModel
 import org.nekomanga.presentation.screens.deepLink.DeepLinkScreen
 import org.nekomanga.presentation.screens.deepLink.DeepLinkViewModel
 import org.nekomanga.presentation.screens.feed.FeedViewModel

--- a/app/src/main/java/org/nekomanga/presentation/screens/about/AboutScreenState.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/about/AboutScreenState.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.ui.more.about
+package org.nekomanga.presentation.screens.about
 
 import eu.kanade.tachiyomi.data.updater.AppUpdateResult
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/about/AboutViewModel.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/about/AboutViewModel.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.ui.more.about
+package org.nekomanga.presentation.screens.about
 
 import android.os.Build
 import androidx.lifecycle.ViewModel


### PR DESCRIPTION
💡 What: Moved `AboutViewModel.kt` and `AboutScreenState.kt` to `org.nekomanga.presentation.screens.about` and updated package declarations and imports across the project.
🎯 Why: Adherence to Clean Architecture / Feature Modularity. Co-locating distinct feature files (ViewModel, Screen State, and UI) together in the presentation layer.
📍 From/To: `eu.kanade.tachiyomi.ui.more.about` -> `org.nekomanga.presentation.screens.about`

---
*PR created automatically by Jules for task [9443601256830186204](https://jules.google.com/task/9443601256830186204) started by @nonproto*