### PR TITLE
fix: chunk manga IN-clause queries to avoid SQLite "too many SQL variables" crash

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
@@ -81,12 +81,8 @@ suspend fun Iterable<SourceManga>.toDisplayManga(
     val sourceMangas = this.toList()
     val urls = sourceMangas.map { it.url }.distinct()
 
-    // Fetch existing mangas from database by URLs in chunks to avoid SQLite parameter limit
-    val existingMangas =
-        urls
-            .chunked(900)
-            .flatMap { chunk -> mangaRepository.getMangaByUrls(chunk) }
-            .associateBy { it.url }
+    // The repository chunks internally to respect the SQLite bind-variable limit.
+    val existingMangas = mangaRepository.getMangaByUrls(urls).associateBy { it.url }
 
     val newMangasList = mutableListOf<Manga>()
     val updateMangasList = mutableListOf<Manga>()
@@ -289,13 +285,9 @@ suspend fun List<DisplayManga>.resyncDisplayManga(
 ): List<DisplayManga> {
     if (this.isEmpty()) return emptyList()
 
-    // Fetch existing mangas from database by IDs in chunks to avoid SQLite parameter limit
+    // The repository chunks internally to respect the SQLite bind-variable limit.
     val mangaIds = this.map { it.mangaId }.distinct()
-    val existingMangas =
-        mangaIds
-            .chunked(900)
-            .flatMap { chunk -> mangaRepository.getMangaByIds(chunk) }
-            .associateBy { it.id }
+    val existingMangas = mangaRepository.getMangaByIds(mangaIds).associateBy { it.id }
 
     return this.mapNotNull { displayManga ->
         val dbManga = existingMangas[displayManga.mangaId]

--- a/app/src/main/java/org/nekomanga/data/database/repository/MangaRepositoryImpl.kt
+++ b/app/src/main/java/org/nekomanga/data/database/repository/MangaRepositoryImpl.kt
@@ -17,6 +17,11 @@ import org.nekomanga.data.database.mapper.toManga
 import org.nekomanga.domain.library.LibraryPreferences
 import org.nekomanga.domain.site.MangaDexPreferences
 
+// SQLite caps a statement at 999 bind variables (SQLITE_MAX_VARIABLE_NUMBER) on older Android.
+// Exceeding it throws "too many SQL variables"; 900 leaves margin. getMangaByUrls expands each
+// url into url + alt url, so the EXPANDED list is what must be chunked, not the caller's input.
+private const val MAX_DB_QUERY_VARIABLES = 900
+
 class MangaRepositoryImpl(
     private val libraryDao: LibraryDao,
     private val mangaDao: MangaDao,
@@ -74,7 +79,9 @@ class MangaRepositoryImpl(
         mangaDao.getFavoriteMangaList().map { it.toManga() }
 
     override suspend fun getMangaByIds(ids: List<Long>): List<Manga> =
-        mangaDao.getMangaByIds(ids).map { it.toManga() }
+        ids.chunked(MAX_DB_QUERY_VARIABLES)
+            .flatMap { chunk -> mangaDao.getMangaByIds(chunk) }
+            .map { it.toManga() }
 
     override suspend fun getMangaByUrlAndSource(url: String, sourceId: Long): Manga? {
         val altUrl = getAltUrl(url)
@@ -86,7 +93,10 @@ class MangaRepositoryImpl(
 
     override suspend fun getMangaByUrls(urls: List<String>): List<Manga> {
         val allUrls = urls.flatMap { url -> listOfNotNull(url, getAltUrl(url)) }
-        return mangaDao.getMangaByUrls(allUrls).map { it.toManga() }
+        return allUrls
+            .chunked(MAX_DB_QUERY_VARIABLES)
+            .flatMap { chunk -> mangaDao.getMangaByUrls(chunk) }
+            .map { it.toManga() }
     }
 
     override suspend fun getMangaByUrl(url: String): Manga? {

--- a/app/src/main/java/org/nekomanga/data/database/repository/MangaRepositoryImpl.kt
+++ b/app/src/main/java/org/nekomanga/data/database/repository/MangaRepositoryImpl.kt
@@ -92,7 +92,10 @@ class MangaRepositoryImpl(
     }
 
     override suspend fun getMangaByUrls(urls: List<String>): List<Manga> {
-        val allUrls = urls.flatMap { url -> listOfNotNull(url, getAltUrl(url)) }
+        // Distinct guards against the input containing both a "/title/x" and its
+        // "/manga/x" counterpart: each expands into the same pair, which would otherwise
+        // be queried twice and waste bind variables.
+        val allUrls = urls.flatMap { url -> listOfNotNull(url, getAltUrl(url)) }.distinct()
         return allUrls
             .chunked(MAX_DB_QUERY_VARIABLES)
             .flatMap { chunk -> mangaDao.getMangaByUrls(chunk) }

--- a/app/src/test/java/org/nekomanga/data/database/repository/MangaRepositoryImplTest.kt
+++ b/app/src/test/java/org/nekomanga/data/database/repository/MangaRepositoryImplTest.kt
@@ -55,6 +55,22 @@ class MangaRepositoryImplTest {
         }
 
     @Test
+    fun `getMangaByUrls deduplicates urls so the same manga is not queried twice`() = runTest {
+        // Input contains both forms of the SAME manga. Without distinct(), the alt-url
+        // expansion would query ["/title/uuid-1", "/manga/uuid-1", "/manga/uuid-1",
+        // "/title/uuid-1"], doubling the bind variables and repeating the lookup.
+        val inputUrls = listOf("/title/uuid-1", "/manga/uuid-1")
+
+        val capturedQueries = mutableListOf<List<String>>()
+        coEvery { mangaDao.getMangaByUrls(capture(capturedQueries)) } returns emptyList()
+
+        repository.getMangaByUrls(inputUrls)
+
+        capturedQueries.flatten() shouldContainExactlyInAnyOrder
+            listOf("/title/uuid-1", "/manga/uuid-1")
+    }
+
+    @Test
     fun `getMangaByIds splits id list so no query exceeds the SQLite variable limit`() = runTest {
         val inputIds = (1L..1500L).toList()
 

--- a/app/src/test/java/org/nekomanga/data/database/repository/MangaRepositoryImplTest.kt
+++ b/app/src/test/java/org/nekomanga/data/database/repository/MangaRepositoryImplTest.kt
@@ -1,0 +1,69 @@
+package org.nekomanga.data.database.repository
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveAtMostSize
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.nekomanga.data.database.dao.LibraryDao
+import org.nekomanga.data.database.dao.MangaDao
+import org.nekomanga.domain.library.LibraryPreferences
+import org.nekomanga.domain.site.MangaDexPreferences
+
+class MangaRepositoryImplTest {
+
+    // SQLite caps a statement at 999 bind variables (SQLITE_MAX_VARIABLE_NUMBER) on Android <= 10.
+    // Exceeding it throws "too many SQL variables". The repository chunks well under this; the
+    // tests
+    // assert against the real crash threshold so they fail for any chunk size that would actually
+    // crash, regardless of the exact margin chosen in production.
+    private val sqliteMaxVariables = 999
+
+    private val mangaDao: MangaDao = mockk()
+
+    private val repository =
+        MangaRepositoryImpl(
+            libraryDao = mockk<LibraryDao>(),
+            mangaDao = mangaDao,
+            mangaDexPreferences = mockk<MangaDexPreferences>(),
+            libraryPreferences = mockk<LibraryPreferences>(),
+            ioDispatcher = UnconfinedTestDispatcher(),
+        )
+
+    @Test
+    fun `getMangaByUrls splits expanded url list so no query exceeds the SQLite variable limit`() =
+        runTest {
+            // Each "/title/..." url is expanded by the repository into url + "/manga/..." alt url,
+            // so 900 inputs become 1800 bind variables in a single query unless chunked.
+            val inputUrls = (1..900).map { "/title/uuid-$it" }
+            val expectedExpanded = inputUrls.flatMap {
+                listOf(it, it.replaceFirst("/title/", "/manga/"))
+            }
+
+            val capturedQueries = mutableListOf<List<String>>()
+            coEvery { mangaDao.getMangaByUrls(capture(capturedQueries)) } returns emptyList()
+
+            repository.getMangaByUrls(inputUrls)
+
+            // No single DAO query may exceed the SQLite bind-variable limit.
+            capturedQueries.forEach { query -> query shouldHaveAtMostSize sqliteMaxVariables }
+            // Every url (and its alt url) must still be queried across the chunks - nothing
+            // dropped.
+            capturedQueries.flatten() shouldContainExactlyInAnyOrder expectedExpanded
+        }
+
+    @Test
+    fun `getMangaByIds splits id list so no query exceeds the SQLite variable limit`() = runTest {
+        val inputIds = (1L..1500L).toList()
+
+        val capturedQueries = mutableListOf<List<Long>>()
+        coEvery { mangaDao.getMangaByIds(capture(capturedQueries)) } returns emptyList()
+
+        repository.getMangaByIds(inputIds)
+
+        capturedQueries.forEach { query -> query shouldHaveAtMostSize sqliteMaxVariables }
+        capturedQueries.flatten() shouldContainExactlyInAnyOrder inputIds
+    }
+}


### PR DESCRIPTION
## Summary

Fixes an `android.database.sqlite.SQLiteException: too many SQL variables` crash when browsing/searching sources that return many results (reported on Android 10 / SDK 29, where SQLite caps a statement at 999 bind variables).

Resolves #3108.

## Root cause

`toDisplayManga()` chunks source URLs to 900 before querying, to stay under the SQLite bind-variable limit. But `MangaRepositoryImpl.getMangaByUrls()` then expands each URL into `url + altUrl` (the `/title/` ↔ `/manga/` alternate form) *after* the chunk arrives. Since virtually every MangaDex URL has an alt form, a 900-URL chunk becomes up to ~1800 bind variables in a single `WHERE url IN (...)` query — over the 999 limit, so it crashes.

The chunk guard was in the wrong layer: it bounds the *input* count, but the *expanded* list is what becomes bind parameters. `getMangaByIds()` shares the same risk (some callers pass the full library unchunked).

## Fix

- Chunk inside `MangaRepositoryImpl` on the list that actually becomes bind parameters (the expanded list for URLs), making the repository the single source of truth for the limit. This protects every current and future caller.
- Harden `getMangaByIds()` the same way.
- Remove the now-redundant caller-side chunking in `MangaExtensions.kt` (`toDisplayManga` / `resyncDisplayManga`).

## Testing

- New `MangaRepositoryImplTest` asserts no DAO query exceeds the SQLite variable limit and that no IDs/URLs are dropped across chunks. Both tests fail on the pre-fix code and pass after the fix.
- `./gradlew testDebugUnitTest` (full suite) and `./gradlew assembleDebug` pass.