### PR TITLE
perf: avoid redundant PersistentList .toList() allocations in LibraryViewModel

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -932,7 +932,7 @@ class LibraryViewModel() : ViewModel() {
 
     fun selectAllLibraryMangaItems(libraryMangaItems: List<LibraryMangaItem>) {
         viewModelScope.launchIO {
-            val currentSelected = libraryScreenState.value.selectedItems.toList()
+            val currentSelected = libraryScreenState.value.selectedItems
 
             val categoryItemIds = libraryMangaItems.map { it.displayManga.mangaId }.toSet()
             val selectedItemIds = currentSelected.map { it.displayManga.mangaId }.toSet()
@@ -963,7 +963,7 @@ class LibraryViewModel() : ViewModel() {
 
     fun deleteSelectedLibraryMangaItems() {
         viewModelScope.launchNonCancellable {
-            val currentSelected = libraryScreenState.value.selectedItems.toList()
+            val currentSelected = libraryScreenState.value.selectedItems
             clearSelectedManga()
 
             val mangaIds = currentSelected.map { it.displayManga.mangaId }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -932,10 +932,10 @@ class LibraryViewModel() : ViewModel() {
 
     fun selectAllLibraryMangaItems(libraryMangaItems: List<LibraryMangaItem>) {
         viewModelScope.launchIO {
+            val categoryItemIds = libraryMangaItems.map { it.displayManga.mangaId }.toSet()
             _internalLibraryScreenState.update { state ->
                 val currentSelected = state.selectedItems
 
-                val categoryItemIds = libraryMangaItems.map { it.displayManga.mangaId }.toSet()
                 val selectedItemIds = currentSelected.map { it.displayManga.mangaId }.toSet()
 
                 val allSelected = selectedItemIds.containsAll(categoryItemIds)
@@ -943,16 +943,16 @@ class LibraryViewModel() : ViewModel() {
                 val newSelectedItems =
                     if (allSelected) {
                         // Unselect all
-                        currentSelected.filter { it.displayManga.mangaId !in categoryItemIds }
+                        currentSelected.removeAll { it.displayManga.mangaId in categoryItemIds }
                     } else {
                         // Select all
                         val itemsToAdd = libraryMangaItems.filter {
                             it.displayManga.mangaId !in selectedItemIds
                         }
-                        currentSelected + itemsToAdd
+                        currentSelected.addAll(itemsToAdd)
                     }
 
-                state.copy(selectedItems = newSelectedItems.toPersistentList())
+                state.copy(selectedItems = newSelectedItems)
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -932,31 +932,27 @@ class LibraryViewModel() : ViewModel() {
 
     fun selectAllLibraryMangaItems(libraryMangaItems: List<LibraryMangaItem>) {
         viewModelScope.launchIO {
-            val currentSelected = libraryScreenState.value.selectedItems
+            _internalLibraryScreenState.update { state ->
+                val currentSelected = state.selectedItems
 
-            val categoryItemIds = libraryMangaItems.map { it.displayManga.mangaId }.toSet()
-            val selectedItemIds = currentSelected.map { it.displayManga.mangaId }.toSet()
+                val categoryItemIds = libraryMangaItems.map { it.displayManga.mangaId }.toSet()
+                val selectedItemIds = currentSelected.map { it.displayManga.mangaId }.toSet()
 
-            val allSelected = selectedItemIds.containsAll(categoryItemIds)
+                val allSelected = selectedItemIds.containsAll(categoryItemIds)
 
-            val newSelectedItems: List<LibraryMangaItem>
+                val newSelectedItems =
+                    if (allSelected) {
+                        // Unselect all
+                        currentSelected.filter { it.displayManga.mangaId !in categoryItemIds }
+                    } else {
+                        // Select all
+                        val itemsToAdd = libraryMangaItems.filter {
+                            it.displayManga.mangaId !in selectedItemIds
+                        }
+                        currentSelected + itemsToAdd
+                    }
 
-            if (allSelected) {
-                // Unselect all
-                newSelectedItems = currentSelected.filter {
-                    it.displayManga.mangaId !in categoryItemIds
-                }
-            } else {
-                // Select all
-                val itemsToAdd = libraryMangaItems.filter {
-                    it.displayManga.mangaId !in selectedItemIds
-                }
-
-                newSelectedItems = currentSelected + itemsToAdd
-            }
-
-            _internalLibraryScreenState.update {
-                it.copy(selectedItems = newSelectedItems.toPersistentList())
+                state.copy(selectedItems = newSelectedItems.toPersistentList())
             }
         }
     }


### PR DESCRIPTION
💡 What: Removed unnecessary `.toList()` conversions on `PersistentList`s (specifically `selectedItems`) inside `LibraryViewModel`.
🎯 Why: `PersistentList` already implements the `List` interface. Calling `.toList()` on it inside action lambdas forces an unnecessary `ArrayList` allocation and double-copying of all elements, adding pointless overhead and garbage collection churn during selection processing.

---
*PR created automatically by Jules for task [14894662739641161315](https://jules.google.com/task/14894662739641161315) started by @nonproto*