### PR TITLE
ref: replace hardcoded 0.dp with AppTheme equivalent

### DIFF
--- a/.jules/artisan.md
+++ b/.jules/artisan.md
@@ -1,2 +1,5 @@
-## 2026-04-23 - MangaGridView Hardcoded Value **Learning:** `MangaGridView.kt` contained a hardcoded `2.dp` padding that did not align with the AppTheme. **Action:** Next time, scan for hardcoded DP values using `grep` or similar tooling before assuming UI components are fully utilizing `Size` design tokens like `Size.extraTiny`.
-## 2026-04-23 - Size Tokens Validation **Learning:** Hardcoded DP values (e.g., `24.dp`) should be systematically replaced with design tokens like `Size.large` from `org.nekomanga.presentation.theme.Size`. **Action:** Next time, ensure all dimension and padding references strictly utilize the centralized `Size` object to maintain consistent UI theming.
+## 2024-05-27 - Extract hardcoded size correctly
+
+**Learning:** When trying to apply `Size.none` from `AppTheme` correctly in Compose `LazyColumn`, be careful while matching the text in the code block and consider how it's formatted.
+
+**Action:** Be more attentive when reviewing `git diff` outputs vs code inside the file before starting any change.

--- a/app/src/main/java/org/nekomanga/presentation/screens/library/VerticalCategoriesPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/library/VerticalCategoriesPage.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.unit.dp
 import com.cheonjaeung.compose.grid.SimpleGridCells
 import com.cheonjaeung.compose.grid.VerticalGrid
 import eu.kanade.tachiyomi.ui.library.LibraryCategoryActions
@@ -109,7 +108,7 @@ fun VerticalCategoriesPage(
         modifier = Modifier.fillMaxWidth(),
         contentPadding = contentPadding,
         state = lazyListState,
-        verticalArrangement = Arrangement.spacedBy(0.dp),
+        verticalArrangement = Arrangement.spacedBy(Size.none),
     ) {
         libraryScreenState.items.forEach { item ->
             item(key = "header-${item.categoryItem.name}-${item.categoryItem.id}") {


### PR DESCRIPTION
💡 What: Replaces `0.dp` with `Size.none` in `VerticalCategoriesPage.kt`.

🎯 Why: To ensure we are not hardcoding dimensions and using the `AppTheme` size variables correctly.

---
*PR created automatically by Jules for task [11107894473498903845](https://jules.google.com/task/11107894473498903845) started by @nonproto*