### PR TITLE
fix: tracker not updating after being read

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/jobs/tracking/DelayedTrackingUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jobs/tracking/DelayedTrackingUpdateJob.kt
@@ -61,8 +61,8 @@ class DelayedTrackingUpdateJob(context: Context, workerParams: WorkerParameters)
                             true -> delayedTrackingStore.remove(track.id!!)
                             false -> {
                                 try {
-                                    service.update(track, true)
-                                    trackRepository.insertTrack(track)
+                                    val updatedTrack = service.update(track, true)
+                                    trackRepository.insertTrack(updatedTrack)
                                 } catch (e: Exception) {
                                     delayedTrackingStore.add(track.id!!, track.last_chapter_read)
                                     TimberKt.e(e) { "Error inserting for delayed tracker" }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1095,7 +1095,7 @@ constructor(
      */
     private fun updateTrackChapterAfterReading(readerChapter: ReaderChapter) {
         if (!preferences.autoUpdateTrack().get()) return
-        viewModelScope.launchIO {
+        viewModelScope.launchNonCancellable {
             val newChapterRead = readerChapter.chapter.chapter_number
             updateTrackChapterRead(
                 manga?.id,

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSync.kt
@@ -47,12 +47,13 @@ suspend fun updateTrackChapterRead(
     retryWhenOnline: Boolean = false,
     onError: ((TrackService, String?) -> Unit)? = null,
 ) {
+    mangaId ?: return
     withNonCancellableContext {
         val preferences = Injekt.get<PreferencesHelper>()
         val trackRepository = Injekt.get<TrackRepository>()
         val trackManager = Injekt.get<TrackManager>()
 
-        val trackList = trackRepository.getTracksForManga(mangaId!!)
+        val trackList = trackRepository.getTracksForManga(mangaId)
         trackList.map { track ->
             val service = trackManager.getService(track.sync_id)
             if (service != null && service.isLogged() && newChapterRead > track.last_chapter_read) {
@@ -61,8 +62,8 @@ suspend fun updateTrackChapterRead(
                 } else if (preferences.context.isOnline()) {
                     try {
                         track.last_chapter_read = newChapterRead
-                        service.update(track, true)
-                        trackRepository.insertTrack(track)
+                        val updatedTrack = service.update(track, true)
+                        trackRepository.insertTrack(updatedTrack)
                     } catch (e: Exception) {
                         onError?.invoke(service, e.localizedMessage)
                         if (retryWhenOnline) {

--- a/app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSyncTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSyncTest.kt
@@ -1,0 +1,94 @@
+package eu.kanade.tachiyomi.util.chapter
+
+import android.content.Context
+import eu.kanade.tachiyomi.data.database.models.Track
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.data.track.TrackManager
+import eu.kanade.tachiyomi.data.track.TrackService
+import eu.kanade.tachiyomi.util.system.isOnline
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.nekomanga.data.database.repository.TrackRepository
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.addSingleton
+
+class ChapterTrackSyncTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var mockTrackRepository: TrackRepository
+    private lateinit var trackManager: TrackManager
+    private lateinit var preferences: PreferencesHelper
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        mockTrackRepository = mockk(relaxed = true)
+        trackManager = mockk(relaxed = true)
+        preferences = mockk(relaxed = true)
+        context = mockk(relaxed = true)
+
+        every { preferences.context } returns context
+
+        // Injekt
+        Injekt.addSingleton(mockTrackRepository)
+        Injekt.addSingleton(trackManager)
+        Injekt.addSingleton(preferences)
+
+        mockkStatic("eu.kanade.tachiyomi.util.system.ContextExtensionsKt")
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        val fields = Injekt::class.java.declaredFields
+        for (field in fields) {
+            if (field.name == "registrars") {
+                field.isAccessible = true
+                val map = field.get(Injekt) as MutableMap<*, *>
+                map.clear()
+            }
+        }
+    }
+
+    @Test
+    fun `given null mangaId when updateTrackChapterRead is called then returns early`() = runTest {
+        updateTrackChapterRead(null, 5f)
+        coVerify(exactly = 0) { mockTrackRepository.getTracksForManga(any()) }
+    }
+
+    @Test
+    fun `given track and online when new chapter read is higher then updates service and inserts returned track`() =
+        runTest {
+            val mangaId = 1L
+            val track =
+                mockk<Track>(relaxed = true) {
+                    every { sync_id } returns 2
+                    every { last_chapter_read } returns 3f
+                }
+            val updatedTrack = mockk<Track>(relaxed = true)
+
+            coEvery { mockTrackRepository.getTracksForManga(mangaId) } returns listOf(track)
+            every { context.isOnline() } returns true
+
+            val service = mockk<TrackService>(relaxed = true) { every { isLogged() } returns true }
+            every { trackManager.getService(2) } returns service
+            coEvery { service.update(track, true) } returns updatedTrack
+
+            updateTrackChapterRead(mangaId, 5f)
+
+            coVerify(exactly = 1) { service.update(track, true) }
+            coVerify(exactly = 1) { mockTrackRepository.insertTrack(updatedTrack) }
+        }
+}


### PR DESCRIPTION
### **User description**
This PR fixes an issue where reading progress updates (e.g., last chapter read) do not reliably propagate to third-party tracking services (such as           
  MyAnimeList                                                                                                                                                   
  or AniList) and fail to update the Manga Details screen UI when returning from the reader.                                                                    
                                                                                                                                                                
  ## Rationale & Root Causes                                                                                                                                    
                                                                                                                                                                
  1. Discarded Third-Party Metadata: In the auto-sync code,  service.update(track, true)  was invoked but its returned  Track  object (which contains service-  
  updated fields, completion flags, dates, etc.) was discarded. The codebase was instead inserting the old local  track  object back into the database.         
  2. Nullable Safety: The helper function  updateTrackChapterRead  accepted a nullable  mangaId: Long?  but immediately invoked  mangaId!! , potentially        
  throwing a  NullPointerException  (swallowed by the coroutine scope) if the manga details state was not yet initialized in the reader.                        
  3. Coroutine Cancellation on Reader Exit: When a user reads the last page and immediately backs out of the reader, the  ReaderViewModel 's  viewModelScope    
  gets cancelled. Although  updateTrackChapterRead  executes inside  withNonCancellableContext , launching it via  launchIO  on the cancelled  viewModelScope   
  could cause the coroutine to be cancelled before it could even enter the non-cancellable block.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Persist updated track object from services.

- Handle null manga ID in tracking updates.

- Ensure tracking updates are non-cancellable.

- Add unit tests for chapter tracking sync.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ReaderViewModel -- "Triggers updateTrackChapterAfterReading" --> updateTrackChapterRead["updateTrackChapterRead (ChapterTrackSync.kt)"];
  updateTrackChapterRead -- "Fetches tracks for manga" --> TrackRepository["TrackRepository"];
  updateTrackChapterRead -- "Updates track via service" --> TrackService["TrackService.update()"];
  TrackService -- "Returns updated track" --> updateTrackChapterRead;
  updateTrackChapterRead -- "Inserts updated track" --> TrackRepository;
  DelayedTrackingUpdateJob["DelayedTrackingUpdateJob"] -- "Updates delayed track via service" --> TrackService;
  TrackService -- "Returns updated track" --> DelayedTrackingUpdateJob;
  DelayedTrackingUpdateJob -- "Inserts updated track" --> TrackRepository;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DelayedTrackingUpdateJob.kt</strong><dd><code>Persist service-updated track data in delayed job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/eu/kanade/tachiyomi/jobs/tracking/DelayedTrackingUpdateJob.kt

<ul><li>Modified the <code>service.update</code> call to capture the <code>updatedTrack</code> object.<br> <li> Ensured that the <code>updatedTrack</code> object, containing service-updated <br>fields, is inserted into the repository.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3128/files#diff-8a0b9a6f72360c908565236ff5de5a283810b039cbc53c3a59327025c0d2a89e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ReaderViewModel.kt</strong><dd><code>Launch tracking updates in non-cancellable scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt

<ul><li>Changed <code>viewModelScope.launchIO</code> to <code>viewModelScope.launchNonCancellable</code> <br>for <code>updateTrackChapterAfterReading</code>.<br> <li> This ensures that tracking updates are not prematurely cancelled if <br>the <code>ReaderViewModel</code> scope is terminated.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3128/files#diff-400127186c785ac7247d8b72668c4d76b2dbb8a573b9bf1ee3fc0673c3d75206">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChapterTrackSync.kt</strong><dd><code>Safely handle mangaId and persist service-updated track</code>&nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSync.kt

<ul><li>Added a null check <code>mangaId ?: return</code> at the beginning of <br><code>updateTrackChapterRead</code> to prevent <code>NullPointerException</code>.<br> <li> Removed the non-null assertion <code>mangaId!!</code> when calling <br><code>trackRepository.getTracksForManga</code>.<br> <li> Captured the <code>updatedTrack</code> object returned by <code>service.update</code> and used <br>it for <code>trackRepository.insertTrack</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3128/files#diff-f07a50415e87be10a201d32fa5d991818286dece46d6e4cb50ff972432ced110">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChapterTrackSyncTest.kt</strong><dd><code>Add unit tests for ChapterTrackSync utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSyncTest.kt

<ul><li>Added a new test file for <code>ChapterTrackSync</code> utility functions.<br> <li> Included a test case to verify early return when <code>mangaId</code> is null.<br> <li> Added a test to confirm that <code>service.update</code> is called and the returned <br><code>updatedTrack</code> is inserted when online.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3128/files#diff-b92922486f7a57fbcae149e477311c6143bb453012e180425577b0c9b821d1d4">+94/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

