### PR TITLE
fix: reader getting stuck when going to previous chapter

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/model/ReaderPage.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/model/ReaderPage.kt
@@ -14,6 +14,9 @@ open class ReaderPage(
     var bgType: Int? = null,
 ) : Page(index, url, imageUrl, mangaDexChapterId, null) {
 
+    /** Rendered height after image is decoded and laid out (pixels at fit-width). */
+    var renderedHeight: Int = 0
+
     /** Value to check if this page is used to as if it was too wide */
     var shiftedPage: Boolean = false
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
@@ -33,6 +33,10 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
 
         // Add previous chapter pages and transition.
         if (chapters.prevChapter != null) {
+            // We only need to add the last few pages of the previous chapter, because it'll be
+            // selected as the current chapter when one of those pages is selected.
+            // The pages need to be at least one screen tall total for the reader to not get stuck
+            // when going back to the previous chapter.
             val prevPages = chapters.prevChapter.pages
             if (prevPages != null) {
                 val screenHeight = viewer.recycler.height

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
@@ -33,11 +33,19 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
 
         // Add previous chapter pages and transition.
         if (chapters.prevChapter != null) {
-            // We only need to add the last few pages of the previous chapter, because it'll be
-            // selected as the current chapter when one of those pages is selected.
             val prevPages = chapters.prevChapter.pages
             if (prevPages != null) {
-                newItems.addAll(prevPages.takeLast(2))
+                val screenHeight = viewer.recycler.height
+                var accumulatedHeight = 0
+                var pagesToTake = 0
+                for (page in prevPages.reversed()) {
+                    if (page.renderedHeight > 0) {
+                        accumulatedHeight += page.renderedHeight
+                        pagesToTake++
+                        if (accumulatedHeight >= screenHeight) break
+                    }
+                }
+                newItems.addAll(prevPages.takeLast(maxOf(2,pagesToTake)))
             }
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -294,6 +294,7 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
     /** Called when the image is decoded and going to be displayed. */
     private fun onImageDecoded() {
         progressContainer.isVisible = false
+        page?.renderedHeight = frame.measuredHeight
     }
 
     /** Called when the image fails to decode. */


### PR DESCRIPTION
Specifically if the last 2 pages don't occupy the full screen.

This bug has been bothering me for over a year, I finally found what caused it.