### PR TITLE
fix: refresh Recents/Feed screen when returning from ReaderActivity

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt
@@ -26,17 +26,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.ui.main.states.RefreshState
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
@@ -75,11 +76,12 @@ fun FeedScreen(
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
+    val currentUpdateMangaForChanges by rememberUpdatedState(feedViewModel::updateMangaForChanges)
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                feedViewModel.updateMangaForChanges()
+                currentUpdateMangaForChanges()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -76,12 +75,11 @@ fun FeedScreen(
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
-    val currentUpdateMangaForChanges by rememberUpdatedState(feedViewModel::updateMangaForChanges)
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                currentUpdateMangaForChanges()
+                feedViewModel.updateMangaForChanges()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -75,11 +76,12 @@ fun FeedScreen(
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
+    val currentUpdateMangaForChanges by rememberUpdatedState(feedViewModel::updateMangaForChanges)
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                feedViewModel.updateMangaForChanges()
+                currentUpdateMangaForChanges()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Ensures Feed screen refreshes on resume.

- Uses `rememberUpdatedState` for refresh callback.

- Prevents stale callback issues in `DisposableEffect`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ReaderActivity -- "Returns from" --> FeedScreen
  FeedScreen -- "ON_RESUME event" --> "Call updateMangaForChanges"
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FeedScreen.kt</strong><dd><code>Refactor Feed screen refresh logic using `rememberUpdatedState`</code></dd></summary>
<hr>

app/src/main/java/org/nekomanga/presentation/screens/FeedScreen.kt

<ul><li>Updated the import path for <code>LocalLifecycleOwner</code> to <br><code>androidx.lifecycle.compose</code>.<br> <li> Introduced <code>rememberUpdatedState</code> to capture the latest reference of <br><code>feedViewModel::updateMangaForChanges</code>.<br> <li> Modified the <code>DisposableEffect</code> to use the <code>currentUpdateMangaForChanges</code> <br>state, ensuring the latest refresh logic is invoked when the screen <br>resumes.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3132/files#diff-bf6aad1a4ab130c3409b1e774834411b96c6c2ef3913a9d02a7a98d9b3212021">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

