### PR TITLE
ref: migrate michaelbull.result onSuccess/onFailure to onOk/onErr

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -22,7 +22,7 @@ import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.getOrThrow
-import com.github.michaelbull.result.onFailure
+import com.github.michaelbull.result.onErr
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.database.models.Chapter
@@ -401,7 +401,7 @@ class LibraryUpdateJob(private val context: Context, workerParameters: WorkerPar
                                             // in the future check the merge type
                                             MergeType.getSource(mergeManga.mergeType, sourceManager)
                                                 .fetchChapters(mergeManga.url)
-                                                .onFailure {
+                                                .onErr {
                                                     errorFromMerged = true
                                                     failedUpdates[manga] =
                                                         "Merged Chapter --${mergeManga.mergeType}-- ${it.message()}"

--- a/app/src/main/java/eu/kanade/tachiyomi/jobs/follows/FollowsSyncProcessor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jobs/follows/FollowsSyncProcessor.kt
@@ -1,7 +1,7 @@
 package eu.kanade.tachiyomi.jobs.follows
 
-import com.github.michaelbull.result.onFailure
-import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.onErr
+import com.github.michaelbull.result.onOk
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.database.models.MangaCategory
 import eu.kanade.tachiyomi.data.database.models.uuid
@@ -61,12 +61,12 @@ class FollowsSyncProcessor {
 
             sourceManager.mangaDex
                 .fetchAllFollows()
-                .onFailure {
+                .onErr {
                     errorNotification(
                         (it as? ResultError.Generic)?.errorString ?: "Error fetching follows"
                     )
                 }
-                .onSuccess { unfilteredManga ->
+                .onOk { unfilteredManga ->
                     val listManga =
                         unfilteredManga
                             .groupBy { FollowStatus.fromStringRes(it.displayTextRes).int }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ImageHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ImageHandler.kt
@@ -3,7 +3,7 @@ package eu.kanade.tachiyomi.source.online.handlers
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrThrow
-import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.onOk
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.services.NetworkServices
@@ -93,7 +93,7 @@ class ImageHandler {
                 }
         }
 
-        attempt.onSuccess { response ->
+        attempt.onOk { response ->
             if (!response.isSuccessful) {
                 response.close()
                 TimberKt.e(attempt.getError()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ListHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ListHandler.kt
@@ -4,8 +4,8 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.andThen
-import com.github.michaelbull.result.onFailure
-import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.onErr
+import com.github.michaelbull.result.onOk
 import eu.kanade.tachiyomi.network.services.MangaDexService
 import eu.kanade.tachiyomi.network.services.NetworkServices
 import eu.kanade.tachiyomi.source.online.utils.MdUtil
@@ -134,11 +134,11 @@ class ListHandler {
         var resultError: ResultError? = null
         while (hasPages) {
             retrieveMangaFromList(listUUID, page, privateList, false)
-                .onFailure {
+                .onErr {
                     hasPages = false
                     resultError = it
                 }
-                .onSuccess { successResult ->
+                .onOk { successResult ->
                     page++
                     hasPages = successResult.hasNextPage
                     list = list + (successResult.sourceManga.toMutableList())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaUpdateCoordinator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaUpdateCoordinator.kt
@@ -2,8 +2,8 @@ package eu.kanade.tachiyomi.ui.manga
 
 import androidx.room.withTransaction
 import com.github.michaelbull.result.getOrElse
-import com.github.michaelbull.result.onFailure
-import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.onErr
+import com.github.michaelbull.result.onOk
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.database.models.MergeType
@@ -108,11 +108,11 @@ class MangaUpdateCoordinator {
     ) {
         sourceManager.mangaDex
             .getMangaDetails(mangaItem.uuid())
-            .onFailure {
+            .onErr {
                 send(MangaResult.Error(text = "Error getting manga from MangaDex"))
                 throw UpdateError()
             }
-            .onSuccess { (networkManga, sourceArtwork) ->
+            .onOk { (networkManga, sourceArtwork) ->
                 val currentManga = mangaItem.toManga()
                 currentManga.copyFrom(networkManga)
                 currentManga.initialized = true
@@ -209,7 +209,7 @@ class MangaUpdateCoordinator {
         val dexChaptersDeferred = async {
             sourceManager.mangaDex
                 .fetchChapterList(manga)
-                .onFailure {
+                .onErr {
                     send(MangaResult.Error(text = "MangaDex chapter fetch failed: ${it.message()}"))
                     throw UpdateError()
                 }
@@ -224,7 +224,7 @@ class MangaUpdateCoordinator {
                     val source = MergeType.getSource(mergeManga.mergeType, sourceManager)
                     source
                         .fetchChapters(mergeManga.url)
-                        .onFailure {
+                        .onErr {
                             val msg = "Failed to fetch from ${source.name}: ${it.message()}"
                             send(MangaResult.Error(text = msg))
 
@@ -287,7 +287,7 @@ class MangaUpdateCoordinator {
     }
 
     suspend fun updateGroup(group: String) {
-        sourceManager.mangaDex.getScanlatorGroup(group).onSuccess {
+        sourceManager.mangaDex.getScanlatorGroup(group).onOk {
             val scanlatorGroupImpl = it.toScanlatorGroupImpl()
             if (group == scanlatorGroupImpl.name) {
                 scanlatorGroupRepository.insertScanlatorGroups(listOf(scanlatorGroupImpl))
@@ -296,7 +296,7 @@ class MangaUpdateCoordinator {
     }
 
     suspend fun updateUploader(uploader: String) {
-        sourceManager.mangaDex.getUploader(uploader).onSuccess {
+        sourceManager.mangaDex.getUploader(uploader).onOk {
             uploaderRepository.insertUploaders(listOf(it.toUploaderImpl()))
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.viewModelScope
 import com.github.michaelbull.result.fold
 import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.onErr
-import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.runCatching
 import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.data.cache.CoverCache

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -8,8 +8,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.room.withTransaction
 import com.github.michaelbull.result.getOrElse
-import com.github.michaelbull.result.onFailure
-import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.onErr
+import com.github.michaelbull.result.onOk
 import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.database.models.Chapter
@@ -375,7 +375,7 @@ constructor(
                     this.url = url
                     title = ""
                 })
-        mangaDex.fetchMangaAndChapterDetails(tempManga, false).onSuccess { fetchedInfo ->
+        mangaDex.fetchMangaAndChapterDetails(tempManga, false).onOk { fetchedInfo ->
             val networkManga = fetchedInfo.sManga!!
             val chapters = fetchedInfo.sChapters
 
@@ -1134,7 +1134,7 @@ constructor(
         val threadId =
             sourceManager.mangaDex
                 .getChapterCommentId(chapterId)
-                .onFailure { TimberKt.e { it.message() } }
+                .onErr { TimberKt.e { it.message() } }
                 .getOrElse { null }
 
         return threadId

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseViewModel.kt
@@ -2,8 +2,8 @@ package eu.kanade.tachiyomi.ui.source.browse
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.github.michaelbull.result.onFailure
-import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.onErr
+import com.github.michaelbull.result.onOk
 import eu.kanade.tachiyomi.data.database.models.BrowseFilterImpl
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.database.models.MangaCategory
@@ -259,7 +259,7 @@ class BrowseViewModel : ViewModel() {
             if (!isOnline()) return@launchIO
             browseRepository
                 .getHomePage()
-                .onFailure { resultError ->
+                .onErr { resultError ->
                     _browseScreenState.update { state ->
                         state.copy(
                             error = UiText.String(resultError.message()),
@@ -267,7 +267,7 @@ class BrowseViewModel : ViewModel() {
                         )
                     }
                 }
-                .onSuccess {
+                .onOk {
                     _browseScreenState.update { state ->
                         state.copy(
                             homePageManga = it.updateVisibility(preferences),
@@ -289,12 +289,12 @@ class BrowseViewModel : ViewModel() {
                 _browseScreenState.update { state -> state.copy(initialLoading = true) }
                 browseRepository
                     .getFollows()
-                    .onFailure {
+                    .onErr {
                         _browseScreenState.update { state ->
                             state.copy(error = UiText.String(it.message()), initialLoading = false)
                         }
                     }
-                    .onSuccess {
+                    .onOk {
                         val groupedManga =
                             it.updateVisibility(preferences)
                                 .groupBy { manga -> manga.displayTextRes!! }
@@ -407,12 +407,12 @@ class BrowseViewModel : ViewModel() {
             _browseScreenState.update { it.copy(initialLoading = true) }
             browseRepository
                 .getRandomManga()
-                .onFailure { error ->
+                .onErr { error ->
                     _browseScreenState.update {
                         it.copy(initialLoading = false, error = UiText.String(error.message()))
                     }
                 }
-                .onSuccess { displayManga ->
+                .onOk { displayManga ->
                     _browseScreenState.update { it.copy(initialLoading = false) }
                     _deepLinkManga.value = displayManga.mangaId
                 }

--- a/app/src/main/java/org/nekomanga/presentation/screens/deepLink/DeepLinkViewModel.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/deepLink/DeepLinkViewModel.kt
@@ -8,8 +8,8 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.andThen
 import com.github.michaelbull.result.map
-import com.github.michaelbull.result.onFailure
-import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.onErr
+import com.github.michaelbull.result.onOk
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.online.MangaDex
 import eu.kanade.tachiyomi.ui.source.latest.DisplayScreenType
@@ -71,8 +71,8 @@ class DeepLinkViewModel() : ViewModel() {
                         }
                     }
                 }
-                .onFailure { _deepLinkState.value = Error(it.message()) }
-                .onSuccess { screens -> _deepLinkState.value = Success(screens) }
+                .onErr { _deepLinkState.value = Error(it.message()) }
+                .onOk { screens -> _deepLinkState.value = Success(screens) }
         }
     }
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedViewModel.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedViewModel.kt
@@ -2,7 +2,7 @@ package org.nekomanga.presentation.screens.feed
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.onOk
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
@@ -435,7 +435,7 @@ class FeedViewModel() : ViewModel() {
 
     fun loadSummaryPage() {
         viewModelScope.launchIO {
-            feedRepository.getSummaryUpdatesList().onSuccess { list ->
+            feedRepository.getSummaryUpdatesList().onOk { list ->
                 _summaryScreenPagingState.update { state ->
                     state.copy(
                         updatesFeedMangaList = list.toPersistentList(),
@@ -446,7 +446,7 @@ class FeedViewModel() : ViewModel() {
         }
 
         viewModelScope.launchIO {
-            feedRepository.getSummaryContinueReadingList().onSuccess { list ->
+            feedRepository.getSummaryContinueReadingList().onOk { list ->
                 _summaryScreenPagingState.update { state ->
                     state.copy(
                         continueReadingList = list.toPersistentList(),
@@ -457,7 +457,7 @@ class FeedViewModel() : ViewModel() {
         }
 
         viewModelScope.launchIO {
-            feedRepository.getSummaryNewlyAddedList().onSuccess { list ->
+            feedRepository.getSummaryNewlyAddedList().onOk { list ->
                 _summaryScreenPagingState.update { state ->
                     state.copy(
                         newlyAddedFeedMangaList = list.toPersistentList(),
@@ -500,7 +500,7 @@ class FeedViewModel() : ViewModel() {
                                 limit = 100,
                                 _historyScreenPagingState.value.historyGrouping,
                             )
-                            .onSuccess { results ->
+                            .onOk { results ->
                                 _historyScreenPagingState.update {
                                     it.copy(
                                         searchQuery = searchQuery,
@@ -518,7 +518,7 @@ class FeedViewModel() : ViewModel() {
                                 limit = 100,
                                 _updatesScreenPagingState.value.updatesSortedByFetch,
                             )
-                            .onSuccess { results ->
+                            .onOk { results ->
                                 _updatesScreenPagingState.update {
                                     it.copy(
                                         searchQuery = searchQuery,
@@ -713,7 +713,7 @@ class FeedViewModel() : ViewModel() {
                         limit = limit,
                         uploadsFetchSort = _updatesScreenPagingState.value.updatesSortedByFetch,
                     )
-                    .onSuccess { results ->
+                    .onOk { results ->
                         mutableFeedManga = (mutableFeedManga + results.second).toMutableList()
                     }
             }
@@ -740,7 +740,7 @@ class FeedViewModel() : ViewModel() {
                         offset = i,
                         group = _historyScreenPagingState.value.historyGrouping,
                     )
-                    .onSuccess { results ->
+                    .onOk { results ->
                         mutableFeedManga = (mutableFeedManga + results.second).toMutableList()
                     }
             }
@@ -798,7 +798,7 @@ class FeedViewModel() : ViewModel() {
                     group = _historyScreenPagingState.value.historyGrouping,
                 )
             }
-            .onSuccess { results -> update(results.second.toPersistentList()) }
+            .onOk { results -> update(results.second.toPersistentList()) }
     }
 
     private fun updateReadOnFeed(chapterItem: ChapterItem) {

--- a/app/src/main/java/org/nekomanga/usecases/manga/UpdateMangaAggregate.kt
+++ b/app/src/main/java/org/nekomanga/usecases/manga/UpdateMangaAggregate.kt
@@ -1,6 +1,6 @@
 package org.nekomanga.usecases.manga
 
-import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.onOk
 import eu.kanade.tachiyomi.data.database.models.MangaAggregate
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.online.utils.MdUtil
@@ -12,7 +12,7 @@ class UpdateMangaAggregate(
 ) {
     suspend operator fun invoke(mangaId: Long, mangaUrl: String, isFavorite: Boolean) {
         if (isFavorite) {
-            sourceManager.mangaDex.getAggregate(MdUtil.getMangaUUID(mangaUrl)).onSuccess {
+            sourceManager.mangaDex.getAggregate(MdUtil.getMangaUUID(mangaUrl)).onOk {
                 aggregateDto ->
                 mangaAggregateRepository.insertMangaAggregate(
                     MangaAggregate(mangaId = mangaId, volumes = aggregateDto.volumes.toString())

--- a/app/src/main/java/org/nekomanga/util/paging/DefaultPaginator.kt
+++ b/app/src/main/java/org/nekomanga/util/paging/DefaultPaginator.kt
@@ -1,8 +1,8 @@
 package org.nekomanga.util.paging
 
 import com.github.michaelbull.result.Result
-import com.github.michaelbull.result.onFailure
-import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.onErr
+import com.github.michaelbull.result.onOk
 import org.nekomanga.domain.network.ResultError
 
 class DefaultPaginator<Key, Item>(
@@ -26,12 +26,12 @@ class DefaultPaginator<Key, Item>(
         isMakingRequest = false
 
         result
-            .onSuccess { (hasNextPage, items) ->
+            .onOk { (hasNextPage, items) ->
                 currentKey = getNextKey(items)
                 onSuccess(hasNextPage, items, currentKey)
                 onLoadUpdated(false)
             }
-            .onFailure {
+            .onErr {
                 onError(it)
                 onLoadUpdated(false)
             }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Migrate `onSuccess` calls to `onOk`.

- Migrate `onFailure` calls to `onErr`.

- Update `michaelbull.result` library API usage.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Api migration</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>LibraryUpdateJob.kt</strong><dd><code>Migrate `onFailure` to `onErr` for result handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3137/files#diff-ff3f9a6d0ae5789fd98814f1d30c313a4e10623262577119c521d7767c11eb49">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FollowsSyncProcessor.kt</strong><dd><code>Migrate `onFailure` to `onErr` and `onSuccess` to `onOk`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3137/files#diff-e8a58584d1c3e55478f761e1fb1a9a2ecff08581945e6ffd1d75b098fbb6f14f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ImageHandler.kt</strong><dd><code>Migrate `onSuccess` to `onOk` for image request handling</code>&nbsp; </dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3137/files#diff-8bec88be55747768d0e43608c97fb631fa17c1cbafc143fd1174868780d48878">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ListHandler.kt</strong><dd><code>Migrate <code>onFailure</code> to <code>onErr</code> and <code>onSuccess</code> to <code>onOk</code> in list retrieval</code></dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3137/files#diff-8b59f60950415f83e10c2cde7daef6ca975c064584fe44ad63e7ceae5d680b32">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MangaUpdateCoordinator.kt</strong><dd><code>Migrate <code>onFailure</code> to <code>onErr</code> and <code>onSuccess</code> to <code>onOk</code> in manga updates</code></dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3137/files#diff-91163f6403d72f21a5a24629368ac77d16332e5ef84e8f6a88b9b0d4127be5e4">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MangaViewModel.kt</strong><dd><code>Migrate `onFailure` to `onErr` in manga view model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3137/files#diff-c20ff50d5b7bc266cfca6b31fdcdd9e67e1e71682360339b091c5d3fb45a8b8a">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ReaderViewModel.kt</strong><dd><code>Migrate <code>onFailure</code> to <code>onErr</code> and <code>onSuccess</code> to <code>onOk</code> in reader view model</code></dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3137/files#diff-400127186c785ac7247d8b72668c4d76b2dbb8a573b9bf1ee3fc0673c3d75206">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BrowseViewModel.kt</strong><dd><code>Migrate <code>onFailure</code> to <code>onErr</code> and <code>onSuccess</code> to <code>onOk</code> in browse view model</code></dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3137/files#diff-d018685e7e002bb19143eb358246ccf02f01f69e23d84ef7130bc160294fb76a">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DeepLinkViewModel.kt</strong><dd><code>Migrate <code>onFailure</code> to <code>onErr</code> and <code>onSuccess</code> to <code>onOk</code> in deep link handling</code></dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3137/files#diff-35e4d8b14eef23678f027b3398dedb96c9345690998a2357b5f58ad320bc3841">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FeedViewModel.kt</strong><dd><code>Migrate `onSuccess` to `onOk` in feed view model data loading</code></dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3137/files#diff-04cb20c16d8419815269dbf9be3dfa6bd1995695498478e8d52c2fdfc0659612">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UpdateMangaAggregate.kt</strong><dd><code>Migrate `onSuccess` to `onOk` when updating manga aggregate</code></dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3137/files#diff-d69350e76d72625c4efefcbe7350d2ce59dbf8f33e63d603802e63cd0b21fa12">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DefaultPaginator.kt</strong><dd><code>Migrate <code>onFailure</code> to <code>onErr</code> and <code>onSuccess</code> to <code>onOk</code> in paginator logic</code></dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3137/files#diff-d62d87cceb96cc38cb12f2926611de6c477f51cfa54cbf275e2a2fa4f3294efe">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

