### PR TITLE
ref: extract auto tracking link logic into AutoAddTrackers usecase

### DIFF
--- a/.jules/distiller.md
+++ b/.jules/distiller.md
@@ -24,3 +24,8 @@
 **Learning:** The project relies on `ShouldUpdateMangaUseCase` to coordinate smart library update filtering across both background sync `LibraryUpdateJob` and frontend `StatsViewModel`. Use Cases are registered via `addSingleton(...)` in `AppModule.kt`. 
 **Action:** When working on library update features or tracking-status matching, reuse `ShouldUpdateMangaUseCase` and fetch restrictions from `libraryPreferences.autoUpdateMangaRestrictions()` rather than incorrect device restriction keys.
 
+## 2026-06-09 - Extracting AutoAddTrackers Use Case
+**Learning:** The project wraps tracking results in a custom `TrackingUpdate` sealed class (`Success` / `Error`). For DI, tracking use cases are nested inside a central `TrackUseCases` class which is registered as a singleton `addSingleton(TrackUseCases())` in `AppModule.kt`. Use Case naming typically uses verb phrases (e.g. `RegisterTracking`).
+**Action:** When creating new tracking domain logic, nest the Use Case in `TrackUseCases` and use verb phrases for naming.
+
+

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -1843,142 +1843,22 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
         tracks: List<TrackItem>,
     ) {
         viewModelScope.launchIO {
-            val autoAddTracker = preferences.autoAddTracker().get()
-            val manga = mangaItem.toManga()
-            loggedInTrackerService
-                .firstOrNull { it.isMdList }
-                ?.let {
-                    val mdList = trackManager.mdList
-                    var track = tracks.firstOrNull { mdList.matchingTrack(it) }?.toDbTrack()
-                    if (track == null) {
-                        track = mdList.createInitialTracker(manga)
-
-                        if (isOnline()) {
-                            // Try to bind the new track to the remote service (e.g., get a remote
-                            // ID)
-                            runCatching {
-                                    mdList.bind(track)
-                                } // Assumes bind() mutates the 'track' object
-                                .onErr { exception ->
-                                    TimberKt.e(exception) { "Error binding new MangaDex track" }
-                                }
-                        }
-                        // Save the new track (with or without remote data) to the local DB *once*
-                        trackRepository.insertTrack(track)
-                    }
-                    val autoAddStatus = mangaDexPreferences.autoAddToMangaDexLibrary().get()
-                    val canAutoAdd =
-                        mangaItem.favorite && FollowStatus.isUnfollowed(track.status) && isOnline()
-
-                    if (canAutoAdd) {
-                        val newStatus =
-                            when (autoAddStatus) {
-                                1 -> FollowStatus.PLAN_TO_READ.int
-                                3 -> FollowStatus.READING.int
-                                2 -> FollowStatus.ON_HOLD.int
-                                else -> null // Preference is not set to auto-add
-                            }
-
-                        if (newStatus != null) {
-                            track.status = newStatus
-                            trackUseCases.updateTrackingService.await(
-                                track.toTrackItem(),
-                                mdList.toTrackServiceItem(),
+            trackUseCases.autoAddTrackers(
+                mangaItem = mangaItem,
+                loggedInTrackerService = loggedInTrackerService,
+                tracks = tracks,
+                onShowSnackbar = { message, prefixRes ->
+                    launchUI {
+                        appSnackbarManager.showSnackbar(
+                            SnackbarState(
+                                message = message,
+                                prefixRes = prefixRes,
+                                snackBarColor = _mangaDetailScreenState.value.general.snackbarColor,
                             )
-                        }
-                    }
-                }
-
-            if (autoAddTracker.size <= 1 || !mangaItem.favorite) return@launchIO
-
-            val validContentRatings = preferences.autoTrackContentRatingSelections().get()
-            val contentRating = manga.getContentRating()
-
-            if (contentRating != null && !validContentRatings.contains(contentRating.lowercase()))
-                return@launchIO
-
-            if (!isOnline()) {
-                launchUI {
-                    appSnackbarManager.showSnackbar(
-                        SnackbarState(
-                            message = "No network connection, cannot autolink tracker",
-                            snackBarColor = _mangaDetailScreenState.value.general.snackbarColor,
                         )
-                    )
-                }
-                return@launchIO
-            }
-
-            val existingTrackIds = tracks.map { it.trackServiceId }.toSet()
-
-            autoAddTracker
-                .mapNotNull { it.toIntOrNull() } // Safely convert preference strings to Ints
-                .map { autoAddTrackerId ->
-                    async {
-                        val trackService =
-                            loggedInTrackerService.firstOrNull { it.id == autoAddTrackerId }
-                                ?: return@async // Not logged in to this service, skip
-
-                        if (trackService.id in existingTrackIds)
-                            return@async // Already tracked, skip
-
-                        // Check if the manga has a remote ID for this service
-                        val id =
-                            trackManager.getIdFromManga(trackService, manga)
-                                ?: return@async // No ID found, skip
-
-                        // --- 4. Perform the search and register the track ---
-
-                        // We are online, not tracked, and have a remote ID. Proceed.
-                        val trackResult =
-                            trackUseCases.searchTracker.byId(
-                                id = id,
-                                service = trackService,
-                                manga = manga,
-                                previouslyTracker = false,
-                            )
-
-                        when (trackResult) {
-                            is TrackingConstants.TrackSearchResult.Success -> {
-                                val trackSearchItem = trackResult.trackSearchResult.firstOrNull()
-                                if (trackSearchItem != null) {
-                                    // Found a match, register it
-                                    val trackingUpdate =
-                                        trackUseCases.registerTracking.await(
-                                            TrackAndService(
-                                                trackSearchItem.trackItem,
-                                                trackService,
-                                            ),
-                                            mangaId,
-                                        )
-                                    handleTrackingUpdate(trackingUpdate)
-                                } else {
-                                    TimberKt.w {
-                                        "Auto-track search for ${trackService.id} was successful but returned no results."
-                                    }
-                                }
-                            }
-
-                            is TrackingConstants.TrackSearchResult.Error -> {
-                                // Show a specific error for *this* tracker
-                                launchUI {
-                                    appSnackbarManager.showSnackbar(
-                                        SnackbarState(
-                                            prefixRes = trackResult.trackerNameRes,
-                                            message =
-                                                " error trying to autolink tracking. ${trackResult.errorMessage}",
-                                            snackBarColor =
-                                                _mangaDetailScreenState.value.general.snackbarColor,
-                                        )
-                                    )
-                                }
-                            }
-
-                            else -> Unit
-                        }
                     }
                 }
-                .awaitAll()
+            )
         }
     }
 

--- a/app/src/main/java/org/nekomanga/usecases/tracking/AutoAddTrackers.kt
+++ b/app/src/main/java/org/nekomanga/usecases/tracking/AutoAddTrackers.kt
@@ -1,0 +1,187 @@
+package org.nekomanga.usecases.tracking
+
+import com.github.michaelbull.result.onErr
+import com.github.michaelbull.result.runCatching
+import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.data.track.TrackManager
+import eu.kanade.tachiyomi.data.track.matchingTrack
+import eu.kanade.tachiyomi.source.online.utils.FollowStatus
+import eu.kanade.tachiyomi.ui.manga.TrackingConstants
+import eu.kanade.tachiyomi.ui.manga.TrackingConstants.TrackAndService
+import eu.kanade.tachiyomi.ui.manga.TrackingUpdate
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import org.nekomanga.data.database.repository.TrackRepository
+import org.nekomanga.domain.manga.MangaItem
+import org.nekomanga.domain.manga.toManga
+import org.nekomanga.domain.site.MangaDexPreferences
+import org.nekomanga.domain.track.TrackItem
+import org.nekomanga.domain.track.TrackServiceItem
+import org.nekomanga.domain.track.toDbTrack
+import org.nekomanga.domain.track.toTrackItem
+import org.nekomanga.domain.track.toTrackServiceItem
+import org.nekomanga.logging.TimberKt
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class AutoAddTrackers(
+    private val preferences: PreferencesHelper = Injekt.get(),
+    private val mangaDexPreferences: MangaDexPreferences = Injekt.get(),
+    private val trackManager: TrackManager = Injekt.get(),
+    private val trackRepository: TrackRepository = Injekt.get(),
+    private val downloadManager: DownloadManager = Injekt.get(),
+    private val updateTrackingService: UpdateTrackingService = UpdateTrackingService(),
+    private val searchTracker: SearchTracker = SearchTracker(),
+    private val registerTracking: RegisterTracking = RegisterTracking(),
+) {
+
+    private suspend fun isOnline(): Boolean {
+        val networkState =
+            downloadManager.networkStateFlow().map { it }.distinctUntilChanged().firstOrNull()
+        networkState ?: return false
+        return networkState.isOnline
+    }
+
+    suspend operator fun invoke(
+        mangaItem: MangaItem,
+        loggedInTrackerService: List<TrackServiceItem>,
+        tracks: List<TrackItem>,
+        onShowSnackbar: (message: String?, prefixRes: Int?) -> Unit,
+    ) {
+        val autoAddTracker = preferences.autoAddTracker().get()
+        val manga = mangaItem.toManga()
+        loggedInTrackerService
+            .firstOrNull { it.isMdList }
+            ?.let {
+                val mdList = trackManager.mdList
+                var track = tracks.firstOrNull { mdList.matchingTrack(it) }?.toDbTrack()
+                if (track == null) {
+                    track = mdList.createInitialTracker(manga)
+
+                    if (isOnline()) {
+                        // Try to bind the new track to the remote service (e.g., get a remote
+                        // ID)
+                        runCatching { mdList.bind(track) } // Assumes bind() mutates the 'track' object
+                            .onErr { exception ->
+                                TimberKt.e(exception) { "Error binding new MangaDex track" }
+                            }
+                    }
+                    // Save the new track (with or without remote data) to the local DB *once*
+                    trackRepository.insertTrack(track)
+                }
+                val autoAddStatus = mangaDexPreferences.autoAddToMangaDexLibrary().get()
+                val canAutoAdd =
+                    mangaItem.favorite && FollowStatus.isUnfollowed(track.status) && isOnline()
+
+                if (canAutoAdd) {
+                    val newStatus =
+                        when (autoAddStatus) {
+                            1 -> FollowStatus.PLAN_TO_READ.int
+                            3 -> FollowStatus.READING.int
+                            2 -> FollowStatus.ON_HOLD.int
+                            else -> null // Preference is not set to auto-add
+                        }
+
+                    if (newStatus != null) {
+                        track.status = newStatus
+                        val trackingUpdate =
+                            updateTrackingService.await(
+                                track.toTrackItem(),
+                                mdList.toTrackServiceItem(),
+                            )
+                        handleTrackingUpdate(trackingUpdate, onShowSnackbar)
+                    }
+                }
+            }
+
+        if (autoAddTracker.size <= 1 || !mangaItem.favorite) return
+
+        val validContentRatings = preferences.autoTrackContentRatingSelections().get()
+        val contentRating = manga.getContentRating()
+
+        if (contentRating != null && !validContentRatings.contains(contentRating.lowercase())) return
+
+        if (!isOnline()) {
+            onShowSnackbar("No network connection, cannot autolink tracker", null)
+            return
+        }
+
+        val existingTrackIds = tracks.map { it.trackServiceId }.toSet()
+
+        coroutineScope {
+            autoAddTracker
+                .mapNotNull { it.toIntOrNull() } // Safely convert preference strings to Ints
+                .map { autoAddTrackerId ->
+                    async {
+                        val trackService =
+                            loggedInTrackerService.firstOrNull { it.id == autoAddTrackerId }
+                                ?: return@async // Not logged in to this service, skip
+
+                        if (trackService.id in existingTrackIds) return@async // Already tracked, skip
+
+                        // Check if the manga has a remote ID for this service
+                        val id =
+                            trackManager.getIdFromManga(trackService, manga)
+                                ?: return@async // No ID found, skip
+
+                        // We are online, not tracked, and have a remote ID. Proceed.
+                        val trackResult =
+                            searchTracker.byId(
+                                id = id,
+                                service = trackService,
+                                manga = manga,
+                                previouslyTracker = false,
+                            )
+
+                        when (trackResult) {
+                            is TrackingConstants.TrackSearchResult.Success -> {
+                                val trackSearchItem = trackResult.trackSearchResult.firstOrNull()
+                                if (trackSearchItem != null) {
+                                    // Found a match, register it
+                                    val trackingUpdate =
+                                        registerTracking.await(
+                                            TrackAndService(
+                                                trackSearchItem.trackItem,
+                                                trackService,
+                                            ),
+                                            mangaItem.id,
+                                        )
+                                    handleTrackingUpdate(trackingUpdate, onShowSnackbar)
+                                } else {
+                                    TimberKt.w {
+                                        "Auto-track search for ${trackService.id} was successful but returned no results."
+                                    }
+                                }
+                            }
+
+                            is TrackingConstants.TrackSearchResult.Error -> {
+                                // Show a specific error for *this* tracker
+                                onShowSnackbar(
+                                    " error trying to autolink tracking. ${trackResult.errorMessage}",
+                                    trackResult.trackerNameRes,
+                                )
+                            }
+
+                            else -> Unit
+                        }
+                    }
+                }
+                .awaitAll()
+        }
+    }
+
+    private suspend fun handleTrackingUpdate(
+        trackingUpdate: TrackingUpdate,
+        onShowSnackbar: (message: String?, prefixRes: Int?) -> Unit,
+    ) {
+        if (trackingUpdate is TrackingUpdate.Error) {
+            TimberKt.e(trackingUpdate.exception) { "handle tracking update had error" }
+            onShowSnackbar(trackingUpdate.message, null)
+        }
+    }
+}

--- a/app/src/main/java/org/nekomanga/usecases/tracking/TrackUseCases.kt
+++ b/app/src/main/java/org/nekomanga/usecases/tracking/TrackUseCases.kt
@@ -15,4 +15,5 @@ class TrackUseCases(trackManager: TrackManager = Injekt.get()) {
     val removeTracking = RemoveTracking()
     val updateTrackingService = UpdateTrackingService()
     val searchTracker = SearchTracker()
+    val autoAddTrackers = AutoAddTrackers()
 }

--- a/app/src/test/java/org/nekomanga/usecases/tracking/AutoAddTrackersTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/tracking/AutoAddTrackersTest.kt
@@ -1,0 +1,165 @@
+package org.nekomanga.usecases.tracking
+
+import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.data.database.models.Track
+import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.data.track.TrackManager
+import eu.kanade.tachiyomi.data.track.TrackService
+import eu.kanade.tachiyomi.data.track.mdlist.MdList
+import eu.kanade.tachiyomi.ui.manga.TrackingConstants
+import eu.kanade.tachiyomi.ui.manga.TrackingUpdate
+import eu.kanade.tachiyomi.util.system.NetworkState
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.nekomanga.data.database.repository.TrackRepository
+import org.nekomanga.domain.manga.MangaItem
+import org.nekomanga.domain.site.MangaDexPreferences
+import org.nekomanga.domain.track.TrackItem
+import org.nekomanga.domain.track.TrackServiceItem
+import org.nekomanga.domain.track.toDbTrack
+import tachiyomi.core.preference.Preference
+
+class AutoAddTrackersTest {
+
+    private val preferences: PreferencesHelper = mockk()
+    private val mangaDexPreferences: MangaDexPreferences = mockk()
+    private val trackManager: TrackManager = mockk()
+    private val trackRepository: TrackRepository = mockk()
+    private val downloadManager: DownloadManager = mockk()
+    private val updateTrackingService: UpdateTrackingService = mockk()
+    private val searchTracker: SearchTracker = mockk()
+    private val registerTracking: RegisterTracking = mockk()
+
+    private val useCase =
+        AutoAddTrackers(
+            preferences = preferences,
+            mangaDexPreferences = mangaDexPreferences,
+            trackManager = trackManager,
+            trackRepository = trackRepository,
+            downloadManager = downloadManager,
+            updateTrackingService = updateTrackingService,
+            searchTracker = searchTracker,
+            registerTracking = registerTracking,
+        )
+
+    private fun mockNetworkState(isOnline: Boolean) {
+        val networkState = mockk<NetworkState> { every { this@mockk.isOnline } returns isOnline }
+        every { downloadManager.networkStateFlow() } returns flowOf(networkState)
+    }
+
+    private fun mockPreferences(
+        autoAddTracker: Set<String> = emptySet(),
+        autoAddToMangaDexLibrary: Int = 0,
+        autoTrackContentRatingSelections: Set<String> = emptySet(),
+    ) {
+        val autoAddTrackerPref = mockk<Preference<Set<String>>> {
+            every { get() } returns autoAddTracker
+        }
+        every { preferences.autoAddTracker() } returns autoAddTrackerPref
+
+        val autoAddToMangaDexLibraryPref = mockk<Preference<Int>> {
+            every { get() } returns autoAddToMangaDexLibrary
+        }
+        every { mangaDexPreferences.autoAddToMangaDexLibrary() } returns
+            autoAddToMangaDexLibraryPref
+
+        val autoTrackContentRatingSelectionsPref = mockk<Preference<Set<String>>> {
+            every { get() } returns autoTrackContentRatingSelections
+        }
+        every { preferences.autoTrackContentRatingSelections() } returns
+            autoTrackContentRatingSelectionsPref
+    }
+
+    @Test
+    fun `given no auto-add trackers selected when invoked then does not auto-add`() = runTest {
+        mockPreferences(autoAddTracker = emptySet())
+        mockNetworkState(isOnline = true)
+
+        val mangaItem = mockk<MangaItem>(relaxed = true) {
+            every { favorite } returns true
+        }
+
+        useCase(
+            mangaItem = mangaItem,
+            loggedInTrackerService = emptyList(),
+            tracks = emptyList(),
+            onShowSnackbar = { _, _ -> },
+        )
+
+        coVerify(exactly = 0) { trackRepository.insertTrack(any()) }
+    }
+
+    @Test
+    fun `given auto-add trackers when offline then shows snackbar and returns`() = runTest {
+        mockPreferences(
+            autoAddTracker = setOf("1", "2"),
+            autoTrackContentRatingSelections = setOf("safe"),
+        )
+        mockNetworkState(isOnline = false)
+
+        val mangaMock = mockk<Manga> {
+            every { getContentRating() } returns "safe"
+        }
+        val mangaItem = mockk<MangaItem>(relaxed = true) {
+            every { favorite } returns true
+            every { toManga() } returns mangaMock
+        }
+
+        var snackbarMessage: String? = null
+        useCase(
+            mangaItem = mangaItem,
+            loggedInTrackerService = emptyList(),
+            tracks = emptyList(),
+            onShowSnackbar = { message, _ -> snackbarMessage = message },
+        )
+
+        assertEquals("No network connection, cannot autolink tracker", snackbarMessage)
+    }
+
+    @Test
+    fun `given mdList auto-add configured when online and mdList track does not exist then creates and binds track`() =
+        runTest {
+            mockPreferences(autoAddTracker = setOf("123")) // mdList has specific id
+            mockNetworkState(isOnline = true)
+
+            val mangaMock = mockk<Manga>(relaxed = true) {
+                every { getContentRating() } returns "safe"
+            }
+            val mangaItem = mockk<MangaItem>(relaxed = true) {
+                every { favorite } returns true
+                every { toManga() } returns mangaMock
+            }
+
+            val mdListServiceItem = mockk<TrackServiceItem> {
+                every { isMdList } returns true
+                every { id } returns 123
+            }
+
+            val mdListMock = mockk<MdList>(relaxed = true)
+            every { trackManager.mdList } returns mdListMock
+
+            val initialTrack = mockk<Track>(relaxed = true)
+            every { mdListMock.matchingTrack(any()) } returns false
+            every { mdListMock.createInitialTracker(any()) } returns initialTrack
+            coEvery { mdListMock.bind(any()) } returns Unit
+            coEvery { trackRepository.insertTrack(any()) } returns 1L
+
+            useCase(
+                mangaItem = mangaItem,
+                loggedInTrackerService = listOf(mdListServiceItem),
+                tracks = emptyList(),
+                onShowSnackbar = { _, _ -> },
+            )
+
+            coVerify(exactly = 1) { trackRepository.insertTrack(initialTrack) }
+            coVerify(exactly = 1) { mdListMock.bind(initialTrack) }
+        }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,9 +94,7 @@ subprojects {
 
     extensions.findByType<LibraryExtension>()?.apply {
       compileSdk = AndroidConfig.compileSdkVersion
-      defaultConfig {
-        minSdk = AndroidConfig.minSdkVersion
-      }
+      defaultConfig { minSdk = AndroidConfig.minSdkVersion }
 
       compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Extracted auto-tracking logic into a dedicated use case.

- Improved code organization and testability.

- Updated `MangaViewModel` to delegate auto-tracking.

- Added comprehensive unit tests for the new use case.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MangaViewModel["MangaViewModel"] -- "Calls" --> AutoAddTrackersUseCase["AutoAddTrackers Use Case"]
  AutoAddTrackersUseCase -- "Interacts with" --> TrackManager["TrackManager"]
  AutoAddTrackersUseCase -- "Interacts with" --> TrackRepository["TrackRepository"]
  AutoAddTrackersUseCase -- "Interacts with" --> Preferences["PreferencesHelper, MangaDexPreferences"]
  AutoAddTrackersUseCase -- "Uses" --> TrackingServices["UpdateTrackingService, SearchTracker, RegisterTracking"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MangaViewModel.kt</strong><dd><code>Delegate auto-tracking logic to new use case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt

<ul><li>Removed the extensive <code>autoAddTrackers</code> implementation.<br> <li> Delegated the auto-tracking functionality to the new <br><code>trackUseCases.autoAddTrackers</code> method.<br> <li> Passed a lambda for <code>onShowSnackbar</code> to allow the UI to handle snackbar <br>display.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3138/files#diff-c20ff50d5b7bc266cfca6b31fdcdd9e67e1e71682360339b091c5d3fb45a8b8a">+12/-132</a></td>

</tr>
</table></td></tr><tr><td><strong>New feature</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AutoAddTrackers.kt</strong><dd><code>Introduce `AutoAddTrackers` use case for auto-tracking</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/org/nekomanga/usecases/tracking/AutoAddTrackers.kt

<ul><li>Introduced a new <code>AutoAddTrackers</code> use case class.<br> <li> Encapsulated all auto-tracking logic previously in <code>MangaViewModel.kt</code>.<br> <li> Injected necessary dependencies like <code>PreferencesHelper</code>, <code>TrackManager</code>, <br>and other tracking use cases.<br> <li> Added a <code>handleTrackingUpdate</code> private function for error handling and <br>snackbar display.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3138/files#diff-ecfec1622d43b18922b9fb3125f88830c1e292cae04e3a857d18c7f12c7cefbd">+187/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TrackUseCases.kt</strong><dd><code>Register `AutoAddTrackers` in `TrackUseCases`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/org/nekomanga/usecases/tracking/TrackUseCases.kt

<ul><li>Added a new property <code>val autoAddTrackers = AutoAddTrackers()</code> to <br>register the new use case.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3138/files#diff-3eadc6d6f53d893f02ce265ede58ca68443e0d383cfac4fee8015229d827dd06">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AutoAddTrackersTest.kt</strong><dd><code>Add unit tests for `AutoAddTrackers` use case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/test/java/org/nekomanga/usecases/tracking/AutoAddTrackersTest.kt

<ul><li>Created a new test file for <code>AutoAddTrackers</code> use case.<br> <li> Implemented unit tests for various scenarios, including no trackers <br>selected, offline state, and MangaDex auto-add.<br> <li> Utilized <code>mockk</code> for mocking dependencies and <code>runTest</code> for coroutine <br>testing.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3138/files#diff-d0382d9ac1c6540ae732ab1509f044c9b0885402cad0f3370cbc68044a4a8ef8">+165/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.gradle.kts</strong><dd><code>Minor build script formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build.gradle.kts

<ul><li>Applied a minor formatting change to the <code>defaultConfig</code> block for <br><code>minSdk</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3138/files#diff-c0dfa6bc7a8685217f70a860145fbdf416d449eaff052fa28352c5cec1a98c06">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>distiller.md</strong><dd><code>Document `AutoAddTrackers` use case extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/distiller.md

<ul><li>Added a new entry documenting the extraction of the <code>AutoAddTrackers</code> <br>use case.<br> <li> Provided learning and action points regarding tracking use case <br>architecture.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3138/files#diff-d9d42c71d937bc16e88f279c68e8d45f989cc90e86ef8bc649b2f92b576bb049">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

