### PR TITLE
fix: improve accessibility of LibraryButtonBar icons

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/screens/library/LibraryButtonBar.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/library/LibraryButtonBar.kt
@@ -67,7 +67,12 @@ fun LibraryButtonBar(
                     Icon(
                         imageVector =
                             if (libraryScreenState.allCollapsed) ExpandAllIcon else CollapseAllIcon,
-                        contentDescription = null,
+                        contentDescription =
+                            stringResource(
+                                id =
+                                    if (libraryScreenState.allCollapsed) R.string.expand
+                                    else R.string.collapse
+                            ),
                     )
                 }
             }
@@ -85,7 +90,10 @@ fun LibraryButtonBar(
         }
         AnimatedVisibility(libraryScreenState.hasActiveFilters) {
             FilledIconButton(onClick = libraryScreenActions.clearActiveFilters) {
-                Icon(imageVector = Icons.Default.Clear, contentDescription = null)
+                Icon(
+                    imageVector = Icons.Default.Clear,
+                    contentDescription = stringResource(id = R.string.clear),
+                )
             }
         }
 


### PR DESCRIPTION
### **User description**
💡 What:
Added appropriate string resources (`R.string.expand`, `R.string.collapse`, and `R.string.clear`) as `contentDescription`s to the `ExpandAllIcon`/`CollapseAllIcon` and `Icons.Default.Clear` within the `LibraryButtonBar`.

🎯 Why:
These icons previously had `contentDescription = null`, meaning TalkBack and other screen readers would not announce their purpose to visually impaired users. This change improves the accessibility of the library filtering screen.

---
*PR created automatically by Jules for task [15647494207353878930](https://jules.google.com/task/15647494207353878930) started by @nonproto*


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add dynamic content description for expand/collapse icon.

- Set content description for clear filter icon.

- Improve accessibility for screen readers.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  LibraryButtonBar["LibraryButtonBar.kt"] -- "Adds dynamic contentDescription" --> ExpandCollapseIcon["Expand/Collapse Icon"]
  LibraryButtonBar -- "Adds contentDescription" --> ClearIcon["Clear Icon"]
  ExpandCollapseIcon & ClearIcon -- "Improves accessibility" --> ScreenReaders["Screen Readers"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Accessibility</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LibraryButtonBar.kt</strong><dd><code>Add content descriptions to LibraryButtonBar icons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/org/nekomanga/presentation/screens/library/LibraryButtonBar.kt

<ul><li>Replaced <code>null</code> <code>contentDescription</code> with a dynamic string resource for <br>the expand/collapse icon, based on the <code>libraryScreenState.allCollapsed</code> <br>status.<br> <li> Replaced <code>null</code> <code>contentDescription</code> with <code>stringResource(id = </code><br><code>R.string.clear)</code> for the clear filter icon.<br> <li> Enhanced accessibility for screen readers by providing descriptive <br>content for interactive icons.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3146/files#diff-a88673dfcc1729ed61b76728230e37bb4cd0e3a0f84df5c99a81d4c210b22e53">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

