### PR TITLE
fix: only show default category when user has manga in it

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -429,15 +429,17 @@ class LibraryViewModel() : ViewModel() {
                 libraryMangaListFlow,
             ) { activeMangaList, libraryViewPreferences, categoryList, trackMap, rawLibraryList ->
                 withContext(Dispatchers.Default) {
-                    val showEmptyCategories =
-                        rawLibraryList.isNotEmpty() &&
-                            _internalLibraryScreenState.value.searchQuery.isNullOrBlank()
+                    val isSearching = !_internalLibraryScreenState.value.searchQuery.isNullOrBlank()
+                    val hasMangaInDefaultCategory = rawLibraryList.any { it.category == 0 }
+                    val showEmptyCategories = rawLibraryList.isNotEmpty() && !isSearching
                     when (libraryViewPreferences.groupBy) {
                         LibraryGroup.ByCategory -> {
                             groupLibraryManga.groupByCategory(
-                                activeMangaList,
-                                categoryList,
-                                showEmptyCategories,
+                                libraryMangaList = activeMangaList,
+                                categoryList = categoryList,
+                                showEmptyCategories = showEmptyCategories,
+                                hasMangaInDefaultCategory = hasMangaInDefaultCategory,
+                                isSearching = isSearching,
                             )
                         }
                         LibraryGroup.ByAuthor,

--- a/app/src/main/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCase.kt
+++ b/app/src/main/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCase.kt
@@ -94,6 +94,8 @@ class GroupLibraryMangaUseCase {
         libraryMangaList: List<LibraryMangaItem>,
         categoryList: List<CategoryItem>,
         showEmptyCategories: Boolean = false,
+        hasMangaInDefaultCategory: Boolean = libraryMangaList.any { it.category == 0 },
+        isSearching: Boolean = false,
     ): List<LibraryCategoryItem> {
         if (libraryMangaList.isEmpty() && !showEmptyCategories) {
             return emptyList()
@@ -104,10 +106,13 @@ class GroupLibraryMangaUseCase {
         return categoryList.mapNotNull { categoryItem ->
             val unsortedMangaList = mangaMap[categoryItem.id] ?: emptyList()
 
-            if (
-                categoryItem.isSystemCategory && unsortedMangaList.isEmpty() && !showEmptyCategories
-            ) {
-                return@mapNotNull null
+            if (categoryItem.isSystemCategory) {
+                if (!hasMangaInDefaultCategory) {
+                    return@mapNotNull null
+                }
+                if (unsortedMangaList.isEmpty() && !showEmptyCategories && !isSearching) {
+                    return@mapNotNull null
+                }
             }
 
             LibraryCategoryItem(

--- a/app/src/main/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCase.kt
+++ b/app/src/main/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCase.kt
@@ -94,7 +94,7 @@ class GroupLibraryMangaUseCase {
         libraryMangaList: List<LibraryMangaItem>,
         categoryList: List<CategoryItem>,
         showEmptyCategories: Boolean = false,
-        hasMangaInDefaultCategory: Boolean = libraryMangaList.any { it.category == 0 },
+        hasMangaInDefaultCategory: Boolean,
         isSearching: Boolean = false,
     ): List<LibraryCategoryItem> {
         if (libraryMangaList.isEmpty() && !showEmptyCategories) {

--- a/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
@@ -291,6 +291,7 @@ class GroupLibraryMangaUseCaseTest {
             useCase.groupByCategory(
                 libraryMangaList = listOf(manga1, manga2, manga3),
                 categoryList = listOf(category2, category1),
+                hasMangaInDefaultCategory = false,
             )
 
         val expected =
@@ -318,6 +319,7 @@ class GroupLibraryMangaUseCaseTest {
             useCase.groupByCategory(
                 libraryMangaList = listOf(manga1, manga1Duplicate),
                 categoryList = listOf(category1),
+                hasMangaInDefaultCategory = false,
             )
 
         assertEquals(1, result.size)
@@ -337,6 +339,7 @@ class GroupLibraryMangaUseCaseTest {
             useCase.groupByCategory(
                 libraryMangaList = listOf(manga1),
                 categoryList = listOf(category1, systemCategory),
+                hasMangaInDefaultCategory = false,
             )
 
         val expected =
@@ -474,6 +477,7 @@ class GroupLibraryMangaUseCaseTest {
             useCase.groupByCategory(
                 libraryMangaList = listOf(manga1),
                 categoryList = listOf(systemCategory),
+                hasMangaInDefaultCategory = true,
             )
 
         val expected =
@@ -494,6 +498,7 @@ class GroupLibraryMangaUseCaseTest {
                 libraryMangaList = emptyList(),
                 categoryList =
                     listOf(CategoryItem(id = 1, name = "Cat", sortOrder = LibrarySort.Title)),
+                hasMangaInDefaultCategory = false,
             )
 
         assertEquals(emptyList<LibraryCategoryItem>(), result)
@@ -507,6 +512,7 @@ class GroupLibraryMangaUseCaseTest {
                 libraryMangaList = emptyList(),
                 categoryList = listOf(category1),
                 showEmptyCategories = true,
+                hasMangaInDefaultCategory = false,
             )
 
         val expected =

--- a/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
@@ -351,7 +351,7 @@ class GroupLibraryMangaUseCaseTest {
     }
 
     @Test
-    fun `groupByCategory includes empty system category when showEmptyCategories is true`() {
+    fun `groupByCategory excludes empty system category when showEmptyCategories is true but hasMangaInDefaultCategory is false`() {
         val manga1 = createMockManga(1, category = 1)
         val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
         val systemCategory =
@@ -362,6 +362,91 @@ class GroupLibraryMangaUseCaseTest {
                 libraryMangaList = listOf(manga1),
                 categoryList = listOf(category1, systemCategory),
                 showEmptyCategories = true,
+                hasMangaInDefaultCategory = false,
+            )
+
+        val expected =
+            listOf(
+                LibraryCategoryItem(
+                    categoryItem = category1,
+                    libraryItems = persistentListOf(manga1),
+                )
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `groupByCategory includes empty system category when showEmptyCategories is true and hasMangaInDefaultCategory is true`() {
+        val manga1 = createMockManga(1, category = 1)
+        val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
+        val systemCategory =
+            CategoryItem(id = 0, name = CategoryItem.SYSTEM_CATEGORY, sortOrder = LibrarySort.Title)
+
+        val result =
+            useCase.groupByCategory(
+                libraryMangaList = listOf(manga1),
+                categoryList = listOf(category1, systemCategory),
+                showEmptyCategories = true,
+                hasMangaInDefaultCategory = true,
+            )
+
+        val expected =
+            listOf(
+                LibraryCategoryItem(
+                    categoryItem = category1,
+                    libraryItems = persistentListOf(manga1),
+                ),
+                LibraryCategoryItem(
+                    categoryItem = systemCategory,
+                    libraryItems = persistentListOf(),
+                ),
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `groupByCategory excludes empty system category during search when hasMangaInDefaultCategory is false`() {
+        val manga1 = createMockManga(1, category = 1)
+        val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
+        val systemCategory =
+            CategoryItem(id = 0, name = CategoryItem.SYSTEM_CATEGORY, sortOrder = LibrarySort.Title)
+
+        val result =
+            useCase.groupByCategory(
+                libraryMangaList = listOf(manga1),
+                categoryList = listOf(category1, systemCategory),
+                showEmptyCategories = false,
+                hasMangaInDefaultCategory = false,
+                isSearching = true,
+            )
+
+        val expected =
+            listOf(
+                LibraryCategoryItem(
+                    categoryItem = category1,
+                    libraryItems = persistentListOf(manga1),
+                )
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `groupByCategory includes empty system category during search when hasMangaInDefaultCategory is true but matches is empty`() {
+        val manga1 = createMockManga(1, category = 1)
+        val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
+        val systemCategory =
+            CategoryItem(id = 0, name = CategoryItem.SYSTEM_CATEGORY, sortOrder = LibrarySort.Title)
+
+        val result =
+            useCase.groupByCategory(
+                libraryMangaList = listOf(manga1),
+                categoryList = listOf(category1, systemCategory),
+                showEmptyCategories = false,
+                hasMangaInDefaultCategory = true,
+                isSearching = true,
             )
 
         val expected =


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Refine default category display logic.

- Only show default category if it contains manga.

- Pass search state and default category manga presence.

- Add comprehensive tests for new display rules.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  LibraryViewModel["LibraryViewModel.kt"] -- "Calculates display parameters" --> GroupLibraryMangaUseCase["GroupLibraryMangaUseCase.kt"]
  GroupLibraryMangaUseCase -- "Applies new display rules for system category" --> LibraryDisplay["Library Display"]
  GroupLibraryMangaUseCaseTest["GroupLibraryMangaUseCaseTest.kt"] -- "Validates new display logic" --> GroupLibraryMangaUseCase
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LibraryViewModel.kt</strong><dd><code>Pass default category and search state to grouping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt

<ul><li>Introduced <code>isSearching</code> and <code>hasMangaInDefaultCategory</code> variables to <br>determine the current library state.<br> <li> Modified the <code>showEmptyCategories</code> logic to exclude search queries.<br> <li> Passed the new <code>hasMangaInDefaultCategory</code> and <code>isSearching</code> parameters to <br>the <code>groupByCategory</code> use case.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3147/files#diff-515ab8df479362e60e4b12f66d0a9124d1274ae346d0f40134d324711c0da63f">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GroupLibraryMangaUseCase.kt</strong><dd><code>Refine system category display based on content and search</code></dd></summary>
<hr>

app/src/main/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCase.kt

<ul><li>Added <code>hasMangaInDefaultCategory</code> and <code>isSearching</code> parameters to the <br><code>groupByCategory</code> function.<br> <li> Implemented new conditional logic to hide the system category (ID 0) <br>if it has no manga and <code>hasMangaInDefaultCategory</code> is false.<br> <li> Adjusted the display of empty system categories based on <br><code>showEmptyCategories</code> and <code>isSearching</code> flags.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3147/files#diff-5bead3744298ae027091b570b3d99b9c2ca2cc1308bd7a6adf4c1ec11b228fcf">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GroupLibraryMangaUseCaseTest.kt</strong><dd><code>Add comprehensive tests for system category display logic</code></dd></summary>
<hr>

app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt

<ul><li>Updated existing test cases for <code>groupByCategory</code> to include the new <br><code>hasMangaInDefaultCategory</code> parameter.<br> <li> Renamed a test to clarify that empty system categories are excluded <br>when <code>hasMangaInDefaultCategory</code> is false.<br> <li> Added new test cases to cover scenarios where empty system categories <br>are included or excluded based on <code>showEmptyCategories</code>, <br><code>hasMangaInDefaultCategory</code>, and <code>isSearching</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3147/files#diff-e0292fecce817a90c4fec1215f6769286532737fa588689f8aa278977c1ab14c">+92/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

