### PR TITLE
feat: improve data & storage settings with unified backup buttons and disk usage

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupCreatorJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupCreatorJob.kt
@@ -19,6 +19,7 @@ import eu.kanade.tachiyomi.util.system.notificationManager
 import eu.kanade.tachiyomi.util.system.withIOContext
 import java.util.concurrent.TimeUnit
 import org.nekomanga.domain.storage.StorageManager
+import org.nekomanga.domain.storage.StoragePreferences
 import org.nekomanga.logging.TimberKt
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -41,6 +42,8 @@ class BackupCreatorJob(private val context: Context, workerParams: WorkerParamet
                     UniFile.fromUri(context, location.toUri())?.let {
                         notifier.showBackupComplete(it)
                     }
+                } else {
+                    Injekt.get<StoragePreferences>().lastAutoBackupTimestamp().set(System.currentTimeMillis())
                 }
             }
             Result.success()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -429,15 +429,17 @@ class LibraryViewModel() : ViewModel() {
                 libraryMangaListFlow,
             ) { activeMangaList, libraryViewPreferences, categoryList, trackMap, rawLibraryList ->
                 withContext(Dispatchers.Default) {
-                    val showEmptyCategories =
-                        rawLibraryList.isNotEmpty() &&
-                            _internalLibraryScreenState.value.searchQuery.isNullOrBlank()
+                    val isSearching = !_internalLibraryScreenState.value.searchQuery.isNullOrBlank()
+                    val hasMangaInDefaultCategory = rawLibraryList.any { it.category == 0 }
+                    val showEmptyCategories = rawLibraryList.isNotEmpty() && !isSearching
                     when (libraryViewPreferences.groupBy) {
                         LibraryGroup.ByCategory -> {
                             groupLibraryManga.groupByCategory(
-                                activeMangaList,
-                                categoryList,
-                                showEmptyCategories,
+                                libraryMangaList = activeMangaList,
+                                categoryList = categoryList,
+                                showEmptyCategories = showEmptyCategories,
+                                hasMangaInDefaultCategory = hasMangaInDefaultCategory,
+                                isSearching = isSearching,
                             )
                         }
                         LibraryGroup.ByAuthor,

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/DataStorageSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/DataStorageSettingsScreen.kt
@@ -12,8 +12,30 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import android.os.Environment
+import android.os.StatFs
+import android.text.format.Formatter
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import org.nekomanga.presentation.components.ButtonGroup
+import org.nekomanga.presentation.theme.Size
+import com.hippo.unifile.UniFile
+import java.io.File
 import eu.kanade.tachiyomi.data.backup.BackupCreatorJob
 import eu.kanade.tachiyomi.data.backup.BackupRestoreJob
 import eu.kanade.tachiyomi.data.backup.models.Backup
@@ -21,10 +43,13 @@ import eu.kanade.tachiyomi.ui.setting.CacheData
 import eu.kanade.tachiyomi.ui.setting.CacheType
 import eu.kanade.tachiyomi.util.system.MiuiUtil
 import eu.kanade.tachiyomi.util.system.toast
+import eu.kanade.tachiyomi.util.system.toTimestampString
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.nekomanga.R
 import org.nekomanga.domain.storage.StoragePreferences
 import org.nekomanga.presentation.components.UiText
@@ -32,8 +57,13 @@ import org.nekomanga.presentation.components.dialog.CreateBackupDialog
 import org.nekomanga.presentation.components.dialog.RestoreDialog
 import org.nekomanga.presentation.components.storage.storageLocationPicker
 import org.nekomanga.presentation.components.storage.storageLocationText
+import org.nekomanga.presentation.extensions.collectAsState
 import org.nekomanga.presentation.screens.settings.Preference
 import org.nekomanga.presentation.screens.settings.widgets.SearchTerm
+import org.nekomanga.usecases.preferences.GetDateFormatUseCase
+import tachiyomi.core.util.storage.DiskUtil
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 internal class DataStorageSettingsScreen(
     incognitoMode: Boolean,
@@ -61,12 +91,83 @@ internal class DataStorageSettingsScreen(
                 onClick = { pickStorageLocation.launch(null) },
             ),
             backupAndRestoreGroup(context),
+            storageGroup(context),
             cacheGroup(context, cacheData, clearCache),
         )
     }
 
     @Composable
+    private fun storageGroup(context: Context): Preference.PreferenceGroup {
+        val storages = remember { DiskUtil.getExternalStorages(context) }
+
+        return Preference.PreferenceGroup(
+            title = stringResource(R.string.storage_usage),
+            preferenceItems =
+                persistentListOf(
+                    Preference.PreferenceItem.InfoPreference(stringResource(R.string.storage_usage_info)),
+                    Preference.PreferenceItem.CustomPreference(
+                        title = "",
+                        content = {
+                            Column(
+                                modifier =
+                                    Modifier.fillMaxWidth()
+                                        .padding(horizontal = Size.medium, vertical = Size.small),
+                                verticalArrangement = Arrangement.spacedBy(Size.small),
+                            ) {
+                                storages.forEach { file ->
+                                    val available = remember(file) { DiskUtil.getAvailableStorageSpace(file) }
+                                    val availableText = remember(available) { Formatter.formatFileSize(context, available) }
+                                    val total = remember(file) { DiskUtil.getTotalStorageSpace(file) }
+                                    val totalText = remember(total) { Formatter.formatFileSize(context, total) }
+                                    val progress = if (total > 0L) (1 - (available / total.toFloat())) else 0f
+
+                                    Column(
+                                        verticalArrangement = Arrangement.spacedBy(Size.tiny),
+                                    ) {
+                                        Text(
+                                            text = file.absolutePath,
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            fontWeight = FontWeight.Medium,
+                                            color = MaterialTheme.colorScheme.onSurface,
+                                        )
+
+                                        LinearProgressIndicator(
+                                            progress = { progress },
+                                            modifier =
+                                                Modifier.fillMaxWidth()
+                                                    .height(Size.small)
+                                                    .clip(RoundedCornerShape(Size.tiny)),
+                                            color = MaterialTheme.colorScheme.primary,
+                                            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                                        )
+
+                                        Text(
+                                            text = stringResource(R.string.available_disk_space_info, availableText, totalText),
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                }
+                            }
+                        },
+                    )
+                ),
+        )
+    }
+
+    @Composable
     private fun backupAndRestoreGroup(context: Context): Preference.PreferenceGroup {
+        val lastAutoBackup by storagePreferences.lastAutoBackupTimestamp().collectAsState()
+        val getDateFormatUseCase = remember { Injekt.get<GetDateFormatUseCase>() }
+        val formattedTime = remember(lastAutoBackup) {
+            if (lastAutoBackup == 0L) {
+                context.getString(R.string.never)
+            } else {
+                java.util.Date(lastAutoBackup).toTimestampString(getDateFormatUseCase())
+            }
+        }
+        val backupInfoText = stringResource(R.string.backup_info) + "\n\n" + stringResource(R.string.last_auto_backup_info, formattedTime)
+
         var showCreateBackupDialog by rememberSaveable { mutableStateOf(false) }
         var showRestoreDialog by rememberSaveable { mutableStateOf(false) }
         var restoreUri by rememberSaveable { mutableStateOf<Uri?>(null) }
@@ -119,31 +220,46 @@ internal class DataStorageSettingsScreen(
             title = stringResource(R.string.backup_and_restore),
             preferenceItems =
                 persistentListOf(
-                    Preference.PreferenceItem.TextPreference(
-                        title = stringResource(R.string.create_backup),
-                        subtitle = stringResource(R.string.can_be_used_to_restore),
-                        onClick = {
-                            if (MiuiUtil.isMiui() && MiuiUtil.isMiuiOptimizationDisabled()) {
-                                context.toast(R.string.restore_miui_warning, Toast.LENGTH_LONG)
-                            }
-                            if (!BackupCreatorJob.isManualJobRunning(context)) {
-                                showCreateBackupDialog = !showCreateBackupDialog
-                            } else {
-                                context.toast(R.string.backup_in_progress)
-                            }
-                        },
-                    ),
-                    Preference.PreferenceItem.TextPreference(
-                        title = stringResource(R.string.restore_backup),
-                        subtitle = stringResource(R.string.restore_from_backup_file),
-                        onClick = {
-                            if (MiuiUtil.isMiui() && MiuiUtil.isMiuiOptimizationDisabled()) {
-                                context.toast(R.string.restore_miui_warning, Toast.LENGTH_LONG)
-                            }
-                            if (!BackupRestoreJob.isRunning(context)) {
-                                chooseRestoreFile.launch("*/*")
-                            } else {
-                                context.toast(R.string.restore_in_progress)
+                    Preference.PreferenceItem.CustomPreference(
+                        title = stringResource(R.string.backup),
+                        content = {
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(bottom = Size.medium),
+                                horizontalArrangement = Arrangement.Center,
+                            ) {
+                                ButtonGroup(
+                                    items = listOf("create", "restore"),
+                                    selectedItem = "",
+                                    onItemClick = { action ->
+                                        if (action == "create") {
+                                            if (MiuiUtil.isMiui() && MiuiUtil.isMiuiOptimizationDisabled()) {
+                                                context.toast(R.string.restore_miui_warning, Toast.LENGTH_LONG)
+                                            }
+                                            if (!BackupCreatorJob.isManualJobRunning(context)) {
+                                                showCreateBackupDialog = !showCreateBackupDialog
+                                            } else {
+                                                context.toast(R.string.backup_in_progress)
+                                            }
+                                        } else {
+                                            if (MiuiUtil.isMiui() && MiuiUtil.isMiuiOptimizationDisabled()) {
+                                                context.toast(R.string.restore_miui_warning, Toast.LENGTH_LONG)
+                                            }
+                                            if (!BackupRestoreJob.isRunning(context)) {
+                                                chooseRestoreFile.launch("*/*")
+                                            } else {
+                                                context.toast(R.string.restore_in_progress)
+                                            }
+                                        }
+                                    },
+                                ) { action ->
+                                    val text = if (action == "create") stringResource(R.string.create) else stringResource(R.string.restore)
+                                    Text(
+                                        text = text,
+                                        modifier = Modifier.padding(horizontal = Size.huge, vertical = Size.tiny),
+                                        fontWeight = FontWeight.Medium,
+                                        style = MaterialTheme.typography.labelLarge,
+                                    )
+                                }
                             }
                         },
                     ),
@@ -160,7 +276,7 @@ internal class DataStorageSettingsScreen(
                                 168 to stringResource(R.string.weekly),
                             ),
                     ),
-                    Preference.PreferenceItem.InfoPreference(stringResource(R.string.backup_info)),
+                    Preference.PreferenceItem.InfoPreference(backupInfoText),
                 ),
         )
     }
@@ -225,13 +341,11 @@ internal class DataStorageSettingsScreen(
             return persistentListOf(
                 SearchTerm(title = stringResource(R.string.storage_location)),
                 SearchTerm(
-                    title = stringResource(R.string.create_backup),
-                    subtitle = stringResource(R.string.can_be_used_to_restore),
-                    group = stringResource(R.string.backup_and_restore),
+                    title = stringResource(R.string.storage_usage),
+                    group = stringResource(R.string.storage_usage),
                 ),
                 SearchTerm(
-                    title = stringResource(R.string.restore_backup),
-                    subtitle = stringResource(R.string.restore_from_backup_file),
+                    title = stringResource(R.string.backup),
                     group = stringResource(R.string.backup_and_restore),
                 ),
                 SearchTerm(

--- a/app/src/main/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCase.kt
+++ b/app/src/main/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCase.kt
@@ -94,6 +94,8 @@ class GroupLibraryMangaUseCase {
         libraryMangaList: List<LibraryMangaItem>,
         categoryList: List<CategoryItem>,
         showEmptyCategories: Boolean = false,
+        hasMangaInDefaultCategory: Boolean = libraryMangaList.any { it.category == 0 },
+        isSearching: Boolean = false,
     ): List<LibraryCategoryItem> {
         if (libraryMangaList.isEmpty() && !showEmptyCategories) {
             return emptyList()
@@ -104,10 +106,13 @@ class GroupLibraryMangaUseCase {
         return categoryList.mapNotNull { categoryItem ->
             val unsortedMangaList = mangaMap[categoryItem.id] ?: emptyList()
 
-            if (
-                categoryItem.isSystemCategory && unsortedMangaList.isEmpty() && !showEmptyCategories
-            ) {
-                return@mapNotNull null
+            if (categoryItem.isSystemCategory) {
+                if (!hasMangaInDefaultCategory) {
+                    return@mapNotNull null
+                }
+                if (unsortedMangaList.isEmpty() && !showEmptyCategories && !isSearching) {
+                    return@mapNotNull null
+                }
             }
 
             LibraryCategoryItem(

--- a/app/src/main/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCase.kt
+++ b/app/src/main/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCase.kt
@@ -94,7 +94,7 @@ class GroupLibraryMangaUseCase {
         libraryMangaList: List<LibraryMangaItem>,
         categoryList: List<CategoryItem>,
         showEmptyCategories: Boolean = false,
-        hasMangaInDefaultCategory: Boolean = libraryMangaList.any { it.category == 0 },
+        hasMangaInDefaultCategory: Boolean,
         isSearching: Boolean = false,
     ): List<LibraryCategoryItem> {
         if (libraryMangaList.isEmpty() && !showEmptyCategories) {

--- a/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
@@ -291,6 +291,7 @@ class GroupLibraryMangaUseCaseTest {
             useCase.groupByCategory(
                 libraryMangaList = listOf(manga1, manga2, manga3),
                 categoryList = listOf(category2, category1),
+                hasMangaInDefaultCategory = false,
             )
 
         val expected =
@@ -318,6 +319,7 @@ class GroupLibraryMangaUseCaseTest {
             useCase.groupByCategory(
                 libraryMangaList = listOf(manga1, manga1Duplicate),
                 categoryList = listOf(category1),
+                hasMangaInDefaultCategory = false,
             )
 
         assertEquals(1, result.size)
@@ -337,6 +339,7 @@ class GroupLibraryMangaUseCaseTest {
             useCase.groupByCategory(
                 libraryMangaList = listOf(manga1),
                 categoryList = listOf(category1, systemCategory),
+                hasMangaInDefaultCategory = false,
             )
 
         val expected =
@@ -474,6 +477,7 @@ class GroupLibraryMangaUseCaseTest {
             useCase.groupByCategory(
                 libraryMangaList = listOf(manga1),
                 categoryList = listOf(systemCategory),
+                hasMangaInDefaultCategory = true,
             )
 
         val expected =
@@ -494,6 +498,7 @@ class GroupLibraryMangaUseCaseTest {
                 libraryMangaList = emptyList(),
                 categoryList =
                     listOf(CategoryItem(id = 1, name = "Cat", sortOrder = LibrarySort.Title)),
+                hasMangaInDefaultCategory = false,
             )
 
         assertEquals(emptyList<LibraryCategoryItem>(), result)
@@ -507,6 +512,7 @@ class GroupLibraryMangaUseCaseTest {
                 libraryMangaList = emptyList(),
                 categoryList = listOf(category1),
                 showEmptyCategories = true,
+                hasMangaInDefaultCategory = false,
             )
 
         val expected =

--- a/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
@@ -351,7 +351,7 @@ class GroupLibraryMangaUseCaseTest {
     }
 
     @Test
-    fun `groupByCategory includes empty system category when showEmptyCategories is true`() {
+    fun `groupByCategory excludes empty system category when showEmptyCategories is true but hasMangaInDefaultCategory is false`() {
         val manga1 = createMockManga(1, category = 1)
         val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
         val systemCategory =
@@ -362,6 +362,91 @@ class GroupLibraryMangaUseCaseTest {
                 libraryMangaList = listOf(manga1),
                 categoryList = listOf(category1, systemCategory),
                 showEmptyCategories = true,
+                hasMangaInDefaultCategory = false,
+            )
+
+        val expected =
+            listOf(
+                LibraryCategoryItem(
+                    categoryItem = category1,
+                    libraryItems = persistentListOf(manga1),
+                )
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `groupByCategory includes empty system category when showEmptyCategories is true and hasMangaInDefaultCategory is true`() {
+        val manga1 = createMockManga(1, category = 1)
+        val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
+        val systemCategory =
+            CategoryItem(id = 0, name = CategoryItem.SYSTEM_CATEGORY, sortOrder = LibrarySort.Title)
+
+        val result =
+            useCase.groupByCategory(
+                libraryMangaList = listOf(manga1),
+                categoryList = listOf(category1, systemCategory),
+                showEmptyCategories = true,
+                hasMangaInDefaultCategory = true,
+            )
+
+        val expected =
+            listOf(
+                LibraryCategoryItem(
+                    categoryItem = category1,
+                    libraryItems = persistentListOf(manga1),
+                ),
+                LibraryCategoryItem(
+                    categoryItem = systemCategory,
+                    libraryItems = persistentListOf(),
+                ),
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `groupByCategory excludes empty system category during search when hasMangaInDefaultCategory is false`() {
+        val manga1 = createMockManga(1, category = 1)
+        val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
+        val systemCategory =
+            CategoryItem(id = 0, name = CategoryItem.SYSTEM_CATEGORY, sortOrder = LibrarySort.Title)
+
+        val result =
+            useCase.groupByCategory(
+                libraryMangaList = listOf(manga1),
+                categoryList = listOf(category1, systemCategory),
+                showEmptyCategories = false,
+                hasMangaInDefaultCategory = false,
+                isSearching = true,
+            )
+
+        val expected =
+            listOf(
+                LibraryCategoryItem(
+                    categoryItem = category1,
+                    libraryItems = persistentListOf(manga1),
+                )
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `groupByCategory includes empty system category during search when hasMangaInDefaultCategory is true but matches is empty`() {
+        val manga1 = createMockManga(1, category = 1)
+        val category1 = CategoryItem(id = 1, name = "Category 1", sortOrder = LibrarySort.Title)
+        val systemCategory =
+            CategoryItem(id = 0, name = CategoryItem.SYSTEM_CATEGORY, sortOrder = LibrarySort.Title)
+
+        val result =
+            useCase.groupByCategory(
+                libraryMangaList = listOf(manga1),
+                categoryList = listOf(category1, systemCategory),
+                showEmptyCategories = false,
+                hasMangaInDefaultCategory = true,
+                isSearching = true,
             )
 
         val expected =

--- a/constants/src/main/res/values/strings.xml
+++ b/constants/src/main/res/values/strings.xml
@@ -918,6 +918,11 @@
     <string name="data_storage">Data and storage</string>
     <string name="storage_location">Storage location</string>
     <string name="storage_location_info">Used for automatic backups, saved images and chapter downloads.</string>
+    <string name="storage_usage">Storage usage</string>
+    <string name="storage_usage_info">This shows the overall space status of your device\'s storage drives. It is not the amount of space Neko itself is using.</string>
+    <string name="storage_used_of">%1$s used of %2$s</string>
+    <string name="storage_free">%1$s free</string>
+    <string name="available_disk_space_info">%1$s free of %2$s (total drive space)</string>
     <string name="backup">Backup</string>
     <string name="backup_and_restore">Backup and restore</string>
     <string name="create_backup">Create backup</string>
@@ -949,6 +954,7 @@
     <string name="backup_restore_invalid_uri">Error: empty URI</string>
     <string name="creating_backup">Creating backup</string>
     <string name="backup_info">Automatic backups are enabled by default. A backup is created every 24 hours, up to 6 backups will saved. For best results  You should manually keep copies in other places as well.</string>
+    <string name="last_auto_backup_info">Last automatic backup: %1$s</string>
     <string name="what_should_backup">What do you want to backup?</string>
     <string name="restoring_backup">Restoring backup</string>
     <string name="restore_duration">%1$02d min, %2$02d sec</string>

--- a/core/src/main/kotlin/tachiyomi/core/util/storage/DiskUtil.kt
+++ b/core/src/main/kotlin/tachiyomi/core/util/storage/DiskUtil.kt
@@ -74,6 +74,36 @@ object DiskUtil {
         }
     }
 
+    /** Gets the total space for the disk that a file path points to, in bytes. */
+    fun getTotalStorageSpace(f: UniFile): Long {
+        return try {
+            val stat = StatFs(f.uri.path)
+            stat.blockCountLong * stat.blockSizeLong
+        } catch (_: Exception) {
+            -1L
+        }
+    }
+
+    /** Gets the available space for the disk that a file path points to, in bytes. */
+    fun getAvailableStorageSpace(file: File): Long {
+        return try {
+            val stat = StatFs(file.absolutePath)
+            stat.availableBlocksLong * stat.blockSizeLong
+        } catch (_: Exception) {
+            -1L
+        }
+    }
+
+    /** Gets the total space for the disk that a file path points to, in bytes. */
+    fun getTotalStorageSpace(file: File): Long {
+        return try {
+            val stat = StatFs(file.absolutePath)
+            stat.blockCountLong * stat.blockSizeLong
+        } catch (_: Exception) {
+            -1L
+        }
+    }
+
     /** Don't display downloaded chapters in gallery apps creating `.nomedia`. */
     fun createNoMediaFile(dir: UniFile?, context: Context?) {
         if (dir != null && dir.exists()) {


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Display device storage usage with progress bars.

- Unify backup and restore actions into a single button group.

- Show the timestamp of the last automatic backup.

- Correctly hide empty default library categories.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DataStorageSettingsScreen"]
  B["DiskUtil"]
  C["StoragePreferences"]
  D["BackupCreatorJob"]
  E["LibraryViewModel"]
  F["GroupLibraryMangaUseCase"]
  G["Library Categories"]

  A -- "Displays storage info" --> B
  A -- "Reads last auto backup time" --> C
  D -- "Updates last auto backup time" --> C
  E -- "Passes category flags" --> F
  F -- "Filters based on flags" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>BackupCreatorJob.kt</strong><dd><code>Record last automatic backup timestamp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3151/files#diff-1fc9a074c2dd0cb61f6048c6693edfd25b48f13ae7afeb8f03fead601445ceec">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LibraryViewModel.kt</strong><dd><code>Pass category flags to group library manga use case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3151/files#diff-515ab8df479362e60e4b12f66d0a9124d1274ae346d0f40134d324711c0da63f">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DataStorageSettingsScreen.kt</strong><dd><code>Add storage usage display and refactor backup/restore UI</code>&nbsp; </dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3151/files#diff-32bcc60b9b5ecdbf23a6f2fcb9287dfdb72d69258718bc49ff1f726c068589a0">+145/-31</a></td>

</tr>

<tr>
  <td><strong>DiskUtil.kt</strong><dd><code>Add `File` overloads for storage space utility functions</code>&nbsp; </dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3151/files#diff-9769990882a3f6338dd186a9c0ba0243c4b9234a181221d672973d0f34b868d7">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>GroupLibraryMangaUseCase.kt</strong><dd><code>Refine logic for displaying system categories based on manga presence </code><br><code>and search</code></dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3151/files#diff-5bead3744298ae027091b570b3d99b9c2ca2cc1308bd7a6adf4c1ec11b228fcf">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>GroupLibraryMangaUseCaseTest.kt</strong><dd><code>Add new test cases for `groupByCategory` logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3151/files#diff-e0292fecce817a90c4fec1215f6769286532737fa588689f8aa278977c1ab14c">+92/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>strings.xml</strong><dd><code>Add new strings for storage usage and last auto backup info</code></dd></td>
  <td><a href="https://github.com/nekomangaorg/Neko/pull/3151/files#diff-dae0acc6061ff737973ebec6882d6486dd7994d01fcd043430a88436c92bd6c1">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

