### PR TITLE
ref: remove kotlinx-collections-immutable and adopt buildList

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -435,8 +435,10 @@ class LibraryUpdateJob(private val context: Context, workerParameters: WorkerPar
                         val blockedUploaders = mangaDexPreferences.blockedUploaders().get()
 
                         val fetchedChapters =
-                            (listOf(holder.sChapters) +
-                                    mergedList.map { it.map { pair -> pair.first } })
+                            buildList {
+                                add(holder.sChapters)
+                                addAll(mergedList.map { it.map { pair -> pair.first } })
+                            }
                                 .mergeSorted(
                                     compareBy<SChapter> { getChapterNum(it) != null }
                                         .thenBy { getChapterNum(it) }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
@@ -30,7 +30,6 @@ import eu.kanade.tachiyomi.util.manga.toDisplayManga
 import eu.kanade.tachiyomi.util.system.notification
 import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.notificationManager
-import kotlinx.collections.immutable.toImmutableMap
 import org.nekomanga.R
 import org.nekomanga.core.security.SecurityPreferences
 import org.nekomanga.logging.TimberKt
@@ -174,7 +173,7 @@ class LibraryUpdateNotifier(private val context: Context) {
     suspend fun showResultNotification(newUpdates: Map<LibraryManga, Array<Chapter>>) {
         if (newUpdates.isEmpty()) return
         // create a copy of the list since it will be cleared by the time it is used
-        val updates = newUpdates.toImmutableMap()
+        val updates = newUpdates.toMap()
         val notifications = ArrayList<Pair<Notification, Int>>()
         if (!securityPreferences.hideNotificationContent().get()) {
             updates.forEach {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangabaka/MangaBaka.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangabaka/MangaBaka.kt
@@ -8,8 +8,6 @@ import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.TrackService
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.data.track.updateNewTrackInfo
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.serialization.json.Json
 import org.nekomanga.R
 import org.nekomanga.data.network.mangabaka.dto.MangaBakaOAuth
@@ -81,18 +79,18 @@ class MangaBaka(private val context: Context, id: Int) : TrackService(id) {
         }
     }
 
-    override fun getScoreList(): ImmutableList<String> {
+    override fun getScoreList(): List<String> {
         return when (scorePreference.get()) {
             // 1, 2, ..., 99, 100
-            STEP_1 -> IntRange(0, 100).map(Int::toString).toImmutableList()
+            STEP_1 -> IntRange(0, 100).map(Int::toString).toList()
             // 5, 10, ..., 95, 100
-            STEP_5 -> IntRange(0, 100).step(5).map(Int::toString).toImmutableList()
+            STEP_5 -> IntRange(0, 100).step(5).map(Int::toString).toList()
             // 10, 20, ..., 90, 100
-            STEP_10 -> IntRange(0, 100).step(10).map(Int::toString).toImmutableList()
+            STEP_10 -> IntRange(0, 100).step(10).map(Int::toString).toList()
             // 20, 40, ..., 80, 100
-            STEP_20 -> IntRange(0, 100).step(20).map(Int::toString).toImmutableList()
+            STEP_20 -> IntRange(0, 100).step(20).map(Int::toString).toList()
             // 25, 50, 75, 100
-            STEP_25 -> IntRange(0, 100).step(25).map(Int::toString).toImmutableList()
+            STEP_25 -> IntRange(0, 100).step(25).map(Int::toString).toList()
             else -> throw Exception("Unknown score type")
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdates.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdates.kt
@@ -12,7 +12,6 @@ import eu.kanade.tachiyomi.data.track.mangaupdates.dto.copyTo
 import eu.kanade.tachiyomi.data.track.mangaupdates.dto.toTrackSearch
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.data.track.updateNewTrackInfo
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.R
 import org.nekomanga.logging.TimberKt
 
@@ -71,7 +70,7 @@ class MangaUpdates(private val context: Context, id: Int) : TrackService(id) {
                     else -> (0..9).map { fraction -> "$decimal.$fraction" }
                 }
             }
-            .toPersistentList()
+            .toList()
 
     override fun getScoreList(): List<String> = _scoreList
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/model/MangaListPage.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/model/MangaListPage.kt
@@ -1,11 +1,9 @@
 package eu.kanade.tachiyomi.source.model
 
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.domain.manga.SourceManga
 
 data class MangaListPage(
     val manga: List<SManga> = emptyList(),
     val hasNextPage: Boolean,
-    val sourceManga: PersistentList<SourceManga> = persistentListOf(),
+    val sourceManga: List<SourceManga> = listOf(),
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/source/model/ResultListPage.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/model/ResultListPage.kt
@@ -1,10 +1,8 @@
 package eu.kanade.tachiyomi.source.model
 
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.domain.SourceResult
 
 data class ResultListPage(
     val hasNextPage: Boolean,
-    val results: PersistentList<SourceResult> = persistentListOf(),
+    val results: List<SourceResult> = listOf(),
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDex.kt
@@ -36,7 +36,6 @@ import eu.kanade.tachiyomi.util.getOrResultError
 import eu.kanade.tachiyomi.util.lang.toResultError
 import eu.kanade.tachiyomi.util.system.logTimeTaken
 import eu.kanade.tachiyomi.util.system.withIOContext
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Headers
@@ -204,7 +203,7 @@ open class MangaDex : HttpSource() {
                             ?: return@async Ok(null)
                     fetchList(id).map { listResults ->
                         listResults.copy(
-                            sourceManga = listResults.sourceManga.shuffled().toPersistentList()
+                            sourceManga = listResults.sourceManga.shuffled().toList()
                         )
                     }
                 }
@@ -213,7 +212,7 @@ open class MangaDex : HttpSource() {
                     fetchList(MdConstants.staffPicksId).andThen { listResults ->
                         Ok(
                             listResults.copy(
-                                sourceManga = listResults.sourceManga.shuffled().toPersistentList()
+                                sourceManga = listResults.sourceManga.shuffled().toList()
                             )
                         )
                     }
@@ -223,7 +222,7 @@ open class MangaDex : HttpSource() {
                     fetchList(MdConstants.nekoDevPicksId).andThen { listResults ->
                         Ok(
                             listResults.copy(
-                                sourceManga = listResults.sourceManga.shuffled().toPersistentList()
+                                sourceManga = listResults.sourceManga.shuffled().toList()
                             )
                         )
                     }
@@ -235,7 +234,7 @@ open class MangaDex : HttpSource() {
                             ListResults(
                                 displayScreenType = DisplayScreenType.PopularNewTitles,
                                 sourceManga =
-                                    mangaListPage.sourceManga.shuffled().toPersistentList(),
+                                    mangaListPage.sourceManga.shuffled().toList(),
                             )
                         )
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
@@ -104,16 +104,18 @@ class ApiMangaParser {
                     "Content rating: " + tempContentRating.capitalized()
                 }
 
-            val genres =
-                (listOf(mangaAttributesDto.publicationDemographic?.capitalized()) +
-                        mangaAttributesDto.tags
-                            .map { it.id }
-                            .map { dexTagId ->
-                                MangaTag.entries.firstOrNull { tag -> tag.uuid == dexTagId }
-                            }
-                            .map { tag -> tag?.prettyPrint } +
-                        listOf(contentRating))
-                    .filterNotNull()
+            val genres = buildList {
+                add(mangaAttributesDto.publicationDemographic?.capitalized())
+                addAll(
+                    mangaAttributesDto.tags
+                        .map { it.id }
+                        .map { dexTagId ->
+                            MangaTag.entries.firstOrNull { tag -> tag.uuid == dexTagId }
+                        }
+                        .map { tag -> tag?.prettyPrint }
+                )
+                add(contentRating)
+            }.filterNotNull()
 
             manga.genre = genres.joinToString(", ")
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FeedUpdatesHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/FeedUpdatesHandler.kt
@@ -13,7 +13,6 @@ import eu.kanade.tachiyomi.source.online.utils.MdUtil
 import eu.kanade.tachiyomi.source.online.utils.toSourceManga
 import eu.kanade.tachiyomi.util.getOrResultError
 import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.nekomanga.constants.MdConstants
@@ -124,7 +123,7 @@ class FeedUpdatesHandler {
 
                         Ok(
                             MangaListPage(
-                                sourceManga = mangaList.toPersistentList(),
+                                sourceManga = mangaList.toList(),
                                 hasNextPage = hasMoreResults,
                             )
                         )

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/LatestChapterHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/LatestChapterHandler.kt
@@ -12,7 +12,6 @@ import eu.kanade.tachiyomi.source.online.utils.MdUtil
 import eu.kanade.tachiyomi.source.online.utils.toSourceManga
 import eu.kanade.tachiyomi.util.getOrResultError
 import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.nekomanga.constants.MdConstants
@@ -118,7 +117,7 @@ class LatestChapterHandler {
 
                         Ok(
                             MangaListPage(
-                                sourceManga = mangaList.toPersistentList(),
+                                sourceManga = mangaList.toList(),
                                 hasNextPage = hasMoreResults,
                             )
                         )

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ListHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ListHandler.kt
@@ -13,9 +13,6 @@ import eu.kanade.tachiyomi.source.online.utils.toSourceManga
 import eu.kanade.tachiyomi.ui.source.latest.DisplayScreenType
 import eu.kanade.tachiyomi.util.getOrResultError
 import kotlin.math.min
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.nekomanga.constants.MdConstants
@@ -60,7 +57,7 @@ class ListHandler {
                                     UiText.String(listDto.data.attributes.name ?: ""),
                                     listUUID,
                                 ),
-                                persistentListOf(),
+                                listOf(),
                             )
                         )
                     false -> {
@@ -110,7 +107,7 @@ class ListHandler {
                                         sourceManga =
                                             mangaListDto.data
                                                 .map { it.toSourceManga(coverQuality) }
-                                                .toPersistentList(),
+                                                .toList(),
                                         hasNextPage =
                                             (mangaListDto.limit + mangaListDto.offset) <
                                                 listDto.data.relationships.size,
@@ -152,7 +149,7 @@ class ListHandler {
                 Ok(
                     ListResults(
                         displayScreenType = displayScreenType!!,
-                        sourceManga = list.toPersistentList(),
+                        sourceManga = list.toList(),
                     )
                 )
         }
@@ -161,6 +158,6 @@ class ListHandler {
 
 data class ListResults(
     val displayScreenType: DisplayScreenType,
-    val sourceManga: PersistentList<SourceManga>,
+    val sourceManga: List<SourceManga>,
     val hasNextPage: Boolean = false,
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SearchHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/SearchHandler.kt
@@ -16,8 +16,6 @@ import eu.kanade.tachiyomi.source.online.utils.toSourceManga
 import eu.kanade.tachiyomi.util.getOrResultError
 import eu.kanade.tachiyomi.util.lang.toResultError
 import java.util.Calendar
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.nekomanga.constants.MdConstants
@@ -41,7 +39,7 @@ class SearchHandler {
             .getOrResultError("trying to view manga with UUID $mangaUUID")
             .andThen { mangaDto ->
                 val sourceManga =
-                    persistentListOf(
+                    listOf(
                         mangaDto.data.toSourceManga(mangaDexPreferences.coverQuality().get(), false)
                     )
                 Ok(MangaListPage(sourceManga = sourceManga, hasNextPage = false))
@@ -62,7 +60,7 @@ class SearchHandler {
                                 information = it.attributes.biography.asMdMap<String>()["en"] ?: "",
                             )
                         }
-                        .toPersistentList()
+                        .toList()
                 Ok(ResultListPage(hasNextPage = false, results = results))
             }
     }
@@ -81,7 +79,7 @@ class SearchHandler {
                                 information = it.attributes.description ?: "",
                             )
                         }
-                        .toPersistentList()
+                        .toList()
                 Ok(ResultListPage(hasNextPage = false, results = results))
             }
     }
@@ -197,7 +195,7 @@ class SearchHandler {
                                 mangaListDto.data
                                     .distinctBy { it.id }
                                     .map { it.toSourceManga(thumbQuality) }
-                                    .toPersistentList(),
+                                    .toList(),
                         )
                     )
                 }
@@ -237,7 +235,7 @@ class SearchHandler {
                                             displayText = "No. ${offset + index + 1}",
                                         )
                                     }
-                                    .toPersistentList(),
+                                    .toList(),
                         )
                     )
                 }
@@ -250,7 +248,7 @@ class SearchHandler {
                 val hasMoreResults = mangaListDto.limit + mangaListDto.offset < mangaListDto.total
                 val thumbQuality = mangaDexPreferences.coverQuality().get()
                 val mangaList =
-                    mangaListDto.data.map { it.toSourceManga(thumbQuality) }.toPersistentList()
+                    mangaListDto.data.map { it.toSourceManga(thumbQuality) }.toList()
                 MangaListPage(hasNextPage = hasMoreResults, sourceManga = mangaList)
             }
             .mapError {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenState.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenState.kt
@@ -12,10 +12,6 @@ import eu.kanade.tachiyomi.ui.library.filter.FilterUnavailable
 import eu.kanade.tachiyomi.ui.library.filter.FilterUnread
 import eu.kanade.tachiyomi.ui.library.filter.LibraryFilterType
 import eu.kanade.tachiyomi.ui.manga.MangaConstants
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
 import org.nekomanga.R
 import org.nekomanga.domain.category.CategoryItem
 import org.nekomanga.domain.chapter.ChapterMarkActions
@@ -44,19 +40,19 @@ data class LibraryScreenState(
     val showUnreadBadges: Boolean = false,
     val showDownloadBadges: Boolean = false,
     val incognitoMode: Boolean = false,
-    val groupByOptions: PersistentList<LibraryGroup> = persistentListOf(),
-    val trackMap: PersistentMap<Long, List<String>> = persistentMapOf(),
+    val groupByOptions: List<LibraryGroup> = listOf(),
+    val trackMap: Map<Long, List<String>> = mapOf(),
     val showUnavailableFilter: Boolean = false,
     val showStartReadingButton: Boolean = true,
     val currentGroupBy: LibraryGroup = LibraryGroup.ByCategory,
-    val items: PersistentList<LibraryCategoryItem> = persistentListOf(),
-    val selectedItems: PersistentList<LibraryMangaItem> = persistentListOf(),
-    val userCategories: PersistentList<CategoryItem> = persistentListOf(),
+    val items: List<LibraryCategoryItem> = listOf(),
+    val selectedItems: List<LibraryMangaItem> = listOf(),
+    val userCategories: List<CategoryItem> = listOf(),
     val horizontalCategories: Boolean = false,
     val showLibraryButtonBar: Boolean = true,
     val pagerIndex: Int = 0,
     val scrollPositions: Map<Int, Int> = emptyMap(),
-    val recentSearches: PersistentList<String> = persistentListOf(),
+    val recentSearches: List<String> = listOf(),
 )
 
 data class LibraryScreenActions(
@@ -107,17 +103,17 @@ data class LibraryCategoryActions(
 data class LibraryViewItem(
     val libraryDisplayMode: LibraryDisplayMode,
     val rawColumnCount: Float = 3f,
-    val libraryCategoryItems: PersistentList<LibraryCategoryItem>,
+    val libraryCategoryItems: List<LibraryCategoryItem>,
     val currentGroupBy: LibraryGroup,
-    val trackMap: PersistentMap<Long, List<String>>,
-    val userCategories: PersistentList<CategoryItem>,
+    val trackMap: Map<Long, List<String>>,
+    val userCategories: List<CategoryItem>,
 )
 
 @Immutable
 data class LibraryCategoryItem(
     val categoryItem: CategoryItem,
     val isRefreshing: Boolean = false,
-    val libraryItems: PersistentList<LibraryMangaItem> = persistentListOf(),
+    val libraryItems: List<LibraryMangaItem> = listOf(),
 )
 
 @Immutable

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -35,9 +35,6 @@ import eu.kanade.tachiyomi.util.manga.toLibraryMangaItem
 import eu.kanade.tachiyomi.util.system.combine
 import eu.kanade.tachiyomi.util.system.launchIO
 import eu.kanade.tachiyomi.util.system.launchNonCancellable
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
-import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -107,7 +104,7 @@ class LibraryViewModel() : ViewModel() {
 
     private val initialState =
         LibraryScreenState(
-            items = lastLibraryCategoryItems?.toPersistentList() ?: persistentListOf(),
+            items = lastLibraryCategoryItems?.toList() ?: listOf(),
             pagerIndex = lastPagerIndex ?: 0,
             scrollPositions = lastScrollPositions ?: emptyMap(),
             isFirstLoad = lastLibraryCategoryItems == null,
@@ -497,11 +494,11 @@ class LibraryViewModel() : ViewModel() {
                                 val sortedList =
                                     libraryCategoryItem.libraryItems
                                         .sortedWith(comparator)
-                                        .toPersistentList()
+                                        .toList()
 
                                 libraryCategoryItem.copy(libraryItems = sortedList)
                             }
-                            .toPersistentList()
+                            .toList()
 
                     Pair(sortedItems, libraryViewPreferences)
                 }
@@ -560,7 +557,7 @@ class LibraryViewModel() : ViewModel() {
                                         libraryCategoryItem.categoryItem.copy(isHidden = isHidden),
                                 )
                             }
-                            .toPersistentList()
+                            .toList()
 
                     val allCollapsed = updatedItems.all { it.categoryItem.isHidden }
 
@@ -617,11 +614,11 @@ class LibraryViewModel() : ViewModel() {
                     rawColumnCount = uiSettings.gridSize,
                     libraryFilters = uiSettings.filters,
                     hasActiveFilters = uiSettings.filters.hasActiveFilter(),
-                    recentSearches = uiSettings.recentSearches.toPersistentList(),
+                    recentSearches = uiSettings.recentSearches.toList(),
                     currentGroupBy = viewPrefs.groupBy,
-                    trackMap = trackMap.toPersistentMap(),
+                    trackMap = trackMap.toMap(),
                     userCategories =
-                        categories.filterNot { it.isSystemCategory }.toPersistentList(),
+                        categories.filterNot { it.isSystemCategory }.toList(),
                     isFirstLoad = false,
                 )
             }
@@ -662,7 +659,7 @@ class LibraryViewModel() : ViewModel() {
                         LibraryGroup.Ungrouped.takeIf { hasCategories },
                     )
                 _internalLibraryScreenState.update {
-                    it.copy(groupByOptions = groupItems.toPersistentList())
+                    it.copy(groupByOptions = groupItems.toList())
                 }
             }
             .launchIn(viewModelScope)
@@ -996,7 +993,7 @@ class LibraryViewModel() : ViewModel() {
                     .distinct()
                     .joinToString()
             StatusSyncJob.startNow(workManager, mangaIds)
-            _internalLibraryScreenState.update { it.copy(selectedItems = persistentListOf()) }
+            _internalLibraryScreenState.update { it.copy(selectedItems = listOf()) }
         }
     }
 
@@ -1010,17 +1007,18 @@ class LibraryViewModel() : ViewModel() {
 
                 val allSelected = selectedItemIds.containsAll(categoryItemIds)
 
-                val newSelectedItems =
+                val newSelectedItems = buildList {
                     if (allSelected) {
                         // Unselect all
-                        currentSelected.removeAll { it.displayManga.mangaId in categoryItemIds }
+                        addAll(currentSelected.filterNot { it.displayManga.mangaId in categoryItemIds })
                     } else {
                         // Select all
-                        val itemsToAdd = libraryMangaItems.filter {
+                        addAll(currentSelected)
+                        addAll(libraryMangaItems.filter {
                             it.displayManga.mangaId !in selectedItemIds
-                        }
-                        currentSelected.addAll(itemsToAdd)
+                        })
                     }
+                }
 
                 state.copy(selectedItems = newSelectedItems)
             }
@@ -1055,20 +1053,23 @@ class LibraryViewModel() : ViewModel() {
                 libraryScreenState.value.selectedItems.indexOfFirst {
                     it.displayManga.mangaId == libraryMangaItem.displayManga.mangaId
                 }
-            val updatedSelectedItems =
+            val selectedItems = libraryScreenState.value.selectedItems
+            val updatedSelectedItems = buildList {
                 if (index >= 0) {
-                    libraryScreenState.value.selectedItems.removeAt(index)
+                    addAll(selectedItems.filterIndexed { i, _ -> i != index })
                 } else {
+                    addAll(selectedItems)
                     val categoryItems =
                         categoryRepository
                             .getCategoriesForManga(libraryMangaItem.displayManga.mangaId)
                             .map { it.toCategoryItem() }
                     val copy = libraryMangaItem.copy(allCategories = categoryItems)
-                    libraryScreenState.value.selectedItems.add(copy)
+                    add(copy)
                 }
+            }
 
             _internalLibraryScreenState.update {
-                it.copy(selectedItems = updatedSelectedItems.distinct().toPersistentList())
+                it.copy(selectedItems = updatedSelectedItems.distinct().toList())
             }
         }
     }
@@ -1076,7 +1077,7 @@ class LibraryViewModel() : ViewModel() {
     fun markChapters(markAction: ChapterMarkActions) {
         viewModelScope.launchIO {
             val selectedItems = libraryScreenState.value.selectedItems
-            _internalLibraryScreenState.update { it.copy(selectedItems = persistentListOf()) }
+            _internalLibraryScreenState.update { it.copy(selectedItems = listOf()) }
 
             val mangaIds = selectedItems.map { it.displayManga.mangaId }
             val mangasMap = mangaRepository.getMangaByIds(mangaIds).associateBy { it.id }
@@ -1207,7 +1208,7 @@ class LibraryViewModel() : ViewModel() {
     }
 
     fun clearSelectedManga() {
-        _internalLibraryScreenState.update { it.copy(selectedItems = persistentListOf()) }
+        _internalLibraryScreenState.update { it.copy(selectedItems = listOf()) }
     }
 
     fun pagerIndexChanged(index: Int) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaConstants.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaConstants.kt
@@ -9,11 +9,6 @@ import eu.kanade.tachiyomi.data.database.models.MergeType
 import eu.kanade.tachiyomi.data.database.models.SourceMergeManga
 import eu.kanade.tachiyomi.data.external.ExternalLink
 import eu.kanade.tachiyomi.util.chapter.MissingChapterHolder
-import kotlinx.collections.immutable.ImmutableSet
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.PersistentSet
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentSetOf
 import org.nekomanga.constants.MdConstants
 import org.nekomanga.domain.category.CategoryItem
 import org.nekomanga.domain.chapter.ChapterItem
@@ -30,12 +25,12 @@ object MangaConstants {
 
     @Immutable
     data class StaticChapterData(
-        val allChapters: PersistentList<ChapterItem>,
+        val allChapters: List<ChapterItem>,
         val missingChapters: MissingChapterHolder,
-        val allScanlators: PersistentSet<String>,
-        val allUploaders: PersistentSet<String>,
-        val allSources: PersistentSet<String>,
-        val allLanguages: PersistentSet<String>,
+        val allScanlators: Set<String>,
+        val allUploaders: Set<String>,
+        val allSources: Set<String>,
+        val allLanguages: Set<String>,
     )
 
     @Immutable
@@ -52,8 +47,8 @@ object MangaConstants {
         val hideButtonText: Boolean = false,
         val backdropSize: BackdropSize = BackdropSize.Default,
         val wrapAltTitles: Boolean = false,
-        val searchChapters: PersistentList<ChapterItem> = persistentListOf(),
-        val removedChapters: PersistentList<ChapterItem> = persistentListOf(),
+        val searchChapters: List<ChapterItem> = listOf(),
+        val removedChapters: List<ChapterItem> = listOf(),
     )
 
     @Immutable
@@ -63,11 +58,11 @@ object MangaConstants {
         val isMerged: MergeConstants.IsMergedManga = MergeConstants.IsMergedManga.No,
         val currentTitle: String = "",
         val originalTitle: String = "",
-        val alternativeTitles: PersistentList<String> = persistentListOf(),
+        val alternativeTitles: List<String> = listOf(),
         val artist: String = "",
         val author: String = "",
         val currentDescription: String = "",
-        val genres: PersistentList<String> = persistentListOf(),
+        val genres: List<String> = listOf(),
         val status: Int = 0,
         val isPornographic: Boolean = false,
         val langFlag: String? = null,
@@ -76,33 +71,33 @@ object MangaConstants {
         val stats: Stats? = null,
         val lastVolume: Int? = null,
         val lastChapter: Int? = null,
-        val externalLinks: PersistentList<ExternalLink> = persistentListOf(),
+        val externalLinks: List<ExternalLink> = listOf(),
         val currentArtwork: Artwork,
-        val alternativeArtwork: PersistentList<Artwork> = persistentListOf(),
+        val alternativeArtwork: List<Artwork> = listOf(),
         val dynamicCovers: Boolean = false,
     )
 
     @Immutable
     data class MangaScreenChapterState(
-        val activeChapters: PersistentList<ChapterItem> = persistentListOf(),
-        val allChapters: PersistentList<ChapterItem> = persistentListOf(),
+        val activeChapters: List<ChapterItem> = listOf(),
+        val allChapters: List<ChapterItem> = listOf(),
         val nextUnreadChapter: NextUnreadChapter = NextUnreadChapter(),
         val chapterFilter: ChapterDisplay = ChapterDisplay(),
         val chapterFilterText: String = "",
         val chapterSortFilter: SortFilter = SortFilter(),
-        val chapterScanlatorFilter: ScanlatorFilter = ScanlatorFilter(persistentListOf()),
-        val chapterSourceFilter: ScanlatorFilter = ScanlatorFilter(persistentListOf()),
-        val chapterLanguageFilter: LanguageFilter = LanguageFilter(persistentListOf()),
-        val allScanlators: ImmutableSet<String> = persistentSetOf(),
-        val allUploaders: ImmutableSet<String> = persistentSetOf(),
-        val allSources: ImmutableSet<String> = persistentSetOf(),
-        val allLanguages: ImmutableSet<String> = persistentSetOf(),
+        val chapterScanlatorFilter: ScanlatorFilter = ScanlatorFilter(listOf()),
+        val chapterSourceFilter: ScanlatorFilter = ScanlatorFilter(listOf()),
+        val chapterLanguageFilter: LanguageFilter = LanguageFilter(listOf()),
+        val allScanlators: Set<String> = setOf(),
+        val allUploaders: Set<String> = setOf(),
+        val allSources: Set<String> = setOf(),
+        val allLanguages: Set<String> = setOf(),
     )
 
     @Immutable
     data class MangaScreenTrackState(
-        val tracks: PersistentList<TrackItem> = persistentListOf(),
-        val loggedInTrackService: PersistentList<TrackServiceItem> = persistentListOf(),
+        val tracks: List<TrackItem> = listOf(),
+        val loggedInTrackService: List<TrackServiceItem> = listOf(),
         val trackServiceCount: Int = 0,
         val trackingSuggestedDates: TrackingConstants.TrackingSuggestedDates? = null,
         val trackSearchResult: TrackingConstants.TrackSearchResult =
@@ -111,13 +106,13 @@ object MangaConstants {
 
     @Immutable
     data class MangaScreenCategoryState(
-        val allCategories: PersistentList<CategoryItem> = persistentListOf(),
-        val currentCategories: PersistentList<CategoryItem> = persistentListOf(),
+        val allCategories: List<CategoryItem> = listOf(),
+        val currentCategories: List<CategoryItem> = listOf(),
     )
 
     @Immutable
     data class MangaScreenMergeState(
-        val validMergeTypes: PersistentList<MergeType> = persistentListOf(),
+        val validMergeTypes: List<MergeType> = listOf(),
         val mergeSearchResult: MergeConstants.MergeSearchResult =
             MergeConstants.MergeSearchResult.Loading,
     )
@@ -150,12 +145,12 @@ object MangaConstants {
     @Immutable data class SortOption(val sortState: SortState, val sortType: SortType)
 
     @Immutable
-    data class ScanlatorFilter(val scanlators: PersistentList<ScanlatorOption> = persistentListOf())
+    data class ScanlatorFilter(val scanlators: List<ScanlatorOption> = listOf())
 
     @Immutable data class ScanlatorOption(val name: String, val disabled: Boolean = false)
 
     @Immutable
-    data class LanguageFilter(val languages: PersistentList<LanguageOption> = persistentListOf())
+    data class LanguageFilter(val languages: List<LanguageOption> = listOf())
 
     @Immutable data class LanguageOption(val name: String, val disabled: Boolean = false)
 
@@ -265,8 +260,8 @@ object MangaConstants {
 
     @Immutable
     data class CategoriesData(
-        val all: PersistentList<CategoryItem>,
-        val current: PersistentList<CategoryItem>,
+        val all: List<CategoryItem>,
+        val current: List<CategoryItem>,
     )
 
     sealed class DownloadAction {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -56,13 +56,6 @@ import eu.kanade.tachiyomi.util.system.launchUI
 import eu.kanade.tachiyomi.util.system.openInWebView
 import eu.kanade.tachiyomi.util.system.withIOContext
 import java.text.DateFormat
-import kotlinx.collections.immutable.ImmutableSet
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.PersistentSet
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentSetOf
-import kotlinx.collections.immutable.toPersistentList
-import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -281,14 +274,14 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
             ) { allCategories, mangaCategories ->
                 val mangaCategorySet = mangaCategories.map { it.category_id }.toSet()
                 MangaConstants.CategoriesData(
-                    all = allCategories.map { it.toCategoryItem() }.toPersistentList(),
+                    all = allCategories.map { it.toCategoryItem() }.toList(),
                     current =
                         allCategories
                             .mapNotNull {
                                 if (it.id != null && it.id in mangaCategorySet) it.toCategoryItem()
                                 else null
                             }
-                            .toPersistentList(),
+                            .toList(),
                 )
             }
             .distinctUntilChanged()
@@ -297,7 +290,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
     val tracksFlow =
         trackRepository
             .observeTracksForManga(mangaId)
-            .map { tracks -> tracks.map { it.toTrackItem() }.toPersistentList() }
+            .map { tracks -> tracks.map { it.toTrackItem() }.toList() }
             .distinctUntilChanged()
             .shareIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1)
 
@@ -400,7 +393,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
     private val staticChapterDataFlow =
         allChapterFlow
             .map { chapters ->
-                val persistentChapters = chapters.toPersistentList()
+                val persistentChapters = chapters.toList()
                 val missingChapterHolder = persistentChapters.getMissingChapters()
 
                 val allSources = mutableSetOf(MdConstants.name)
@@ -415,7 +408,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                             if (it.chapter.scanlator != Constants.NO_GROUP) return@mapNotNull null
                             it.chapter.uploader
                         }
-                        .toPersistentSet()
+                        .toSet()
 
                 SourceManager.mergeSourceNames.forEach { name ->
                     val removed = allChapterScanlators.remove(name)
@@ -427,14 +420,14 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                 val allLanguages =
                     persistentChapters
                         .flatMap { ChapterUtil.getLanguages(it.chapter.language) }
-                        .toPersistentSet()
+                        .toSet()
 
                 MangaConstants.StaticChapterData(
                     allChapters = persistentChapters,
                     missingChapters = missingChapterHolder,
-                    allScanlators = allChapterScanlators.toPersistentSet(),
+                    allScanlators = allChapterScanlators.toSet(),
                     allUploaders = allChapterUploaders,
-                    allSources = allSources.toPersistentSet(),
+                    allSources = allSources.toSet(),
                     allLanguages = allLanguages,
                 )
             }
@@ -533,7 +526,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                             ) {
                                 val manga =
                                     effectiveManga
-                                        .copy(filteredScanlators = persistentListOf())
+                                        .copy(filteredScanlators = listOf())
                                         .toManga()
                                 mangaRepository.updateManga(manga)
                             }
@@ -544,7 +537,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                                         effectiveManga.toManga(),
                                         staticChapterData.allChapters,
                                     )
-                                    .toPersistentList()
+                                    .toList()
 
                             val nextUnread = getNextUnread(effectiveManga, activeChapters)
 
@@ -566,7 +559,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                                         if (it.value.isLogged()) it.value.toTrackServiceItem()
                                         else null
                                     }
-                                    .toPersistentList()
+                                    .toList()
 
                             val trackCount = loggedInTrackerService.count { service ->
                                 tracks.any { track ->
@@ -584,7 +577,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                                 getChapterScanlatorFilter(
                                     effectiveManga,
                                     (allChapterInfo.allScanlators + allChapterInfo.allUploaders)
-                                        .toPersistentSet(),
+                                        .toSet(),
                                 )
                             val languageFilter =
                                 getChapterLanguageFilter(
@@ -609,8 +602,8 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                                 chapterLanguageFilter = languageFilter,
                                 chapterSortFilter = sortFilter,
                                 chapterFilterText = chapterFilterText,
-                                allCategories = categoriesData.all.toPersistentList(),
-                                mangaCategories = categoriesData.current.toPersistentList(),
+                                allCategories = categoriesData.all.toList(),
+                                mangaCategories = categoriesData.current.toList(),
                                 allChapterInfo = allChapterInfo,
                                 artwork = artwork,
                                 altArtwork = alternativeArtwork,
@@ -798,7 +791,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                                                     general =
                                                         it.general.copy(
                                                             removedChapters =
-                                                                removedChapters.toPersistentList()
+                                                                removedChapters.toList()
                                                         )
                                                 )
                                             }
@@ -1156,14 +1149,14 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                             else -> true
                         }
                     }
-                    .toPersistentList()
+                    .toList()
 
             val loggedInServices =
                 trackManager.services
                     .mapNotNull { service ->
                         if (service.value.isLogged()) service.value.toTrackServiceItem() else null
                     }
-                    .toPersistentList()
+                    .toList()
 
             _mangaDetailScreenState.update {
                 it.copy(
@@ -1214,7 +1207,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
         currentArtwork: Artwork,
         dbArtwork: List<ArtworkImpl>,
         useDynamicCover: Boolean,
-    ): PersistentList<Artwork> {
+    ): List<Artwork> {
         val quality = mangaDexPreferences.coverQuality().get()
 
         return dbArtwork
@@ -1237,7 +1230,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                         },
                 )
             }
-            .toPersistentList()
+            .toList()
     }
 
     /** Get current sort filter */
@@ -1298,7 +1291,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
     /** Used to filter sources, or scanlators/uploaders */
     private fun getChapterScanlatorFilter(
         mangaItem: MangaItem,
-        allScanlators: ImmutableSet<String>,
+        allScanlators: Set<String>,
     ): MangaConstants.ScanlatorFilter {
         val scanlatorSet = mangaItem.filteredScanlators.toSet()
         val scanlatorOptions =
@@ -1310,15 +1303,15 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                         disabled = scanlator in scanlatorSet,
                     )
                 }
-                .toPersistentList()
+                .toList()
 
-        return MangaConstants.ScanlatorFilter(scanlators = scanlatorOptions.toPersistentList())
+        return MangaConstants.ScanlatorFilter(scanlators = scanlatorOptions.toList())
     }
 
     /** Used to filter sources, or scanlators/uploaders */
     private fun getChapterLanguageFilter(
         mangaItem: MangaItem,
-        allLanguages: ImmutableSet<String>,
+        allLanguages: Set<String>,
     ): MangaConstants.LanguageFilter {
         val languageSet = mangaItem.filteredLanguage.toSet()
         val languageOptions =
@@ -1330,9 +1323,9 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                         disabled = language in languageSet,
                     )
                 }
-                .toPersistentList()
+                .toList()
 
-        return MangaConstants.LanguageFilter(languages = languageOptions.toPersistentList())
+        return MangaConstants.LanguageFilter(languages = languageOptions.toList())
     }
 
     private fun getSortFilter(mangaItem: MangaItem): MangaConstants.SortFilter {
@@ -1369,7 +1362,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
 
     private fun getNextUnread(
         mangaItem: MangaItem,
-        activeChapters: PersistentList<ChapterItem>,
+        activeChapters: List<ChapterItem>,
     ): NextUnreadChapter {
         val nextChapter =
             chapterSort.getNextUnreadChapter(mangaItem.toManga(), activeChapters)?.chapter
@@ -1417,7 +1410,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
 
             _mangaDetailScreenState.update {
                 it.copy(
-                    general = it.general.copy(searchChapters = filteredChapters.toPersistentList())
+                    general = it.general.copy(searchChapters = filteredChapters.toList())
                 )
             }
         }
@@ -1831,7 +1824,7 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
     fun clearRemovedChapters() {
         viewModelScope.launchIO {
             _mangaDetailScreenState.update {
-                it.copy(general = it.general.copy(removedChapters = persistentListOf()))
+                it.copy(general = it.general.copy(removedChapters = listOf()))
             }
         }
     }
@@ -2105,8 +2098,8 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
         chapterId: Long,
         downloadStatus: Download.State,
         downloadProgress: Int,
-        chapters: PersistentList<ChapterItem>,
-    ): PersistentList<ChapterItem> {
+        chapters: List<ChapterItem>,
+    ): List<ChapterItem> {
         val index = chapters.indexOfFirst { it.chapter.id == chapterId }
         return if (index >= 0) {
             val updatedChapter =
@@ -2114,7 +2107,10 @@ class MangaViewModel(val mangaId: Long) : ViewModel() {
                     downloadState = downloadStatus,
                     downloadProgress = downloadProgress,
                 )
-            chapters.set(index, updatedChapter)
+            buildList {
+                addAll(chapters)
+                set(index, updatedChapter)
+            }
         } else {
             chapters
         }
@@ -2431,23 +2427,23 @@ private data class AllInfo(
     val chapterLanguageFilter: MangaConstants.LanguageFilter = MangaConstants.LanguageFilter(),
     val chapterSortFilter: MangaConstants.SortFilter = MangaConstants.SortFilter(),
     val chapterFilterText: String = "",
-    val allCategories: PersistentList<CategoryItem> = persistentListOf(),
-    val mangaCategories: PersistentList<CategoryItem> = persistentListOf(),
+    val allCategories: List<CategoryItem> = listOf(),
+    val mangaCategories: List<CategoryItem> = listOf(),
     val allChapterInfo: AllChapterInfo = AllChapterInfo(),
     val artwork: Artwork,
-    val altArtwork: PersistentList<Artwork> = persistentListOf(),
-    val tracks: PersistentList<TrackItem> = persistentListOf(),
-    val loggedInTrackerService: PersistentList<TrackServiceItem> = persistentListOf(),
+    val altArtwork: List<Artwork> = listOf(),
+    val tracks: List<TrackItem> = listOf(),
+    val loggedInTrackerService: List<TrackServiceItem> = listOf(),
     val trackServiceCount: Int = 0,
 )
 
 private data class AllChapterInfo(
     val nextUnread: NextUnreadChapter = NextUnreadChapter(),
     val missingChapters: MissingChapterHolder = MissingChapterHolder(),
-    val activeChapters: PersistentList<ChapterItem> = persistentListOf(),
-    val allChapters: PersistentList<ChapterItem> = persistentListOf(),
-    val allScanlators: PersistentSet<String> = persistentSetOf(),
-    val allUploaders: PersistentSet<String> = persistentSetOf(),
-    val allSources: PersistentSet<String> = persistentSetOf(),
-    val allLanguages: PersistentSet<String> = persistentSetOf(),
+    val activeChapters: List<ChapterItem> = listOf(),
+    val allChapters: List<ChapterItem> = listOf(),
+    val allScanlators: Set<String> = setOf(),
+    val allUploaders: Set<String> = setOf(),
+    val allSources: Set<String> = setOf(),
+    val allLanguages: Set<String> = setOf(),
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/TrackingConstants.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/TrackingConstants.kt
@@ -3,7 +3,6 @@ package eu.kanade.tachiyomi.ui.manga
 import androidx.annotation.StringRes
 import java.text.DateFormat
 import java.time.LocalDate
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.domain.track.TrackItem
 import org.nekomanga.domain.track.TrackSearchItem
 import org.nekomanga.domain.track.TrackServiceItem
@@ -40,7 +39,7 @@ object TrackingConstants {
         object NoResult : TrackSearchResult()
 
         class Success(
-            val trackSearchResult: PersistentList<TrackSearchItem>,
+            val trackSearchResult: List<TrackSearchItem>,
             val hasMatchingId: Boolean = false,
         ) : TrackSearchResult()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/DownloadSettingsViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/DownloadSettingsViewModel.kt
@@ -4,9 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -27,7 +24,7 @@ class DownloadSettingsViewModel : ViewModel() {
     val categoryRepository: CategoryRepository by injectLazy()
 
     private val _allCategories =
-        MutableStateFlow<PersistentList<CategoryItem>>((persistentListOf()))
+        MutableStateFlow<List<CategoryItem>>((listOf()))
     val allCategories = _allCategories.asStateFlow()
 
     init {
@@ -38,7 +35,7 @@ class DownloadSettingsViewModel : ViewModel() {
                     (listOf(Category.createSystemCategory()) + categories)
                         .sortedBy { it.order }
                         .map { it.toCategoryItem() }
-                        .toPersistentList()
+                        .toList()
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/LibrarySettingsViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/LibrarySettingsViewModel.kt
@@ -6,9 +6,6 @@ import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.ui.library.LibrarySort
 import eu.kanade.tachiyomi.util.system.launchIO
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -30,7 +27,7 @@ class LibrarySettingsViewModel : ViewModel() {
     val categoryRepository: CategoryRepository by injectLazy()
 
     private val _allCategories =
-        MutableStateFlow<PersistentList<CategoryItem>>((persistentListOf()))
+        MutableStateFlow<List<CategoryItem>>((listOf()))
     val allCategories = _allCategories.asStateFlow()
 
     init {
@@ -41,7 +38,7 @@ class LibrarySettingsViewModel : ViewModel() {
                     (listOf(Category.createSystemCategory()) + categories)
                         .sortedBy { it.order }
                         .map { it.toCategoryItem() }
-                        .toPersistentList()
+                        .toList()
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/MangaDexSettingsViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/MangaDexSettingsViewModel.kt
@@ -4,9 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import eu.kanade.tachiyomi.source.online.MangaDexLoginHelper
 import eu.kanade.tachiyomi.util.system.launchIO
-import kotlinx.collections.immutable.ImmutableSet
-import kotlinx.collections.immutable.persistentSetOf
-import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -52,7 +49,7 @@ class MangaDexSettingsViewModel : ViewModel() {
                 .changes()
                 .distinctUntilChanged()
                 .onEach { blockedGroups ->
-                    _state.update { it.copy(blockedGroups = blockedGroups.toImmutableSet()) }
+                    _state.update { it.copy(blockedGroups = blockedGroups.toSet()) }
                 }
                 .stateIn(viewModelScope)
 
@@ -61,7 +58,7 @@ class MangaDexSettingsViewModel : ViewModel() {
                 .changes()
                 .distinctUntilChanged()
                 .onEach { blockedUploaders ->
-                    _state.update { it.copy(blockedUploaders = blockedUploaders.toImmutableSet()) }
+                    _state.update { it.copy(blockedUploaders = blockedUploaders.toSet()) }
                 }
                 .stateIn(viewModelScope)
         }
@@ -79,7 +76,7 @@ class MangaDexSettingsViewModel : ViewModel() {
     data class MangaDexSettingsState(
         val isLoggedIn: Boolean = false,
         val loginUrl: String = "",
-        val blockedGroups: ImmutableSet<String> = persistentSetOf(),
-        val blockedUploaders: ImmutableSet<String> = persistentSetOf(),
+        val blockedGroups: Set<String> = setOf(),
+        val blockedUploaders: Set<String> = setOf(),
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseRepository.kt
@@ -8,8 +8,6 @@ import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.online.MangaDex
 import eu.kanade.tachiyomi.source.online.MangaDexLoginHelper
 import eu.kanade.tachiyomi.util.manga.toDisplayManga
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -107,16 +105,16 @@ class BrowseRepository(
                             listResult.sourceManga
                                 .toDisplayManga(mangaRepository, mangaDex.id)
                                 .distinctBy { it.url }
-                                .toPersistentList(),
+                                .toList(),
                     )
                 }
             )
         }
     }
 
-    suspend fun getFollows(): Result<PersistentList<DisplayManga>, ResultError> {
+    suspend fun getFollows(): Result<List<DisplayManga>, ResultError> {
         return mangaDex.fetchAllFollows().andThen { sourceManga ->
-            Ok(sourceManga.toDisplayManga(mangaRepository, mangaDex.id).toPersistentList())
+            Ok(sourceManga.toDisplayManga(mangaRepository, mangaDex.id).toList())
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseScreenState.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseScreenState.kt
@@ -3,11 +3,6 @@ package eu.kanade.tachiyomi.ui.source.browse
 import androidx.compose.runtime.Immutable
 import eu.kanade.tachiyomi.data.database.models.BrowseFilterImpl
 import eu.kanade.tachiyomi.ui.source.latest.DisplayScreenType
-import kotlinx.collections.immutable.ImmutableMap
-import kotlinx.collections.immutable.ImmutableSet
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
 import org.nekomanga.R
 import org.nekomanga.domain.DisplayResult
 import org.nekomanga.domain.category.CategoryItem
@@ -27,8 +22,8 @@ data class BrowseScreenState(
     val incognitoMode: Boolean = false,
     val screenType: BrowseScreenType = BrowseScreenType.Homepage,
     val displayMangaHolder: DisplayMangaHolder = DisplayMangaHolder(),
-    val homePageManga: PersistentList<HomePageManga> = persistentListOf(),
-    val otherResults: PersistentList<DisplayResult> = persistentListOf(),
+    val homePageManga: List<HomePageManga> = listOf(),
+    val otherResults: List<DisplayResult> = listOf(),
     val error: UiText? = null,
     val endReached: Boolean = false,
     val page: Int = 1,
@@ -41,24 +36,24 @@ data class BrowseScreenState(
     val rawColumnCount: Float,
     val promptForCategories: Boolean = false,
     val filters: DexFilters,
-    val defaultContentRatings: ImmutableSet<String>,
+    val defaultContentRatings: Set<String>,
     val firstLoad: Boolean = true,
-    val savedFilters: PersistentList<BrowseFilterImpl> = persistentListOf(),
-    val categories: PersistentList<CategoryItem> = persistentListOf(),
+    val savedFilters: List<BrowseFilterImpl> = listOf(),
+    val categories: List<CategoryItem> = listOf(),
 )
 
 @Immutable
 data class HomePageManga(
     val displayScreenType: DisplayScreenType,
-    val displayManga: PersistentList<DisplayManga> = persistentListOf(),
+    val displayManga: List<DisplayManga> = listOf(),
 )
 
 @Immutable
 data class DisplayMangaHolder(
     val resultType: BrowseScreenType = BrowseScreenType.None,
-    val allDisplayManga: PersistentList<DisplayManga> = persistentListOf(),
-    val filteredDisplayManga: PersistentList<DisplayManga> = persistentListOf(),
-    val groupedDisplayManga: ImmutableMap<Int, PersistentList<DisplayManga>> = persistentMapOf(),
+    val allDisplayManga: List<DisplayManga> = listOf(),
+    val filteredDisplayManga: List<DisplayManga> = listOf(),
+    val groupedDisplayManga: Map<Int, List<DisplayManga>> = mapOf(),
 )
 
 object LibraryEntryVisibility {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseViewModel.kt
@@ -20,11 +20,6 @@ import eu.kanade.tachiyomi.util.manga.updateVisibility
 import eu.kanade.tachiyomi.util.system.activeNetworkState
 import eu.kanade.tachiyomi.util.system.launchIO
 import java.util.Date
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableMap
-import kotlinx.collections.immutable.toImmutableSet
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -85,7 +80,7 @@ class BrowseViewModel : ViewModel() {
                 rawColumnCount = libraryPreferences.gridSize().get(),
                 filters = createInitialDexFilter(""),
                 defaultContentRatings =
-                    mangaDexPreferences.visibleContentRatings().get().toImmutableSet(),
+                    mangaDexPreferences.visibleContentRatings().get().toSet(),
                 screenType = BrowseScreenType.Homepage,
             )
         )
@@ -110,7 +105,7 @@ class BrowseViewModel : ViewModel() {
         val contentRatings =
             MangaContentRating.getOrdered()
                 .map { Filter.ContentRating(it, enabledContentRatings.contains(it.key)) }
-                .toPersistentList()
+                .toList()
 
         return DexFilters(
             query = Filter.Query(incomingQuery, QueryType.Title),
@@ -151,15 +146,15 @@ class BrowseViewModel : ViewModel() {
                         .distinctBy { it.url }
 
                 val filteredDisplayManga =
-                    allDisplayManga.filterVisibility(preferences).toPersistentList()
+                    allDisplayManga.filterVisibility(preferences).toList()
                 _browseScreenState.update { state ->
                     state.copy(
                         screenType = BrowseScreenType.Filter,
                         displayMangaHolder =
                             DisplayMangaHolder(
                                 BrowseScreenType.Filter,
-                                allDisplayManga.toPersistentList(),
-                                filteredDisplayManga.toPersistentList(),
+                                allDisplayManga.toList(),
+                                filteredDisplayManga.toList(),
                             ),
                         initialLoading = false,
                         pageLoading = false,
@@ -191,7 +186,7 @@ class BrowseViewModel : ViewModel() {
                 categoryRepository
                     .getCategories()
                     .map { category -> category.toCategoryItem() }
-                    .toPersistentList()
+                    .toList()
 
             _browseScreenState.update {
                 it.copy(
@@ -232,17 +227,17 @@ class BrowseViewModel : ViewModel() {
                                 filteredDisplayManga =
                                     it.displayMangaHolder.allDisplayManga
                                         .filterVisibility(preferences)
-                                        .toPersistentList(),
+                                        .toList(),
                                 groupedDisplayManga =
                                     it.displayMangaHolder.groupedDisplayManga
                                         .map { (stringRes, mangaList) ->
                                             stringRes to
                                                 mangaList
                                                     .updateVisibility(preferences)
-                                                    .toPersistentList()
+                                                    .toList()
                                         }
                                         .toMap()
-                                        .toImmutableMap(),
+                                        .toMap(),
                             )
                     )
                 }
@@ -302,10 +297,10 @@ class BrowseViewModel : ViewModel() {
                                     entry.key to
                                         entry.value
                                             .map { manga -> manga.copy(displayTextRes = null) }
-                                            .toPersistentList()
+                                            .toList()
                                 }
                                 .toMap()
-                                .toImmutableMap()
+                                .toMap()
 
                         _browseScreenState.update { state ->
                             state.copy(
@@ -313,9 +308,9 @@ class BrowseViewModel : ViewModel() {
                                     DisplayMangaHolder(
                                         resultType = BrowseScreenType.Follows,
                                         allDisplayManga =
-                                            it.distinctBy { manga -> manga.url }.toPersistentList(),
+                                            it.distinctBy { manga -> manga.url }.toList(),
                                         filteredDisplayManga =
-                                            it.filterVisibility(preferences).toPersistentList(),
+                                            it.filterVisibility(preferences).toList(),
                                         groupedDisplayManga = groupedManga,
                                     ),
                                 initialLoading = false,
@@ -353,8 +348,8 @@ class BrowseViewModel : ViewModel() {
                     displayMangaHolder =
                         DisplayMangaHolder(
                             resultType = BrowseScreenType.Filter,
-                            allDisplayManga = persistentListOf(),
-                            filteredDisplayManga = persistentListOf(),
+                            allDisplayManga = listOf(),
+                            filteredDisplayManga = listOf(),
                         ),
                 )
             }
@@ -470,12 +465,14 @@ class BrowseViewModel : ViewModel() {
                         if (index == -1) {
                             homePageManga
                         } else {
-                            val updatedList =
-                                list.set(index, list[index].copy(inLibrary = favorite))
+                            val updatedList = buildList {
+                                addAll(list)
+                                set(index, list[index].copy(inLibrary = favorite))
+                            }
                             homePageManga.copy(displayManga = updatedList)
                         }
                     }
-                    .toPersistentList()
+                    .toList()
             _browseScreenState.update { it.copy(homePageManga = tempList) }
         }
         viewModelScope.launchIO {
@@ -492,7 +489,7 @@ class BrowseViewModel : ViewModel() {
                     it.copy(
                         displayMangaHolder =
                             it.displayMangaHolder.copy(
-                                allDisplayManga = tempList.toPersistentList()
+                                allDisplayManga = tempList.toList()
                             )
                     )
                 }
@@ -510,7 +507,7 @@ class BrowseViewModel : ViewModel() {
                         it.copy(
                             displayMangaHolder =
                                 it.displayMangaHolder.copy(
-                                    filteredDisplayManga = tempFilterList.toPersistentList()
+                                    filteredDisplayManga = tempFilterList.toList()
                                 )
                         )
                     }
@@ -574,7 +571,7 @@ class BrowseViewModel : ViewModel() {
                     is Filter.ContentRating -> {
                         val list =
                             lookupAndReplaceEntry(
-                                browseScreenState.value.filters.contentRatings.toPersistentList(),
+                                browseScreenState.value.filters.contentRatings.toList(),
                                 { it.rating == newFilter.rating },
                                 newFilter,
                             )
@@ -593,7 +590,7 @@ class BrowseViewModel : ViewModel() {
                     is Filter.OriginalLanguage -> {
                         val list =
                             lookupAndReplaceEntry(
-                                browseScreenState.value.filters.originalLanguage.toPersistentList(),
+                                browseScreenState.value.filters.originalLanguage.toList(),
                                 { it.language == newFilter.language },
                                 newFilter,
                             )
@@ -603,7 +600,7 @@ class BrowseViewModel : ViewModel() {
                         val list =
                             lookupAndReplaceEntry(
                                 browseScreenState.value.filters.publicationDemographics
-                                    .toPersistentList(),
+                                    .toList(),
                                 { it.demographic == newFilter.demographic },
                                 newFilter,
                             )
@@ -612,7 +609,7 @@ class BrowseViewModel : ViewModel() {
                     is Filter.Status -> {
                         val list =
                             lookupAndReplaceEntry(
-                                browseScreenState.value.filters.statuses.toPersistentList(),
+                                browseScreenState.value.filters.statuses.toList(),
                                 { it.status == newFilter.status },
                                 newFilter,
                             )
@@ -621,7 +618,7 @@ class BrowseViewModel : ViewModel() {
                     is Filter.Tag -> {
                         val list =
                             lookupAndReplaceEntry(
-                                browseScreenState.value.filters.tags.toPersistentList(),
+                                browseScreenState.value.filters.tags.toList(),
                                 { it.tag == newFilter.tag },
                                 newFilter,
                             )
@@ -635,7 +632,7 @@ class BrowseViewModel : ViewModel() {
                             }
 
                         browseScreenState.value.filters.copy(
-                            sort = Filter.Sort.getSortList(filterMode).toPersistentList()
+                            sort = Filter.Sort.getSortList(filterMode).toList()
                         )
                     }
                     is Filter.HasAvailableChapters -> {
@@ -688,12 +685,16 @@ class BrowseViewModel : ViewModel() {
     }
 
     private fun <T> lookupAndReplaceEntry(
-        list: PersistentList<T>,
+        list: List<T>,
         indexMethod: (T) -> Boolean,
         newEntry: T,
-    ): PersistentList<T> {
+    ): List<T> {
         val index = list.indexOfFirst { indexMethod(it) }
-        return list.set(index, newEntry)
+        if (index == -1) return list
+        return buildList {
+            addAll(list)
+            set(index, newEntry)
+        }
     }
 
     /** Add New Category */
@@ -708,7 +709,7 @@ class BrowseViewModel : ViewModel() {
                         categoryRepository
                             .getCategories()
                             .map { category -> category.toCategoryItem() }
-                            .toPersistentList()
+                            .toList()
                 )
             }
         }
@@ -735,7 +736,7 @@ class BrowseViewModel : ViewModel() {
 
     private fun updateBrowseFilters(initialLoad: Boolean = false) {
         viewModelScope.launchIO {
-            val filters = browseFilterRepository.getBrowseFilters().toPersistentList()
+            val filters = browseFilterRepository.getBrowseFilters().toList()
             _browseScreenState.update { it.copy(savedFilters = filters) }
             if (initialLoad) {
                 filters
@@ -766,9 +767,9 @@ class BrowseViewModel : ViewModel() {
                     it.copy(
                         displayMangaHolder =
                             it.displayMangaHolder.copy(
-                                allDisplayManga = allDisplayManga.toPersistentList(),
+                                allDisplayManga = allDisplayManga.toList(),
                                 filteredDisplayManga =
-                                    allDisplayManga.filterVisibility(preferences).toPersistentList(),
+                                    allDisplayManga.filterVisibility(preferences).toList(),
                             )
                     )
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayRepository.kt
@@ -11,7 +11,6 @@ import eu.kanade.tachiyomi.source.online.MangaDex
 import eu.kanade.tachiyomi.source.online.utils.getBlockedScanlatorGroupUUIDs
 import eu.kanade.tachiyomi.source.online.utils.getBlockedUploaderUUIDs
 import eu.kanade.tachiyomi.util.manga.toDisplayManga
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.data.database.repository.MangaRepository
 import org.nekomanga.data.database.repository.ScanlatorGroupRepository
 import org.nekomanga.data.database.repository.UploaderRepository
@@ -56,7 +55,7 @@ class DisplayRepository(
         val contentRatings =
             MangaContentRating.getOrdered()
                 .map { Filter.ContentRating(it, enabledContentRatings.contains(it.key)) }
-                .toPersistentList()
+                .toList()
 
         return DexFilters(
             contentRatings = contentRatings,
@@ -69,7 +68,7 @@ class DisplayRepository(
     ): Result<DisplayPageResult, ResultError> {
         return mangaDex.searchForAuthor(authorSearch).map { resultListPage ->
             val displayResult = resultListPage.results.map { it.toDisplayResult() }
-            DisplayPageResult(displayResult = displayResult.toPersistentList())
+            DisplayPageResult(displayResult = displayResult.toList())
         }
     }
 
@@ -85,7 +84,7 @@ class DisplayRepository(
                     mangaListPage.sourceManga.toDisplayManga(mangaRepository, mangaDex.id)
                 DisplayPageResult(
                     hasNextPage = mangaListPage.hasNextPage,
-                    displayManga = displayMangaList.toPersistentList(),
+                    displayManga = displayMangaList.toList(),
                 )
             }
     }
@@ -93,7 +92,7 @@ class DisplayRepository(
     private suspend fun getGroupPage(groupName: String): Result<DisplayPageResult, ResultError> {
         return mangaDex.searchForGroup(groupName).map { resultListPage ->
             val displayResult = resultListPage.results.map { it.toDisplayResult() }
-            DisplayPageResult(displayResult = displayResult.toPersistentList())
+            DisplayPageResult(displayResult = displayResult.toList())
         }
     }
 
@@ -108,7 +107,7 @@ class DisplayRepository(
                     mangaListPage.sourceManga.toDisplayManga(mangaRepository, mangaDex.id)
                 DisplayPageResult(
                     hasNextPage = mangaListPage.hasNextPage,
-                    displayManga = displayMangaList.toPersistentList(),
+                    displayManga = displayMangaList.toList(),
                 )
             }
     }
@@ -128,7 +127,7 @@ class DisplayRepository(
                     Ok(
                         DisplayPageResult(
                             hasNextPage = mangaListPage.hasNextPage,
-                            displayManga = displayMangaList.toPersistentList(),
+                            displayManga = displayMangaList.toList(),
                         )
                     )
                 },
@@ -151,7 +150,7 @@ class DisplayRepository(
                     Ok(
                         DisplayPageResult(
                             hasNextPage = mangaListPage.hasNextPage,
-                            displayManga = displayMangaList.toPersistentList(),
+                            displayManga = displayMangaList.toList(),
                         )
                     )
                 },
@@ -166,7 +165,7 @@ class DisplayRepository(
                 success = { listResults ->
                     val displayMangaList =
                         listResults.sourceManga.toDisplayManga(mangaRepository, mangaDex.id)
-                    Ok(DisplayPageResult(displayManga = displayMangaList.toPersistentList()))
+                    Ok(DisplayPageResult(displayManga = displayMangaList.toList()))
                 },
                 failure = { Err(it) },
             )
@@ -182,7 +181,7 @@ class DisplayRepository(
                     Ok(
                         DisplayPageResult(
                             hasNextPage = listResults.hasNextPage,
-                            displayManga = displayMangaList.toPersistentList(),
+                            displayManga = displayMangaList.toList(),
                         )
                     )
                 },
@@ -196,7 +195,7 @@ class DisplayRepository(
         val contentRatings =
             MangaContentRating.getOrdered()
                 .map { Filter.ContentRating(it, enabledContentRatings.contains(it.key)) }
-                .toPersistentList()
+                .toList()
 
         val blankFilter = DexFilters(contentRatings = contentRatings)
 
@@ -211,7 +210,7 @@ class DisplayRepository(
                                 if (it.rating == rating) it.copy(state = true)
                                 else it.copy(state = false)
                             }
-                            .toPersistentList()
+                            .toList()
                 )
             } else {
                 blankFilter.copy(
@@ -222,7 +221,7 @@ class DisplayRepository(
                                     it.copy(state = ToggleableState.On)
                                 else it
                             }
-                            .toPersistentList()
+                            .toList()
                 )
             }
 
@@ -235,7 +234,7 @@ class DisplayRepository(
                     Ok(
                         DisplayPageResult(
                             hasNextPage = mangaListPage.hasNextPage,
-                            displayManga = displayMangaList.toPersistentList(),
+                            displayManga = displayMangaList.toList(),
                         )
                     )
                 },
@@ -253,7 +252,7 @@ class DisplayRepository(
                     Ok(
                         DisplayPageResult(
                             hasNextPage = listResults.hasNextPage,
-                            displayManga = displayMangaList.toPersistentList(),
+                            displayManga = displayMangaList.toList(),
                         )
                     )
                 },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayScreenState.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayScreenState.kt
@@ -1,8 +1,6 @@
 package eu.kanade.tachiyomi.ui.source.latest
 
 import androidx.compose.runtime.Immutable
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.R
 import org.nekomanga.domain.DisplayResult
 import org.nekomanga.domain.category.CategoryItem
@@ -14,9 +12,9 @@ data class DisplayScreenState(
     val isLoading: Boolean = false,
     val incognitoMode: Boolean = false,
     val title: UiText = UiText.String(""),
-    val alternativeDisplay: PersistentList<DisplayResult> = persistentListOf(),
-    val allDisplayManga: PersistentList<DisplayManga> = persistentListOf(),
-    val filteredDisplayManga: PersistentList<DisplayManga> = persistentListOf(),
+    val alternativeDisplay: List<DisplayResult> = listOf(),
+    val allDisplayManga: List<DisplayManga> = listOf(),
+    val filteredDisplayManga: List<DisplayManga> = listOf(),
     val error: String? = null,
     val endReached: Boolean = false,
     val page: Int = 1,
@@ -28,14 +26,14 @@ data class DisplayScreenState(
     val rawColumnCount: Float,
     val promptForCategories: Boolean = false,
     val libraryEntryVisibility: Int,
-    val categories: PersistentList<CategoryItem> = persistentListOf(),
+    val categories: List<CategoryItem> = listOf(),
 )
 
 @Immutable
 data class DisplayPageResult(
     val hasNextPage: Boolean = false,
-    val displayResult: PersistentList<DisplayResult> = persistentListOf(),
-    val displayManga: PersistentList<DisplayManga> = persistentListOf(),
+    val displayResult: List<DisplayResult> = listOf(),
+    val displayManga: List<DisplayManga> = listOf(),
 )
 
 sealed interface DisplayScreenType {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/latest/DisplayViewModel.kt
@@ -14,7 +14,6 @@ import eu.kanade.tachiyomi.util.manga.resyncDisplayManga
 import eu.kanade.tachiyomi.util.manga.unique
 import eu.kanade.tachiyomi.util.system.launchIO
 import java.util.Date
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -116,9 +115,9 @@ class DisplayViewModel(val displayScreenType: DisplayScreenType) : ViewModel() {
                             isLoading = false,
                             page = newKey,
                             endReached = !hasNextPage,
-                            allDisplayManga = allDisplayManga.toPersistentList(),
+                            allDisplayManga = allDisplayManga.toList(),
                             filteredDisplayManga =
-                                allDisplayManga.filterVisibility(preferences).toPersistentList(),
+                                allDisplayManga.filterVisibility(preferences).toList(),
                         )
                     }
                 }
@@ -139,7 +138,7 @@ class DisplayViewModel(val displayScreenType: DisplayScreenType) : ViewModel() {
                 categoryRepository
                     .getCategories()
                     .map { category -> category.toCategoryItem() }
-                    .toPersistentList()
+                    .toList()
             _displayScreenState.update {
                 it.copy(
                     categories = categories,
@@ -160,7 +159,7 @@ class DisplayViewModel(val displayScreenType: DisplayScreenType) : ViewModel() {
                 it.copy(
                     libraryEntryVisibility = visibility,
                     filteredDisplayManga =
-                        it.allDisplayManga.filterVisibility(preferences).toPersistentList(),
+                        it.allDisplayManga.filterVisibility(preferences).toList(),
                 )
             }
         }
@@ -215,22 +214,31 @@ class DisplayViewModel(val displayScreenType: DisplayScreenType) : ViewModel() {
         viewModelScope.launchIO {
             val index =
                 _displayScreenState.value.allDisplayManga.indexOfFirst { it.mangaId == mangaId }
-            val tempDisplayManga =
-                _displayScreenState.value.allDisplayManga[index].copy(inLibrary = favorite)
-            _displayScreenState.update {
-                it.copy(allDisplayManga = it.allDisplayManga.set(index, tempDisplayManga))
-            }
-
-            val filteredIndex =
-                _displayScreenState.value.filteredDisplayManga.indexOfFirst {
-                    it.mangaId == mangaId
-                }
-            if (filteredIndex >= 0) {
+            if (index >= 0) {
+                val tempDisplayManga =
+                    _displayScreenState.value.allDisplayManga[index].copy(inLibrary = favorite)
                 _displayScreenState.update {
                     it.copy(
-                        filteredDisplayManga =
-                            it.filteredDisplayManga.set(filteredIndex, tempDisplayManga)
+                        allDisplayManga = buildList {
+                            addAll(it.allDisplayManga)
+                            set(index, tempDisplayManga)
+                        }
                     )
+                }
+
+                val filteredIndex =
+                    _displayScreenState.value.filteredDisplayManga.indexOfFirst {
+                        it.mangaId == mangaId
+                    }
+                if (filteredIndex >= 0) {
+                    _displayScreenState.update {
+                        it.copy(
+                            filteredDisplayManga = buildList {
+                                addAll(it.filteredDisplayManga)
+                                set(filteredIndex, tempDisplayManga)
+                            }
+                        )
+                    }
                 }
             }
 
@@ -238,7 +246,7 @@ class DisplayViewModel(val displayScreenType: DisplayScreenType) : ViewModel() {
                 _displayScreenState.update {
                     it.copy(
                         filteredDisplayManga =
-                            it.allDisplayManga.filterVisibility(preferences).toPersistentList()
+                            it.allDisplayManga.filterVisibility(preferences).toList()
                     )
                 }
             }
@@ -258,7 +266,7 @@ class DisplayViewModel(val displayScreenType: DisplayScreenType) : ViewModel() {
                         categoryRepository
                             .getCategories()
                             .map { category -> category.toCategoryItem() }
-                            .toPersistentList()
+                            .toList()
                 )
             }
         }
@@ -278,12 +286,12 @@ class DisplayViewModel(val displayScreenType: DisplayScreenType) : ViewModel() {
                 _displayScreenState.value.allDisplayManga
                     .resyncDisplayManga(mangaRepository)
                     .unique()
-                    .toPersistentList()
+                    .toList()
             _displayScreenState.update {
                 it.copy(
                     allDisplayManga = newDisplayManga,
                     filteredDisplayManga =
-                        newDisplayManga.filterVisibility(preferences).toPersistentList(),
+                        newDisplayManga.filterVisibility(preferences).toList(),
                 )
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
@@ -58,13 +58,19 @@ fun reorderChapters(sourceChapters: List<Chapter>): List<Chapter> {
             }
     if (hasVolumeChange) {
         val (firstVolume, withVolume) = withVolume.partition { getVolumeNum(it) == 1 }
-        return specials +
-            withVolume +
-            listOf(nullVolume, firstVolume).mergeSorted(comp) +
-            zeroVolume
+        return buildList {
+            addAll(specials)
+            addAll(withVolume)
+            addAll(listOf(nullVolume, firstVolume).mergeSorted(comp))
+            addAll(zeroVolume)
+        }
     }
     // Otherwise, we assume null volume chapters are part of any volume
-    return specials + listOf(nullVolume, withVolume).mergeSorted(comp) + zeroVolume
+    return buildList {
+        addAll(specials)
+        addAll(listOf(nullVolume, withVolume).mergeSorted(comp))
+        addAll(zeroVolume)
+    }
 }
 
 // Adapted from https://stackoverflow.com/a/69041133

--- a/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
@@ -12,8 +12,6 @@ import eu.kanade.tachiyomi.ui.source.browse.HomePageManga
 import eu.kanade.tachiyomi.ui.source.browse.LibraryEntryVisibility
 import eu.kanade.tachiyomi.util.lang.capitalizeWords
 import kotlin.math.roundToInt
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.runBlocking
 import org.nekomanga.constants.MdConstants
 import org.nekomanga.data.database.repository.CategoryRepository
@@ -268,16 +266,16 @@ fun SManga.getSlug(): String {
 /** resync homepage manga with db manga */
 suspend fun List<HomePageManga>.resyncHomePageManga(
     mangaRepository: MangaRepository
-): PersistentList<HomePageManga> {
+): List<HomePageManga> {
     return this.map { homePageManga ->
             homePageManga.copy(
                 displayManga =
                     homePageManga.displayManga
                         .resyncDisplayManga(mangaRepository)
-                        .toPersistentList()
+                        .toList()
             )
         }
-        .toPersistentList()
+        .toList()
 }
 
 suspend fun List<DisplayManga>.resyncDisplayManga(
@@ -311,13 +309,14 @@ fun List<DisplayManga>.unique(): List<DisplayManga> {
 }
 
 /** Updates the visibility of HomePageManga display manga */
-fun List<HomePageManga>.updateVisibility(prefs: PreferencesHelper): PersistentList<HomePageManga> {
+@JvmName("updateHomePageMangaVisibility")
+fun List<HomePageManga>.updateVisibility(prefs: PreferencesHelper): List<HomePageManga> {
     return this.map { homePageManga ->
             homePageManga.copy(
-                displayManga = homePageManga.displayManga.updateVisibility(prefs).toPersistentList()
+                displayManga = homePageManga.displayManga.updateVisibility(prefs).toList()
             )
         }
-        .toPersistentList()
+        .toList()
 }
 
 /**

--- a/app/src/main/java/org/nekomanga/domain/category/CategoryItem.kt
+++ b/app/src/main/java/org/nekomanga/domain/category/CategoryItem.kt
@@ -4,9 +4,6 @@ import androidx.compose.runtime.Immutable
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.database.models.CategoryImpl
 import eu.kanade.tachiyomi.ui.library.LibrarySort
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 
 @Immutable
 data class CategoryItem(
@@ -14,7 +11,7 @@ data class CategoryItem(
     val name: String,
     val order: Int = 0,
     val flags: Int = 0,
-    val mangaOrder: PersistentList<Long> = persistentListOf(),
+    val mangaOrder: List<Long> = listOf(),
     val sortOrder: LibrarySort,
     val isAscending: Boolean = true,
     val isAlone: Boolean = true,
@@ -62,7 +59,7 @@ fun Category.toCategoryItem(): CategoryItem {
         name = this.name,
         order = this.order,
         flags = this.flags,
-        mangaOrder = this.mangaOrder.toPersistentList(),
+        mangaOrder = this.mangaOrder.toList(),
         isAscending = this.isAscending(),
         sortOrder = LibrarySort.filteredValueOf(this.mangaSort) ?: LibrarySort.Title,
         isAlone = this.isAlone,

--- a/app/src/main/java/org/nekomanga/domain/manga/MangaItem.kt
+++ b/app/src/main/java/org/nekomanga/domain/manga/MangaItem.kt
@@ -7,9 +7,6 @@ import eu.kanade.tachiyomi.source.online.utils.FollowStatus
 import eu.kanade.tachiyomi.source.online.utils.MdUtil
 import eu.kanade.tachiyomi.util.chapter.ChapterUtil
 import eu.kanade.tachiyomi.util.manga.MangaUtil
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 
 data class MangaItem(
     val id: Long = 0L,
@@ -20,7 +17,7 @@ data class MangaItem(
     val author: String = "",
     val description: String = "",
     val contentRating: String = "",
-    val genre: PersistentList<String> = persistentListOf(),
+    val genre: List<String> = listOf(),
     val status: Int = 0,
     val coverUrl: String = "",
     val favorite: Boolean = false,
@@ -37,15 +34,15 @@ data class MangaItem(
     val myAnimeListId: String = "",
     val mangaUpdatesId: String = "",
     val animePlanetId: String = "",
-    val externalLinks: PersistentList<ExternalLink> = persistentListOf(),
-    val filteredScanlators: PersistentList<String> = persistentListOf(),
-    val filteredLanguage: PersistentList<String> = persistentListOf(),
+    val externalLinks: List<ExternalLink> = listOf(),
+    val filteredScanlators: List<String> = listOf(),
+    val filteredLanguage: List<String> = listOf(),
     val missingChapters: String = "",
     val rating: String = "",
     val users: String = "",
     val lastVolumeNumber: Int? = null,
     val lastChapterNumber: Int? = null,
-    val altTitles: PersistentList<String> = persistentListOf(),
+    val altTitles: List<String> = listOf(),
     val userCover: String = "",
     val dynamicCover: String = "",
     val userTitle: String = "",
@@ -106,7 +103,7 @@ fun Manga.toMangaItem(): MangaItem {
         author = this.author ?: "",
         description = this.description ?: "",
         contentRating = MangaUtil.getContentRating(MangaUtil.getGenres(this.genre)),
-        genre = MangaUtil.getGenres(this.genre, true).toPersistentList(),
+        genre = MangaUtil.getGenres(this.genre, true).toList(),
         status = this.status,
         coverUrl = this.thumbnail_url ?: "",
         favorite = this.favorite,
@@ -123,15 +120,15 @@ fun Manga.toMangaItem(): MangaItem {
         myAnimeListId = this.my_anime_list_id ?: "",
         mangaUpdatesId = this.manga_updates_id ?: "",
         animePlanetId = this.anime_planet_id ?: "",
-        externalLinks = this.getExternalLinks().toPersistentList(),
-        filteredScanlators = ChapterUtil.getScanlators(this.filtered_scanlators).toPersistentList(),
-        filteredLanguage = ChapterUtil.getLanguages(this.filtered_language).toPersistentList(),
+        externalLinks = this.getExternalLinks().toList(),
+        filteredScanlators = ChapterUtil.getScanlators(this.filtered_scanlators).toList(),
+        filteredLanguage = ChapterUtil.getLanguages(this.filtered_language).toList(),
         missingChapters = this.missing_chapters ?: "",
         rating = this.rating ?: "",
         users = this.users ?: "",
         lastVolumeNumber = this.last_volume_number,
         lastChapterNumber = this.last_chapter_number,
-        altTitles = this.getAltTitles().toPersistentList(),
+        altTitles = this.getAltTitles().toList(),
         dynamicCover = this.dynamic_cover ?: "",
         userCover = this.user_cover ?: "",
         userTitle = this.user_title ?: "",

--- a/app/src/main/java/org/nekomanga/domain/track/Track.kt
+++ b/app/src/main/java/org/nekomanga/domain/track/Track.kt
@@ -3,8 +3,6 @@ package org.nekomanga.domain.track
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.TrackService
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 
 data class TrackItem(
     val id: Long?,
@@ -27,14 +25,14 @@ data class TrackServiceItem(
     val nameRes: Int,
     val logoRes: Int,
     val logoColor: Int,
-    val statusList: PersistentList<Int>,
+    val statusList: List<Int>,
     val supportsReadingDates: Boolean,
     val canRemoveFromService: Boolean,
     val isAutoAddTracker: Boolean,
     val isMdList: Boolean,
     val status: (Int) -> String,
     val displayScore: (TrackItem) -> String,
-    val scoreList: PersistentList<String>,
+    val scoreList: List<String>,
     val indexToScore: (Int) -> Float,
 )
 
@@ -44,14 +42,14 @@ fun TrackService.toTrackServiceItem(): TrackServiceItem {
         nameRes = this.nameRes(),
         logoRes = this.getLogo(),
         logoColor = this.getLogoColor(),
-        statusList = this.getStatusList().toPersistentList(),
+        statusList = this.getStatusList().toList(),
         supportsReadingDates = this.supportsReadingDates,
         canRemoveFromService = this.canRemoveFromService(),
         isAutoAddTracker = this.isAutoAddTracker(),
         isMdList = this.isMdList(),
         status = { num -> this.getStatus(num) },
         displayScore = { track -> this.displayScore(track.toDbTrack()) },
-        scoreList = this.getScoreList().toPersistentList(),
+        scoreList = this.getScoreList().toList(),
         indexToScore = { index -> this.indexToScore(index) },
     )
 }

--- a/app/src/main/java/org/nekomanga/presentation/components/AppBarActions.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/AppBarActions.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.R
 import org.nekomanga.presentation.components.dropdown.MainDropdownMenu
 import org.nekomanga.presentation.components.dropdown.SimpleDropDownItem
@@ -55,7 +54,7 @@ fun AppBarActions(
                 dropDownItems =
                     overflowActions
                         .map { appBarAction -> appBarAction.toSimpleAction() }
-                        .toPersistentList(),
+                        .toList(),
             )
         }
     }

--- a/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
@@ -51,8 +51,6 @@ import eu.kanade.tachiyomi.util.chapter.ChapterUtil
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import me.saket.swipe.SwipeAction
 import org.nekomanga.R
 import org.nekomanga.constants.Constants
@@ -412,7 +410,7 @@ private fun buildChapterDropdownItems(
     onComment: () -> Unit,
     markPrevious: (Boolean) -> Unit,
     blockScanlator: (MangaConstants.BlockType, String) -> Unit,
-): PersistentList<SimpleDropDownItem> {
+): List<SimpleDropDownItem> {
     return buildList {
             if (!isLocal) {
                 add(
@@ -476,7 +474,7 @@ private fun buildChapterDropdownItems(
                 )
             }
         }
-        .toPersistentList()
+        .toList()
 }
 
 @Composable

--- a/app/src/main/java/org/nekomanga/presentation/components/DownloadButton.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/DownloadButton.kt
@@ -57,7 +57,6 @@ import androidx.compose.ui.unit.dp
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.ui.manga.MangaConstants
 import java.text.NumberFormat
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
 import org.nekomanga.R
 import org.nekomanga.core.util.launchDelayed
@@ -180,7 +179,7 @@ fun DownloadButton(
         val dropDownItems =
             when (downloadState) {
                 Download.State.DOWNLOADED -> {
-                    persistentListOf(
+                    listOf(
                         SimpleDropDownItem.Action(
                             text = UiText.StringResource(R.string.remove),
                             onClick = { isDraining = true },
@@ -188,7 +187,7 @@ fun DownloadButton(
                     )
                 }
                 Download.State.ERROR -> {
-                    persistentListOf(
+                    listOf(
                         SimpleDropDownItem.Action(
                             text = UiText.StringResource(R.string.cancel),
                             onClick = {
@@ -201,7 +200,7 @@ fun DownloadButton(
                 }
                 Download.State.QUEUE,
                 Download.State.DOWNLOADING -> {
-                    persistentListOf(
+                    listOf(
                         SimpleDropDownItem.Action(
                             text = UiText.StringResource(R.string.start_downloading_now),
                             onClick = {
@@ -220,7 +219,7 @@ fun DownloadButton(
                         ),
                     )
                 }
-                Download.State.NOT_DOWNLOADED -> persistentListOf()
+                Download.State.NOT_DOWNLOADED -> listOf()
             }
 
         SimpleDropdownMenu(

--- a/app/src/main/java/org/nekomanga/presentation/components/MangaGridView.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/MangaGridView.kt
@@ -39,9 +39,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import com.cheonjaeung.compose.grid.SimpleGridCells
 import com.cheonjaeung.compose.grid.VerticalGrid
-import kotlinx.collections.immutable.ImmutableMap
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toImmutableMap
 import org.nekomanga.R
 import org.nekomanga.domain.manga.DisplayManga
 import org.nekomanga.presentation.theme.Shapes
@@ -49,7 +46,7 @@ import org.nekomanga.presentation.theme.Size
 
 @Composable
 fun MangaGridWithHeader(
-    groupedManga: ImmutableMap<Int, PersistentList<DisplayManga>>,
+    groupedManga: Map<Int, List<DisplayManga>>,
     shouldOutlineCover: Boolean,
     dynamicCover: Boolean,
     columns: Int,
@@ -65,7 +62,7 @@ fun MangaGridWithHeader(
             groupedManga
                 .mapValues { (_, list) -> list.filter { it.isVisible }.chunked(columns) }
                 .filterValues { it.isNotEmpty() }
-                .toImmutableMap()
+                .toMap()
         }
 
     LazyColumn(

--- a/app/src/main/java/org/nekomanga/presentation/components/MangaListView.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/MangaListView.kt
@@ -33,10 +33,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.ImmutableMap
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toImmutableMap
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.domain.manga.DisplayManga
 import org.nekomanga.presentation.components.listcard.ExpressiveListCard
 import org.nekomanga.presentation.components.listcard.ListCardType
@@ -44,7 +40,7 @@ import org.nekomanga.presentation.theme.Size
 
 @Composable
 fun MangaList(
-    mangaList: PersistentList<DisplayManga>,
+    mangaList: List<DisplayManga>,
     shouldOutlineCover: Boolean = true,
     dynamicCover: Boolean,
     contentPadding: PaddingValues = PaddingValues(),
@@ -99,7 +95,7 @@ fun MangaList(
 
 @Composable
 fun MangaListWithHeader(
-    groupedManga: ImmutableMap<Int, PersistentList<DisplayManga>>,
+    groupedManga: Map<Int, List<DisplayManga>>,
     shouldOutlineCover: Boolean,
     dynamicCover: Boolean,
     modifier: Modifier = Modifier,
@@ -110,9 +106,9 @@ fun MangaListWithHeader(
     val filteredGroupedManga =
         remember(groupedManga) {
             groupedManga
-                .mapValues { (_, list) -> list.filter { it.isVisible }.toPersistentList() }
+                .mapValues { (_, list) -> list.filter { it.isVisible }.toList() }
                 .filterValues { it.isNotEmpty() }
-                .toImmutableMap()
+                .toMap()
         }
 
     LazyColumn(

--- a/app/src/main/java/org/nekomanga/presentation/components/OtherResultListView.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/OtherResultListView.kt
@@ -14,13 +14,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.domain.DisplayResult
 import org.nekomanga.presentation.theme.Size
 
 @Composable
 fun ResultList(
-    results: PersistentList<DisplayResult>,
+    results: List<DisplayResult>,
     contentPadding: PaddingValues = PaddingValues(),
     onClick: (String) -> Unit = {},
 ) {

--- a/app/src/main/java/org/nekomanga/presentation/components/dialog/RemovedChaptersDialog.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/dialog/RemovedChaptersDialog.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.R
 import org.nekomanga.domain.chapter.ChapterItem
 import org.nekomanga.presentation.components.theme.ThemeColorState
@@ -18,7 +17,7 @@ import org.nekomanga.presentation.components.theme.ThemeColorState
 @Composable
 fun RemovedChaptersDialog(
     themeColorState: ThemeColorState,
-    chapters: PersistentList<ChapterItem>,
+    chapters: List<ChapterItem>,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {

--- a/app/src/main/java/org/nekomanga/presentation/components/dropdown/SimpleDropdownMenu.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/dropdown/SimpleDropdownMenu.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
-import kotlinx.collections.immutable.PersistentList
 import me.saket.cascade.CascadeColumnScope
 import org.nekomanga.presentation.components.UiText
 import org.nekomanga.presentation.components.theme.ThemeColorState
@@ -17,7 +16,7 @@ import org.nekomanga.presentation.components.theme.ThemeColorState
 fun SimpleDropdownMenu(
     expanded: Boolean,
     onDismiss: () -> Unit,
-    dropDownItems: PersistentList<SimpleDropDownItem>,
+    dropDownItems: List<SimpleDropDownItem>,
     themeColorState: ThemeColorState,
 ) {
     NekoDropdownMenu(

--- a/app/src/main/java/org/nekomanga/presentation/components/sheets/EditCategorySheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/sheets/EditCategorySheet.kt
@@ -28,8 +28,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import java.util.Locale
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.R
 import org.nekomanga.domain.category.CategoryItem
 import org.nekomanga.presentation.components.CheckboxRow
@@ -42,8 +40,8 @@ import org.nekomanga.presentation.theme.Size
 @Composable
 fun EditCategorySheet(
     addingToLibrary: Boolean,
-    categories: PersistentList<CategoryItem>,
-    mangaCategories: PersistentList<CategoryItem> = persistentListOf(),
+    categories: List<CategoryItem>,
+    mangaCategories: List<CategoryItem> = listOf(),
     themeColorState: ThemeColorState = defaultThemeColorState(),
     cancelClick: () -> Unit,
     addNewCategory: (String) -> Unit,

--- a/app/src/main/java/org/nekomanga/presentation/components/sheets/FilterBrowseSheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/sheets/FilterBrowseSheet.kt
@@ -57,10 +57,6 @@ import eu.kanade.tachiyomi.data.database.models.BrowseFilterImpl
 import eu.kanade.tachiyomi.source.online.utils.MdSort
 import eu.kanade.tachiyomi.util.lang.isUUID
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.ImmutableSet
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import org.nekomanga.R
@@ -90,8 +86,8 @@ fun FilterBrowseSheet(
     filterDefaultClick: (String, Boolean) -> Unit,
     loadFilter: (BrowseFilterImpl) -> Unit,
     filterChanged: (Filter) -> Unit,
-    defaultContentRatings: ImmutableSet<String>,
-    savedFilters: PersistentList<BrowseFilterImpl>,
+    defaultContentRatings: Set<String>,
+    savedFilters: List<BrowseFilterImpl>,
     bottomContentPadding: Dp = Size.medium,
     themeColorState: ThemeColorState = defaultThemeColorState(),
 ) {
@@ -216,7 +212,7 @@ fun FilterBrowseSheet(
             )
 
             FilterRow(
-                items = filters.originalLanguage.toPersistentList(),
+                items = filters.originalLanguage.toList(),
                 expanded = originalLanguageExpanded,
                 disabled = disabled,
                 headerClicked = { originalLanguageExpanded = !originalLanguageExpanded },
@@ -231,7 +227,7 @@ fun FilterBrowseSheet(
 
             if (filters.contentRatingVisible) {
                 FilterRow(
-                    items = filters.contentRatings.toPersistentList(),
+                    items = filters.contentRatings.toList(),
                     expanded = contentRatingExpanded,
                     disabled = disabled,
                     headerClicked = { contentRatingExpanded = !contentRatingExpanded },
@@ -248,7 +244,7 @@ fun FilterBrowseSheet(
             }
 
             FilterRow(
-                items = filters.publicationDemographics.toPersistentList(),
+                items = filters.publicationDemographics.toList(),
                 expanded = publicationDemographicExpanded,
                 disabled = disabled,
                 headerClicked = {
@@ -262,7 +258,7 @@ fun FilterBrowseSheet(
             )
 
             FilterRow(
-                items = filters.statuses.toPersistentList(),
+                items = filters.statuses.toList(),
                 expanded = statusExpanded,
                 disabled = disabled,
                 headerClicked = { statusExpanded = !statusExpanded },
@@ -274,7 +270,7 @@ fun FilterBrowseSheet(
             )
 
             FilterRow(
-                items = filters.sort.toPersistentList(),
+                items = filters.sort.toList(),
                 expanded = sortExpanded,
                 disabled = disabled,
                 headerClicked = { sortExpanded = !sortExpanded },
@@ -286,7 +282,7 @@ fun FilterBrowseSheet(
             )
 
             FilterTriStateRow(
-                items = filters.tags.toPersistentList(),
+                items = filters.tags.toList(),
                 expanded = tagExpanded,
                 disabled = disabled,
                 headerClicked = { tagExpanded = !tagExpanded },
@@ -400,7 +396,7 @@ fun FilterBrowseSheet(
 
 @Composable
 private fun <T> FilterRow(
-    items: PersistentList<T>,
+    items: List<T>,
     expanded: Boolean,
     disabled: Boolean,
     anyEnabled: Boolean,
@@ -448,7 +444,7 @@ private fun <T> FilterRow(
 
 @Composable
 private fun <T> FilterTriStateRow(
-    items: PersistentList<T>,
+    items: List<T>,
     expanded: Boolean,
     disabled: Boolean,
     headerClicked: () -> Unit,
@@ -631,7 +627,7 @@ fun OtherRow(
 @Composable
 fun SavedFilters(
     visible: Boolean,
-    savedFilters: PersistentList<BrowseFilterImpl>,
+    savedFilters: List<BrowseFilterImpl>,
     nameOfEnabledFilter: String,
     loadFilter: (BrowseFilterImpl) -> Unit,
     deleteFilterClick: (String) -> Unit,
@@ -650,7 +646,7 @@ fun SavedFilters(
                         val mutableFilters = savedFilters.toMutableList()
                         val enabledFilter = mutableFilters.removeAt(enabledFilterIndex)
                         mutableStateOf(
-                            persistentListOf(enabledFilter) + mutableFilters.toPersistentList()
+                            listOf(enabledFilter) + mutableFilters.toList()
                         )
                     }
                 }

--- a/app/src/main/java/org/nekomanga/presentation/components/sheets/TrackingSheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/sheets/TrackingSheet.kt
@@ -42,7 +42,6 @@ import eu.kanade.tachiyomi.ui.manga.TrackingConstants.ReadingDate
 import eu.kanade.tachiyomi.ui.manga.TrackingConstants.TrackAndService
 import eu.kanade.tachiyomi.ui.manga.TrackingConstants.TrackingDate
 import java.text.DateFormat
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.R
 import org.nekomanga.domain.track.TrackItem
 import org.nekomanga.domain.track.TrackServiceItem
@@ -62,8 +61,8 @@ import org.nekomanga.presentation.theme.Size
 fun TrackingSheet(
     themeColor: ThemeColorState,
     inLibrary: Boolean,
-    servicesProvider: () -> PersistentList<TrackServiceItem>,
-    tracksProvider: () -> PersistentList<TrackItem>,
+    servicesProvider: () -> List<TrackServiceItem>,
+    tracksProvider: () -> List<TrackItem>,
     dateFormat: DateFormat,
     onLogoClick: (String, String) -> Unit,
     onSearchTrackClick: (TrackServiceItem, TrackItem?) -> Unit,

--- a/app/src/main/java/org/nekomanga/presentation/screens/BrowseScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/BrowseScreen.kt
@@ -46,7 +46,6 @@ import eu.kanade.tachiyomi.ui.source.browse.FilterActions
 import eu.kanade.tachiyomi.ui.source.browse.NavigationEvent
 import eu.kanade.tachiyomi.ui.source.latest.SerializableDisplayScreenType
 import eu.kanade.tachiyomi.ui.source.latest.toSerializable
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.nekomanga.R
@@ -271,7 +270,7 @@ private fun BrowseWrapper(
                 EmptyScreen(
                     message = browseScreenState.error!!,
                     actions =
-                        persistentListOf(
+                        listOf(
                             Action(
                                 text = UiText.StringResource(R.string.retry),
                                 onClick = retryClick,

--- a/app/src/main/java/org/nekomanga/presentation/screens/DisplayScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/DisplayScreen.kt
@@ -42,7 +42,6 @@ import eu.kanade.tachiyomi.ui.source.latest.DisplayScreenState
 import eu.kanade.tachiyomi.ui.source.latest.DisplayScreenType
 import eu.kanade.tachiyomi.ui.source.latest.DisplayViewModel
 import eu.kanade.tachiyomi.ui.source.latest.toSerializable
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 import org.nekomanga.R
 import org.nekomanga.domain.category.CategoryItem
@@ -215,13 +214,13 @@ private fun DisplayWrapper(
                 message = UiText.String(displayScreenState.error),
                 actions =
                     if (displayScreenState.page == 1)
-                        persistentListOf(
+                        listOf(
                             Action(
                                 text = UiText.StringResource(R.string.retry),
                                 onClick = retryClick,
                             )
                         )
-                    else persistentListOf(),
+                    else listOf(),
             )
         } else {
             if (displayScreenState.isDisplayResult) {

--- a/app/src/main/java/org/nekomanga/presentation/screens/EmptyScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/EmptyScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.presentation.components.NekoColors
 import org.nekomanga.presentation.components.UiText
 import org.nekomanga.presentation.theme.Size
@@ -76,7 +74,7 @@ private val ErrorFaces =
 fun EmptyScreen(
     message: UiText,
     modifier: Modifier = Modifier.fillMaxSize(),
-    actions: PersistentList<Action> = persistentListOf(),
+    actions: List<Action> = listOf(),
     contentPadding: PaddingValues = PaddingValues(),
 ) {
     val errorFace = remember { ErrorFaces.random() }

--- a/app/src/main/java/org/nekomanga/presentation/screens/EmptyScreenPreview.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/EmptyScreenPreview.kt
@@ -2,7 +2,6 @@ package org.nekomanga.presentation.screens
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.R
 import org.nekomanga.presentation.components.UiText
 
@@ -11,6 +10,6 @@ import org.nekomanga.presentation.components.UiText
 private fun EmptyViewPreview() {
     EmptyScreen(
         message = UiText.StringResource(R.string.no_results_found),
-        actions = persistentListOf(Action(UiText.StringResource(R.string.retry))),
+        actions = listOf(Action(UiText.StringResource(R.string.retry))),
     )
 }

--- a/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
@@ -70,7 +70,6 @@ import eu.kanade.tachiyomi.util.system.sharedCacheDir
 import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.system.withUIContext
 import java.text.DateFormat
-import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.nekomanga.R
@@ -591,7 +590,7 @@ private fun MangaScreenWrapper(
 }
 
 private fun LazyListScope.chapterList(
-    chapters: PersistentList<ChapterItem>,
+    chapters: List<ChapterItem>,
     screenState: MangaConstants.MangaDetailScreenState,
     themeColorState: ThemeColorState,
     chapterActions: ChapterActions,

--- a/app/src/main/java/org/nekomanga/presentation/screens/SimilarScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/SimilarScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavKey
 import eu.kanade.tachiyomi.ui.main.states.RefreshState
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 import org.nekomanga.R
 import org.nekomanga.domain.category.CategoryItem
@@ -193,7 +192,7 @@ private fun SimilarContent(
             EmptyScreen(
                 message = UiText.StringResource(resourceId = R.string.no_results_found),
                 actions =
-                    persistentListOf(
+                    listOf(
                         Action(text = UiText.StringResource(R.string.retry), onClick = onRefresh)
                     ),
             )

--- a/app/src/main/java/org/nekomanga/presentation/screens/StatsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/StatsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.R
 import org.nekomanga.presentation.components.ChartColors
 import org.nekomanga.presentation.components.UiText
@@ -52,7 +51,7 @@ fun StatsWrapper(
     windowSizeClass: WindowSizeClass,
 ) {
     val colors = remember {
-        persistentListOf(
+        listOf(
             ChartColors.one,
             ChartColors.two,
             ChartColors.three,

--- a/app/src/main/java/org/nekomanga/presentation/screens/browse/BrowseHomePage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/browse/BrowseHomePage.kt
@@ -33,7 +33,6 @@ import eu.kanade.tachiyomi.ui.source.browse.HomePageManga
 import eu.kanade.tachiyomi.ui.source.latest.SerializableDisplayScreenType
 import eu.kanade.tachiyomi.ui.source.latest.toSerializable
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.R
 import org.nekomanga.domain.manga.DisplayManga
 import org.nekomanga.presentation.components.InLibraryBadge
@@ -45,7 +44,7 @@ import org.nekomanga.presentation.theme.Size
 
 @Composable
 fun BrowseHomePage(
-    browseHomePageManga: PersistentList<HomePageManga>,
+    browseHomePageManga: List<HomePageManga>,
     shouldOutlineCover: Boolean,
     dynamicCovers: Boolean,
     useVividColorHeaders: Boolean,

--- a/app/src/main/java/org/nekomanga/presentation/screens/browse/DisplayScreenSheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/browse/DisplayScreenSheet.kt
@@ -2,7 +2,6 @@ package org.nekomanga.presentation.screens.browse
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.domain.category.CategoryItem
 import org.nekomanga.presentation.components.sheets.BrowseDisplayOptionsSheet
 import org.nekomanga.presentation.components.sheets.EditCategorySheet
@@ -23,7 +22,7 @@ sealed class DisplaySheetScreen {
 @Composable
 fun DisplayScreenSheet(
     currentScreen: DisplaySheetScreen,
-    categories: PersistentList<CategoryItem>,
+    categories: List<CategoryItem>,
     isList: Boolean,
     libraryEntryVisibility: Int,
     addNewCategory: (String) -> Unit,

--- a/app/src/main/java/org/nekomanga/presentation/screens/download/DownloadChapterRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/download/DownloadChapterRow.kt
@@ -35,8 +35,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import eu.kanade.tachiyomi.data.download.model.Download
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toPersistentList
 import me.saket.swipe.SwipeAction
 import org.nekomanga.R
 import org.nekomanga.domain.download.DownloadItem
@@ -192,7 +190,7 @@ private fun getDropDownItems(
     moveToBottomClicked: () -> Unit,
     moveSeriesToBottomClicked: () -> Unit,
     cancelSeriesClicked: () -> Unit,
-): PersistentList<SimpleDropDownItem> {
+): List<SimpleDropDownItem> {
     return listOf(
             SimpleDropDownItem.Parent(
                 text = UiText.StringResource(R.string.move_download),
@@ -229,7 +227,7 @@ private fun getDropDownItems(
                 onClick = cancelSeriesClicked,
             ),
         )
-        .toPersistentList()
+        .toList()
 }
 
 @Composable

--- a/app/src/main/java/org/nekomanga/presentation/screens/download/DownloadScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/download/DownloadScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import eu.kanade.tachiyomi.data.database.models.MergeType
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.R
 import org.nekomanga.constants.MdConstants
 import org.nekomanga.domain.download.DownloadItem
@@ -48,7 +47,7 @@ import soup.compose.material.motion.MaterialFade
 @Composable
 fun DownloadScreen(
     contentPadding: PaddingValues,
-    downloads: PersistentList<DownloadItem>,
+    downloads: List<DownloadItem>,
     downloaderStatus: DownloaderStatus,
     downloadScreenActions: DownloadScreenActions,
 ) {

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedPage.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.unit.Dp
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import eu.kanade.tachiyomi.source.online.utils.MdLang
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.domain.manga.Artwork
 import org.nekomanga.logging.TimberKt
 import org.nekomanga.presentation.components.MangaCover
@@ -41,7 +40,7 @@ import org.nekomanga.presentation.theme.Size
 @Composable
 fun FeedPage(
     modifier: Modifier,
-    feedMangaList: PersistentList<FeedManga>,
+    feedMangaList: List<FeedManga>,
     summaryScreenPagingState: SummaryScreenPagingState,
     outlineCovers: Boolean,
     dynamicCovers: Boolean,

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedRepository.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedRepository.kt
@@ -17,8 +17,6 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.delay
 import org.nekomanga.constants.Constants
 import org.nekomanga.data.database.repository.ChapterRepository
@@ -72,7 +70,7 @@ class FeedRepository(
 
                     chapter.toSimpleChapter(chpHistory.history.last_read)?.toChapterItem()
                 }
-                .toPersistentList()
+                .toList()
 
         return feedManga.copy(chapters = simpleChapters)
     }
@@ -128,7 +126,7 @@ class FeedRepository(
                             mangaTitle = manga.displayTitle(),
                             date = recentUploadDate ?: 0L,
                             artwork = manga.toDisplayManga().currentArtwork,
-                            chapters = persistentListOf(getChapterItem(manga, chapter)),
+                            chapters = listOf(getChapterItem(manga, chapter)),
                         )
                     }
                 }
@@ -185,7 +183,7 @@ class FeedRepository(
                                     mangaTitle = history.manga.displayTitle(),
                                     date = history.history.last_read,
                                     artwork = history.manga.toDisplayManga().currentArtwork,
-                                    chapters = persistentListOf(chapter),
+                                    chapters = listOf(chapter),
                                 )
                             }
                             .groupBy { it.mangaId }
@@ -255,7 +253,7 @@ class FeedRepository(
                                 date = 0L,
                                 artwork = manga.toDisplayManga().currentArtwork,
                                 lastReadChapter = lastReadChapter,
-                                chapters = persistentListOf(chapter.toChapterItem()),
+                                chapters = listOf(chapter.toChapterItem()),
                             )
                         }
                     }
@@ -316,7 +314,7 @@ class FeedRepository(
                             mangaTitle = displayManga.getTitle(),
                             date = manga.date_added,
                             artwork = displayManga.currentArtwork,
-                            chapters = persistentListOf(getChapterItem(manga, simpleChapter)),
+                            chapters = listOf(getChapterItem(manga, simpleChapter)),
                         )
                     }
                     .takeLast(6)
@@ -372,7 +370,7 @@ class FeedRepository(
                                                     )!!,
                                                 )
                                             }
-                                            .toPersistentList()
+                                            .toList()
 
                                     bySeriesSet.add(history.manga.id!!)
 
@@ -417,7 +415,7 @@ class FeedRepository(
                                                     )!!,
                                                 )
                                             }
-                                            .toPersistentList()
+                                            .toList()
                                     FeedManga(
                                         mangaId = manga.first.id!!,
                                         mangaTitle = manga.first.displayTitle(),
@@ -448,7 +446,7 @@ class FeedRepository(
                                         mangaTitle = it.manga.displayTitle(),
                                         date = it.history.last_read,
                                         artwork = it.manga.toDisplayManga().currentArtwork,
-                                        chapters = persistentListOf(chapterItem),
+                                        chapters = listOf(chapterItem),
                                     )
                                 }
                         }
@@ -512,7 +510,7 @@ class FeedRepository(
                                 mangaTitle = it.manga.displayTitle(),
                                 date = date,
                                 artwork = it.manga.toDisplayManga().currentArtwork,
-                                chapters = persistentListOf(chapterItem),
+                                chapters = listOf(chapterItem),
                             )
                         }
                 Pair(chapters.isNotEmpty(), chapters)

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedScreenState.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedScreenState.kt
@@ -2,8 +2,6 @@ package org.nekomanga.presentation.screens.feed
 
 import androidx.compose.runtime.Immutable
 import eu.kanade.tachiyomi.ui.manga.MangaConstants
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.domain.chapter.ChapterItem
 import org.nekomanga.domain.chapter.SimpleChapter
 import org.nekomanga.domain.download.DownloadItem
@@ -22,7 +20,7 @@ data class FeedScreenState(
     val incognitoMode: Boolean = false,
     val useVividColorHeaders: Boolean = true,
     val swipeRefreshEnabled: Boolean = true,
-    val downloads: PersistentList<DownloadItem> = persistentListOf(),
+    val downloads: List<DownloadItem> = listOf(),
     val downloaderStatus: DownloaderStatus = DownloaderStatus.Paused,
     val downloadOnlyOnUnmetered: Boolean,
 )
@@ -33,8 +31,8 @@ data class HistoryScreenPagingState(
     val hasMoreResults: Boolean = true,
     val pageLoading: Boolean = false,
     val historyGrouping: FeedHistoryGroup,
-    val historyFeedMangaList: PersistentList<FeedManga> = persistentListOf(),
-    val searchHistoryFeedMangaList: PersistentList<FeedManga> = persistentListOf(),
+    val historyFeedMangaList: List<FeedManga> = listOf(),
+    val searchHistoryFeedMangaList: List<FeedManga> = listOf(),
     val searchQuery: String = "",
 )
 
@@ -44,19 +42,19 @@ data class UpdatesScreenPagingState(
     val hasMoreResults: Boolean = true,
     val pageLoading: Boolean = false,
     val updatesSortedByFetch: Boolean = true,
-    val updatesFeedMangaList: PersistentList<FeedManga> = persistentListOf(),
-    val searchUpdatesFeedMangaList: PersistentList<FeedManga> = persistentListOf(),
+    val updatesFeedMangaList: List<FeedManga> = listOf(),
+    val searchUpdatesFeedMangaList: List<FeedManga> = listOf(),
     val searchQuery: String = "",
 )
 
 @Immutable
 data class SummaryScreenPagingState(
     val updatingUpdates: Boolean = true,
-    val updatesFeedMangaList: PersistentList<FeedManga> = persistentListOf(),
+    val updatesFeedMangaList: List<FeedManga> = listOf(),
     val updatingContinueReading: Boolean = true,
-    val continueReadingList: PersistentList<FeedManga> = persistentListOf(),
+    val continueReadingList: List<FeedManga> = listOf(),
     val updatingNewlyAdded: Boolean = true,
-    val newlyAddedFeedMangaList: PersistentList<FeedManga> = persistentListOf(),
+    val newlyAddedFeedMangaList: List<FeedManga> = listOf(),
 )
 
 enum class FeedScreenType {
@@ -123,6 +121,6 @@ data class FeedManga(
     val date: Long,
     val mangaId: Long,
     val artwork: Artwork,
-    val chapters: PersistentList<ChapterItem>,
+    val chapters: List<ChapterItem>,
     val lastReadChapter: String = "",
 )

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedViewModel.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/FeedViewModel.kt
@@ -9,9 +9,6 @@ import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.ui.manga.MangaConstants
 import eu.kanade.tachiyomi.util.system.launchIO
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -109,9 +106,9 @@ class FeedViewModel() : ViewModel() {
                         // cache
                         updatesFeedMangaList =
                             if (state.offset == 0) {
-                                items.toPersistentList()
+                                items.toList()
                             } else {
-                                (state.updatesFeedMangaList + items).toPersistentList()
+                                (state.updatesFeedMangaList + items).toList()
                             },
                     )
                 }
@@ -144,9 +141,9 @@ class FeedViewModel() : ViewModel() {
                         // cache
                         historyFeedMangaList =
                             if (state.offset == 0) {
-                                items.toPersistentList()
+                                items.toList()
                             } else {
-                                (state.historyFeedMangaList + items).toPersistentList()
+                                (state.historyFeedMangaList + items).toList()
                             },
                     )
                 }
@@ -184,7 +181,7 @@ class FeedViewModel() : ViewModel() {
                                 ),
                         )
                     }
-                    .toPersistentList()
+                    .toList()
 
             _feedScreenState.update { it.copy(downloads = downloads) }
         }
@@ -224,7 +221,7 @@ class FeedViewModel() : ViewModel() {
                 state.copy(
                     historyGrouping = it,
                     offset = 0,
-                    historyFeedMangaList = persistentListOf(),
+                    historyFeedMangaList = listOf(),
                 )
             }
             historyPaginator.reset()
@@ -238,7 +235,7 @@ class FeedViewModel() : ViewModel() {
                     _historyScreenPagingState.update { state ->
                         state.copy(
                             offset = 0,
-                            searchHistoryFeedMangaList = persistentListOf(),
+                            searchHistoryFeedMangaList = listOf(),
                             searchQuery = "",
                         )
                     }
@@ -248,7 +245,7 @@ class FeedViewModel() : ViewModel() {
                     _updatesScreenPagingState.update { state ->
                         state.copy(
                             offset = 0,
-                            searchUpdatesFeedMangaList = persistentListOf(),
+                            searchUpdatesFeedMangaList = listOf(),
                             searchQuery = "",
                         )
                     }
@@ -270,9 +267,9 @@ class FeedViewModel() : ViewModel() {
                 state.copy(
                     updatesSortedByFetch = it,
                     offset = 0,
-                    updatesFeedMangaList = persistentListOf(),
+                    updatesFeedMangaList = listOf(),
                     searchQuery = "",
-                    searchUpdatesFeedMangaList = persistentListOf(),
+                    searchUpdatesFeedMangaList = listOf(),
                 )
             }
             updatesPaginator.reset()
@@ -357,8 +354,8 @@ class FeedViewModel() : ViewModel() {
             _historyScreenPagingState.update {
                 it.copy(
                     offset = 0,
-                    historyFeedMangaList = persistentListOf(),
-                    searchHistoryFeedMangaList = persistentListOf(),
+                    historyFeedMangaList = listOf(),
+                    searchHistoryFeedMangaList = listOf(),
                     searchQuery = "",
                 )
             }
@@ -377,7 +374,7 @@ class FeedViewModel() : ViewModel() {
                     historyFeedMangaList =
                         it.historyFeedMangaList
                             .filter { fm -> fm.mangaId != feedManga.mangaId }
-                            .toPersistentList()
+                            .toList()
                 )
             }
             loadSummaryPage()
@@ -401,7 +398,7 @@ class FeedViewModel() : ViewModel() {
                     continueReadingList =
                         state.continueReadingList
                             .filter { fm -> fm.mangaId != feedManga.mangaId }
-                            .toPersistentList()
+                            .toList()
                 )
             }
 
@@ -421,11 +418,11 @@ class FeedViewModel() : ViewModel() {
                             chapters =
                                 newFeedManga.chapters
                                     .filter { it.chapter.url != simpleChapter.url }
-                                    .toPersistentList()
+                                    .toList()
                         )
                 }
                 _historyScreenPagingState.update {
-                    it.copy(historyFeedMangaList = mutableFeedManga.toPersistentList())
+                    it.copy(historyFeedMangaList = mutableFeedManga.toList())
                 }
             }
 
@@ -438,7 +435,7 @@ class FeedViewModel() : ViewModel() {
             feedRepository.getSummaryUpdatesList().onOk { list ->
                 _summaryScreenPagingState.update { state ->
                     state.copy(
-                        updatesFeedMangaList = list.toPersistentList(),
+                        updatesFeedMangaList = list.toList(),
                         updatingUpdates = false,
                     )
                 }
@@ -449,7 +446,7 @@ class FeedViewModel() : ViewModel() {
             feedRepository.getSummaryContinueReadingList().onOk { list ->
                 _summaryScreenPagingState.update { state ->
                     state.copy(
-                        continueReadingList = list.toPersistentList(),
+                        continueReadingList = list.toList(),
                         updatingContinueReading = false,
                     )
                 }
@@ -460,7 +457,7 @@ class FeedViewModel() : ViewModel() {
             feedRepository.getSummaryNewlyAddedList().onOk { list ->
                 _summaryScreenPagingState.update { state ->
                     state.copy(
-                        newlyAddedFeedMangaList = list.toPersistentList(),
+                        newlyAddedFeedMangaList = list.toList(),
                         updatingNewlyAdded = false,
                     )
                 }
@@ -477,14 +474,14 @@ class FeedViewModel() : ViewModel() {
                     FeedScreenType.History ->
                         _historyScreenPagingState.update {
                             it.copy(
-                                searchHistoryFeedMangaList = persistentListOf(),
+                                searchHistoryFeedMangaList = listOf(),
                                 searchQuery = "",
                             )
                         }
                     FeedScreenType.Updates ->
                         _updatesScreenPagingState.update {
                             it.copy(
-                                searchUpdatesFeedMangaList = persistentListOf(),
+                                searchUpdatesFeedMangaList = listOf(),
                                 searchQuery = "",
                             )
                         }
@@ -505,7 +502,7 @@ class FeedViewModel() : ViewModel() {
                                     it.copy(
                                         searchQuery = searchQuery,
                                         searchHistoryFeedMangaList =
-                                            (results.second).toPersistentList(),
+                                            (results.second).toList(),
                                     )
                                 }
                             }
@@ -523,7 +520,7 @@ class FeedViewModel() : ViewModel() {
                                     it.copy(
                                         searchQuery = searchQuery,
                                         searchUpdatesFeedMangaList =
-                                            (results.second).toPersistentList(),
+                                            (results.second).toList(),
                                     )
                                 }
                             }
@@ -653,7 +650,7 @@ class FeedViewModel() : ViewModel() {
 
         val updatedFeedManga =
             feedManga.toMutableList().apply {
-                this[mangaIndex] = mangaToUpdate.copy(chapters = updatedChapters.toPersistentList())
+                this[mangaIndex] = mangaToUpdate.copy(chapters = updatedChapters.toList())
             }
 
         return true to updatedFeedManga
@@ -670,7 +667,7 @@ class FeedViewModel() : ViewModel() {
                     manga.chapters.firstOrNull()?.chapter?.id == updatedChapterItem.chapter.id
             ) {
                 wasUpdated = true
-                manga.copy(chapters = persistentListOf(updatedChapterItem))
+                manga.copy(chapters = listOf(updatedChapterItem))
             } else {
                 manga
             }
@@ -718,7 +715,7 @@ class FeedViewModel() : ViewModel() {
                     }
             }
             _updatesScreenPagingState.update { state ->
-                state.copy(updatesFeedMangaList = mutableFeedManga.toPersistentList())
+                state.copy(updatesFeedMangaList = mutableFeedManga.toList())
             }
         }
     }
@@ -745,7 +742,7 @@ class FeedViewModel() : ViewModel() {
                     }
             }
             _historyScreenPagingState.update { state ->
-                state.copy(historyFeedMangaList = mutableFeedManga.toPersistentList())
+                state.copy(historyFeedMangaList = mutableFeedManga.toList())
             }
         }
     }
@@ -782,7 +779,7 @@ class FeedViewModel() : ViewModel() {
 
     private suspend fun getUpdatedSearchFeedMangaList(
         feedScreenType: FeedScreenType,
-        update: (PersistentList<FeedManga>) -> Unit,
+        update: (List<FeedManga>) -> Unit,
     ) {
         if (feedScreenType == FeedScreenType.Updates) {
                 feedRepository.getUpdatesPage(
@@ -798,7 +795,7 @@ class FeedViewModel() : ViewModel() {
                     group = _historyScreenPagingState.value.historyGrouping,
                 )
             }
-            .onOk { results -> update(results.second.toPersistentList()) }
+            .onOk { results -> update(results.second.toList()) }
     }
 
     private fun updateReadOnFeed(chapterItem: ChapterItem) {
@@ -812,7 +809,7 @@ class FeedViewModel() : ViewModel() {
             if (searchHistoryUpdated) {
                 _historyScreenPagingState.update {
                     it.copy(
-                        searchHistoryFeedMangaList = searchHistoryFeedMangaList.toPersistentList()
+                        searchHistoryFeedMangaList = searchHistoryFeedMangaList.toList()
                     )
                 }
             }
@@ -826,7 +823,7 @@ class FeedViewModel() : ViewModel() {
             if (searchUpdatesUpdated) {
                 _updatesScreenPagingState.update {
                     it.copy(
-                        searchUpdatesFeedMangaList = searchUpdatesFeedMangaList.toPersistentList()
+                        searchUpdatesFeedMangaList = searchUpdatesFeedMangaList.toList()
                     )
                 }
             }
@@ -840,7 +837,7 @@ class FeedViewModel() : ViewModel() {
                 )
             if (historyFeedUpdated) {
                 _historyScreenPagingState.update {
-                    it.copy(historyFeedMangaList = historyFeedMangaList.toPersistentList())
+                    it.copy(historyFeedMangaList = historyFeedMangaList.toList())
                 }
             }
         }
@@ -853,7 +850,7 @@ class FeedViewModel() : ViewModel() {
                 )
             if (updatesFeedUpdated) {
                 _updatesScreenPagingState.update {
-                    it.copy(updatesFeedMangaList = updatesFeedMangaList.toPersistentList())
+                    it.copy(updatesFeedMangaList = updatesFeedMangaList.toList())
                 }
             }
         }
@@ -865,7 +862,7 @@ class FeedViewModel() : ViewModel() {
                 )
             if (updatesFeedUpdated) {
                 _summaryScreenPagingState.update {
-                    it.copy(updatesFeedMangaList = updatesFeedMangaList.toPersistentList())
+                    it.copy(updatesFeedMangaList = updatesFeedMangaList.toList())
                 }
             }
             val (newlyAddedFeedUpdated, newlyAddedFeedMangaList) =
@@ -875,7 +872,7 @@ class FeedViewModel() : ViewModel() {
                 )
             if (newlyAddedFeedUpdated) {
                 _summaryScreenPagingState.update {
-                    it.copy(newlyAddedFeedMangaList = newlyAddedFeedMangaList.toPersistentList())
+                    it.copy(newlyAddedFeedMangaList = newlyAddedFeedMangaList.toList())
                 }
             }
 
@@ -886,7 +883,7 @@ class FeedViewModel() : ViewModel() {
                 )
             if (continueReadingFeedUpdated) {
                 _summaryScreenPagingState.update {
-                    it.copy(continueReadingList = continueReadingList.toPersistentList())
+                    it.copy(continueReadingList = continueReadingList.toList())
                 }
             }
 
@@ -909,7 +906,7 @@ class FeedViewModel() : ViewModel() {
             if (searchHistoryFeedUpdated) {
                 _historyScreenPagingState.update {
                     it.copy(
-                        searchHistoryFeedMangaList = searchHistoryFeedMangaList.toPersistentList()
+                        searchHistoryFeedMangaList = searchHistoryFeedMangaList.toList()
                     )
                 }
             }
@@ -925,7 +922,7 @@ class FeedViewModel() : ViewModel() {
             if (searchUpdatesFeedUpdated) {
                 _updatesScreenPagingState.update {
                     it.copy(
-                        searchUpdatesFeedMangaList = searchUpdatesFeedMangaList.toPersistentList()
+                        searchUpdatesFeedMangaList = searchUpdatesFeedMangaList.toList()
                     )
                 }
             }
@@ -941,7 +938,7 @@ class FeedViewModel() : ViewModel() {
                 )
             if (historyFeedUpdated) {
                 _historyScreenPagingState.update {
-                    it.copy(historyFeedMangaList = historyFeedMangaList.toPersistentList())
+                    it.copy(historyFeedMangaList = historyFeedMangaList.toList())
                 }
             }
         }
@@ -956,7 +953,7 @@ class FeedViewModel() : ViewModel() {
                 )
             if (updatesFeedUpdated) {
                 _updatesScreenPagingState.update {
-                    it.copy(updatesFeedMangaList = updatesFeedMangaList.toPersistentList())
+                    it.copy(updatesFeedMangaList = updatesFeedMangaList.toList())
                 }
             }
         }
@@ -971,7 +968,7 @@ class FeedViewModel() : ViewModel() {
                 )
             if (summaryUpdatesFeedUpdated) {
                 _summaryScreenPagingState.update {
-                    it.copy(updatesFeedMangaList = summaryUpdatesFeedMangaList.toPersistentList())
+                    it.copy(updatesFeedMangaList = summaryUpdatesFeedMangaList.toList())
                 }
             }
         }
@@ -986,7 +983,7 @@ class FeedViewModel() : ViewModel() {
                 )
             if (newlyAddedFeedUpdated) {
                 _summaryScreenPagingState.update {
-                    it.copy(newlyAddedFeedMangaList = newlyAddedFeedMangaList.toPersistentList())
+                    it.copy(newlyAddedFeedMangaList = newlyAddedFeedMangaList.toList())
                 }
             }
         }
@@ -1008,7 +1005,7 @@ class FeedViewModel() : ViewModel() {
                     )
             }
 
-            _feedScreenState.update { it.copy(downloads = mutableList.toPersistentList()) }
+            _feedScreenState.update { it.copy(downloads = mutableList.toList()) }
         }
     }
 
@@ -1028,7 +1025,7 @@ class FeedViewModel() : ViewModel() {
                                     ),
                             )
                         }
-                        .toPersistentList()
+                        .toList()
 
                 _feedScreenState.update { it.copy(downloads = downloads) }
             }
@@ -1106,11 +1103,11 @@ class FeedViewModel() : ViewModel() {
 
     companion object {
 
-        private var lastUpdatesFeedMangaList: PersistentList<FeedManga>? = null
-        private var lastHistoryFeedMangaList: PersistentList<FeedManga>? = null
-        private var lastSummaryUpdatesFeedMangaList: PersistentList<FeedManga>? = null
-        private var lastContinueReadingList: PersistentList<FeedManga>? = null
-        private var lastSummaryNewlyAddedFeedMangaList: PersistentList<FeedManga>? = null
+        private var lastUpdatesFeedMangaList: List<FeedManga>? = null
+        private var lastHistoryFeedMangaList: List<FeedManga>? = null
+        private var lastSummaryUpdatesFeedMangaList: List<FeedManga>? = null
+        private var lastContinueReadingList: List<FeedManga>? = null
+        private var lastSummaryNewlyAddedFeedMangaList: List<FeedManga>? = null
 
         fun onLowMemory() {
             lastUpdatesFeedMangaList = null

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/history/FeedHistoryPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/history/FeedHistoryPage.kt
@@ -19,8 +19,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import java.util.Date
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.R
 import org.nekomanga.presentation.components.UiText
 import org.nekomanga.presentation.screens.EmptyScreen
@@ -33,7 +31,7 @@ import org.nekomanga.presentation.theme.Size
 fun FeedHistoryPage(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
-    feedHistoryMangaList: PersistentList<FeedManga> = persistentListOf(),
+    feedHistoryMangaList: List<FeedManga> = listOf(),
     outlineCovers: Boolean,
     dynamicCovers: Boolean,
     outlineCards: Boolean,

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/history/HistoryCard.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/history/HistoryCard.kt
@@ -37,8 +37,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.R
 import org.nekomanga.domain.chapter.ChapterItem
 import org.nekomanga.domain.chapter.SimpleChapter
@@ -334,7 +332,7 @@ private fun Buttons(
                             SimpleDropDownItem.Parent(
                                 UiText.StringResource(R.string.remove_history),
                                 children =
-                                    persistentListOf(
+                                    listOf(
                                         SimpleDropDownItem.Action(
                                             UiText.String(chapterName),
                                             onClick = deleteHistoryClick,
@@ -346,7 +344,7 @@ private fun Buttons(
                                     ),
                             )
                         )
-                        .toPersistentList(),
+                        .toList(),
             )
         }
     }

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/summary/ContinueReadingCard.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/summary/ContinueReadingCard.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.R
 import org.nekomanga.domain.chapter.SimpleChapter
 import org.nekomanga.presentation.components.NekoColors
@@ -153,7 +152,7 @@ fun ContinueReadingCard(
                                             ),
                                 )
                             )
-                            .toPersistentList(),
+                            .toList(),
                 )
             }
         }

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/summary/FeedSummaryPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/summary/FeedSummaryPage.kt
@@ -22,8 +22,6 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.R
 import org.nekomanga.presentation.components.UiText
 import org.nekomanga.presentation.components.listcard.ExpressiveListCard
@@ -41,9 +39,9 @@ fun FeedSummaryPage(
     updatingUpdates: Boolean = false,
     updatingContinueReading: Boolean = false,
     updatingNewlyAdded: Boolean = false,
-    updatesFeedMangaList: PersistentList<FeedManga> = persistentListOf(),
-    continueReadingFeedMangaList: PersistentList<FeedManga> = persistentListOf(),
-    newlyAddedFeedMangaList: PersistentList<FeedManga> = persistentListOf(),
+    updatesFeedMangaList: List<FeedManga> = listOf(),
+    continueReadingFeedMangaList: List<FeedManga> = listOf(),
+    newlyAddedFeedMangaList: List<FeedManga> = listOf(),
     outlineCovers: Boolean,
     dynamicCovers: Boolean,
     useVividColorHeaders: Boolean,

--- a/app/src/main/java/org/nekomanga/presentation/screens/feed/updates/FeedUpdatesPage.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/feed/updates/FeedUpdatesPage.kt
@@ -19,9 +19,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import java.util.Date
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.R
 import org.nekomanga.presentation.components.UiText
 import org.nekomanga.presentation.components.listcard.ExpressiveListCard
@@ -35,7 +32,7 @@ import org.nekomanga.presentation.theme.Size
 fun FeedUpdatesPage(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
-    feedUpdatesMangaList: PersistentList<FeedManga> = persistentListOf(),
+    feedUpdatesMangaList: List<FeedManga> = listOf(),
     outlineCovers: Boolean,
     dynamicCovers: Boolean,
     useVividColorHeaders: Boolean,
@@ -96,7 +93,7 @@ fun FeedUpdatesPage(
 private fun Grouped(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
-    feedUpdatesMangaList: PersistentList<FeedManga> = persistentListOf(),
+    feedUpdatesMangaList: List<FeedManga> = listOf(),
     headerColor: Color,
     outlineCovers: Boolean = false,
     dynamicCovers: Boolean = false,
@@ -139,7 +136,7 @@ private fun Grouped(
                         .map {
                             val (read, unread) =
                                 it.value.flatMap { it.chapters }.partition { it.chapter.read }
-                            val chapters = (unread.reversed() + read).toPersistentList()
+                            val chapters = (unread.reversed() + read).toList()
                             it.value.first().copy(chapters = chapters)
                         }
                 }
@@ -245,7 +242,7 @@ private fun Grouped(
 private fun Ungrouped(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
-    feedUpdatesMangaList: PersistentList<FeedManga> = persistentListOf(),
+    feedUpdatesMangaList: List<FeedManga> = listOf(),
     headerColor: Color,
     outlineCovers: Boolean = false,
     dynamicCovers: Boolean,

--- a/app/src/main/java/org/nekomanga/presentation/screens/library/LibraryBottomSheet.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/library/LibraryBottomSheet.kt
@@ -3,7 +3,6 @@ package org.nekomanga.presentation.screens.library
 import androidx.compose.runtime.Composable
 import eu.kanade.tachiyomi.ui.library.LibraryScreenState
 import eu.kanade.tachiyomi.ui.library.LibrarySheetActions
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.domain.category.CategoryItem
 import org.nekomanga.presentation.components.sheets.DisplayOptionsSheet
 import org.nekomanga.presentation.components.sheets.EditCategorySheet
@@ -77,7 +76,7 @@ fun LibraryBottomSheet(
                     .map { it.allCategories }
                     .flatten()
                     .distinct()
-                    .toPersistentList()
+                    .toList()
 
             EditCategorySheet(
                 addingToLibrary = false,

--- a/app/src/main/java/org/nekomanga/presentation/screens/manga/ButtonBlock.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/manga/ButtonBlock.kt
@@ -37,9 +37,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.R
 import org.nekomanga.presentation.components.NekoColors
 import org.nekomanga.presentation.components.UiText
@@ -105,123 +102,120 @@ fun ButtonBlock(
 
     val actionButtons =
         remember(inLibrary, mergedCount, trackServiceCount, loggedIntoTrackers) {
-            persistentListOf<ActionButtonData>()
-                .builder()
-                .apply {
-                    // Favorite Button
-                    add(
-                        ActionButtonData(
-                            icon =
-                                if (inLibrary) Icons.Filled.Favorite
-                                else Icons.Filled.FavoriteBorder,
-                            text = UiText.String(""),
-                            contentDescription =
-                                if (inLibrary) UiText.StringResource(R.string.remove_from_library)
-                                else UiText.StringResource(R.string.add_to_library),
-                            isChecked = inLibrary,
-                            onClick = toggleFavorite,
-                            dropdownItems =
-                                if (inLibrary) {
-                                    persistentListOf(
-                                        SimpleDropDownItem.Action(
-                                            text =
-                                                UiText.StringResource(R.string.remove_from_library),
-                                            onClick = toggleFavorite,
-                                        ),
-                                        SimpleDropDownItem.Action(
-                                            text = UiText.StringResource(R.string.edit_categories),
-                                            onClick = moveCategories,
-                                        ),
-                                    )
-                                } else {
-                                    null
-                                },
-                        )
+            buildList<ActionButtonData> {
+                // Favorite Button
+                add(
+                    ActionButtonData(
+                        icon =
+                            if (inLibrary) Icons.Filled.Favorite
+                            else Icons.Filled.FavoriteBorder,
+                        text = UiText.String(""),
+                        contentDescription =
+                            if (inLibrary) UiText.StringResource(R.string.remove_from_library)
+                            else UiText.StringResource(R.string.add_to_library),
+                        isChecked = inLibrary,
+                        onClick = toggleFavorite,
+                        dropdownItems =
+                            if (inLibrary) {
+                                listOf(
+                                    SimpleDropDownItem.Action(
+                                        text =
+                                            UiText.StringResource(R.string.remove_from_library),
+                                        onClick = toggleFavorite,
+                                    ),
+                                    SimpleDropDownItem.Action(
+                                        text = UiText.StringResource(R.string.edit_categories),
+                                        onClick = moveCategories,
+                                    ),
+                                )
+                            } else {
+                                null
+                            },
                     )
+                )
 
-                    // Tracking Button (conditionally added)
-                    if (loggedIntoTrackers) {
-                        val isTracked = trackServiceCount > 0
-                        val trackerIcon =
-                            when {
-                                isTracked ->
-                                    when (trackServiceCount) {
-                                        1 -> Numeric1BoxOutlineIcon
-                                        2 -> Numeric2BoxOutlineIcon
-                                        3 -> Numeric3BoxOutlineIcon
-                                        4 -> Numeric4BoxOutlineIcon
-                                        5 -> Numeric5BoxOutlineIcon
-                                        6 -> Numeric6BoxOutlineIcon
-                                        else -> Numeric0BoxOutlineIcon
-                                    }
-
-                                else -> Icons.Filled.Sync
-                            }
-                        add(
-                            ActionButtonData(
-                                icon = trackerIcon,
-                                text =
-                                    if (isTracked) UiText.StringResource(R.string.tracked)
-                                    else UiText.StringResource(R.string.tracking),
-                                isChecked = isTracked,
-                                onClick = trackingClick,
-                            )
-                        )
-                    }
-
-                    // Other buttons
-                    add(
-                        ActionButtonData(
-                            icon = ArtTrackIcon,
-                            text = UiText.StringResource(R.string.artwork),
-                            onClick = artworkClick,
-                        )
-                    )
-                    add(
-                        ActionButtonData(
-                            icon = AccountTreeIcon,
-                            text = UiText.StringResource(R.string.similar_work),
-                            onClick = similarClick,
-                        )
-                    )
-                    add(
-                        ActionButtonData(
-                            icon =
-                                when (mergedCount) {
-                                    0 -> Numeric0BoxOutlineIcon
+                // Tracking Button (conditionally added)
+                if (loggedIntoTrackers) {
+                    val isTracked = trackServiceCount > 0
+                    val trackerIcon =
+                        when {
+                            isTracked ->
+                                when (trackServiceCount) {
                                     1 -> Numeric1BoxOutlineIcon
                                     2 -> Numeric2BoxOutlineIcon
                                     3 -> Numeric3BoxOutlineIcon
                                     4 -> Numeric4BoxOutlineIcon
                                     5 -> Numeric5BoxOutlineIcon
                                     6 -> Numeric6BoxOutlineIcon
-                                    else -> MergeCheckIcon
-                                },
+                                    else -> Numeric0BoxOutlineIcon
+                                }
+
+                            else -> Icons.Filled.Sync
+                        }
+                    add(
+                        ActionButtonData(
+                            icon = trackerIcon,
                             text =
-                                UiText.StringResource(
-                                    if (mergedCount != 0) R.string.is_merged
-                                    else R.string.is_not_merged
-                                ),
-                            isChecked = mergedCount != 0,
-                            onClick = mergeClick,
-                        )
-                    )
-                    add(
-                        ActionButtonData(
-                            icon = Icons.Filled.OpenInBrowser,
-                            text = UiText.StringResource(R.string.links),
-                            onClick = linksClick,
-                        )
-                    )
-                    add(
-                        ActionButtonData(
-                            icon = Icons.Filled.Share,
-                            text = UiText.StringResource(R.string.share),
-                            onClick = shareClick,
+                                if (isTracked) UiText.StringResource(R.string.tracked)
+                                else UiText.StringResource(R.string.tracking),
+                            isChecked = isTracked,
+                            onClick = trackingClick,
                         )
                     )
                 }
-                .build()
+
+                // Other buttons
+                add(
+                    ActionButtonData(
+                        icon = ArtTrackIcon,
+                        text = UiText.StringResource(R.string.artwork),
+                        onClick = artworkClick,
+                    )
+                )
+                add(
+                    ActionButtonData(
+                        icon = AccountTreeIcon,
+                        text = UiText.StringResource(R.string.similar_work),
+                        onClick = similarClick,
+                    )
+                )
+                add(
+                    ActionButtonData(
+                        icon =
+                            when (mergedCount) {
+                                0 -> Numeric0BoxOutlineIcon
+                                1 -> Numeric1BoxOutlineIcon
+                                2 -> Numeric2BoxOutlineIcon
+                                3 -> Numeric3BoxOutlineIcon
+                                4 -> Numeric4BoxOutlineIcon
+                                5 -> Numeric5BoxOutlineIcon
+                                6 -> Numeric6BoxOutlineIcon
+                                else -> MergeCheckIcon
+                            },
+                        text =
+                            UiText.StringResource(
+                                if (mergedCount != 0) R.string.is_merged
+                                else R.string.is_not_merged
+                            ),
+                        isChecked = mergedCount != 0,
+                        onClick = mergeClick,
+                    )
+                )
+                add(
+                    ActionButtonData(
+                        icon = Icons.Filled.OpenInBrowser,
+                        text = UiText.StringResource(R.string.links),
+                        onClick = linksClick,
+                    )
+                )
+                add(
+                    ActionButtonData(
+                        icon = Icons.Filled.Share,
+                        text = UiText.StringResource(R.string.share),
+                        onClick = shareClick,
+                    )
+                )
+            }
         }
 
     // The UI is rendered by iterating over the data list.
@@ -330,7 +324,7 @@ private fun ActionButton(
                                 it
                             }
                         }
-                        .toPersistentList(),
+                        .toList(),
             )
         }
     }
@@ -341,6 +335,6 @@ private data class ActionButtonData(
     val text: UiText,
     val onClick: () -> Unit,
     val isChecked: Boolean = false,
-    val dropdownItems: ImmutableList<SimpleDropDownItem>? = null,
+    val dropdownItems: List<SimpleDropDownItem>? = null,
     val contentDescription: UiText? = null,
 )

--- a/app/src/main/java/org/nekomanga/presentation/screens/manga/DescriptionBlock.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/manga/DescriptionBlock.kt
@@ -58,8 +58,6 @@ import com.mikepenz.markdown.model.MarkdownState
 import com.mikepenz.markdown.model.rememberMarkdownState
 import eu.kanade.tachiyomi.ui.manga.MangaConstants
 import jp.wasabeef.gap.Gap
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
 import org.nekomanga.R
 import org.nekomanga.presentation.Chip
@@ -77,8 +75,8 @@ fun DescriptionBlock(
     title: String,
     description: String,
     isInitialized: Boolean,
-    altTitles: PersistentList<String>,
-    genres: PersistentList<String>,
+    altTitles: List<String>,
+    genres: List<String>,
     themeColorState: ThemeColorState,
     wrapAltTitles: Boolean,
     isExpanded: Boolean,
@@ -239,8 +237,8 @@ private fun CollapsedDescription(
 /** A combined, reusable composable for displaying both Alt Titles and Genres. */
 @Composable
 private fun AltTitlesAndGenres(
-    altTitles: PersistentList<String>,
-    genres: PersistentList<String>,
+    altTitles: List<String>,
+    genres: List<String>,
     currentTitle: String,
     shouldWrap: Boolean,
     themeColorState: ThemeColorState,
@@ -281,7 +279,7 @@ private fun AltTitlesAndGenres(
  */
 @Composable
 private fun AltTitles(
-    altTitles: PersistentList<String>,
+    altTitles: List<String>,
     currentTitle: String,
     shouldWrap: Boolean,
     tagColor: Color,
@@ -383,7 +381,7 @@ private fun AltTitleChip(title: String, isSelected: Boolean, tagColor: Color, on
  */
 @Composable
 private fun Genres(
-    genres: PersistentList<String>,
+    genres: List<String>,
     tagColor: Color,
     themeColorState: ThemeColorState,
     genreSearch: (String) -> Unit,
@@ -421,7 +419,7 @@ private fun Genres(
                 onDismiss = { selectedGenre = null },
                 themeColorState = themeColorState,
                 dropDownItems =
-                    persistentListOf(
+                    listOf(
                         SimpleDropDownItem.Action(text = UiText.StringResource(R.string.search)) {
                             genreSearch(genre)
                             selectedGenre = null

--- a/app/src/main/java/org/nekomanga/presentation/screens/manga/InformationBlock.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/manga/InformationBlock.kt
@@ -39,7 +39,6 @@ import java.text.NumberFormat
 import java.util.Locale
 import jp.wasabeef.gap.Gap
 import kotlin.math.roundToInt
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.R
 import org.nekomanga.constants.Constants
 import org.nekomanga.domain.manga.Stats
@@ -322,6 +321,6 @@ private fun CreatorDropdown(
                             ),
                     )
                 }
-                .toPersistentList(),
+                .toList(),
     )
 }

--- a/app/src/main/java/org/nekomanga/presentation/screens/manga/MangaDetailsAppBarActions.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/manga/MangaDetailsAppBarActions.kt
@@ -2,7 +2,6 @@ package org.nekomanga.presentation.screens.manga
 
 import androidx.compose.runtime.Composable
 import eu.kanade.tachiyomi.ui.manga.MangaConstants
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.R
 import org.nekomanga.domain.chapter.ChapterItem
 import org.nekomanga.domain.chapter.ChapterMarkActions
@@ -15,7 +14,7 @@ import org.nekomanga.presentation.components.theme.ThemeColorState
 fun MangaDetailsAppBarActions(
     chapterActions: MangaConstants.ChapterActions,
     themeColorState: ThemeColorState,
-    chapters: PersistentList<ChapterItem>,
+    chapters: List<ChapterItem>,
 ) {
     AppBarActions(
         themeColorState = themeColorState,

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/Preference.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/Preference.kt
@@ -4,8 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import kotlinx.collections.immutable.ImmutableMap
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.R
 import org.nekomanga.domain.track.TrackServiceItem
 import tachiyomi.core.preference.Preference as PreferenceData
@@ -70,14 +68,14 @@ sealed class Preference {
             override val subtitle: String? = "%s",
             val subtitleProvider:
                 @Composable
-                (value: T, entries: ImmutableMap<T, String>) -> String? =
+                (value: T, entries: Map<T, String>) -> String? =
                 { v, e ->
                     subtitle?.format(e[v])
                 },
             override val icon: ImageVector? = null,
             override val enabled: Boolean = true,
             override val onValueChanged: suspend (newValue: T) -> Boolean = { true },
-            val entries: ImmutableMap<T, String>,
+            val entries: Map<T, String>,
         ) : PreferenceItem<T>() {
             internal fun internalSet(newValue: Any) = pref.set(newValue as T)
 
@@ -87,8 +85,8 @@ sealed class Preference {
             @Composable
             internal fun internalSubtitleProvider(
                 value: Any?,
-                entries: ImmutableMap<out Any?, String>,
-            ) = subtitleProvider(value as T, entries as ImmutableMap<T, String>)
+                entries: Map<out Any?, String>,
+            ) = subtitleProvider(value as T, entries as Map<T, String>)
         }
 
         /** [ListPreference] but with no connection to a [PreferenceData] */
@@ -98,14 +96,14 @@ sealed class Preference {
             override val subtitle: String? = "%s",
             val subtitleProvider:
                 @Composable
-                (value: String, entries: ImmutableMap<String, String>) -> String? =
+                (value: String, entries: Map<String, String>) -> String? =
                 { v, e ->
                     subtitle?.format(e[v])
                 },
             override val icon: ImageVector? = null,
             override val enabled: Boolean = true,
             override val onValueChanged: suspend (newValue: String) -> Boolean = { true },
-            val entries: ImmutableMap<String, String>,
+            val entries: Map<String, String>,
         ) : PreferenceItem<String>()
 
         /**
@@ -118,7 +116,7 @@ sealed class Preference {
             override val subtitle: String? = "%s",
             val subtitleProvider:
                 @Composable
-                (value: Set<String>, entries: ImmutableMap<String, String>) -> String? =
+                (value: Set<String>, entries: Map<String, String>) -> String? =
                 { v, e ->
                     val combined =
                         remember(v) { v.map { e[it] }.takeIf { it.isNotEmpty() }?.joinToString() }
@@ -129,7 +127,7 @@ sealed class Preference {
             override val icon: ImageVector? = null,
             override val enabled: Boolean = true,
             override val onValueChanged: suspend (newValue: Set<String>) -> Boolean = { true },
-            val entries: ImmutableMap<String, String>,
+            val entries: Map<String, String>,
         ) : PreferenceItem<Set<String>>()
 
         /** A [PreferenceItem] that shows a EditText in the dialog. */
@@ -191,6 +189,6 @@ sealed class Preference {
         override val title: String,
         override val enabled: Boolean = true,
         val subtitle: String? = null,
-        val preferenceItems: PersistentList<PreferenceItem<out Any>>,
+        val preferenceItems: List<PreferenceItem<out Any>>,
     ) : Preference()
 }

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/PreferenceScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/PreferenceScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEachIndexed
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.delay
 import org.nekomanga.presentation.screens.settings.Preference.PreferenceItem
 import org.nekomanga.presentation.screens.settings.screens.SearchableSettings
@@ -28,7 +27,7 @@ import org.nekomanga.presentation.screens.settings.widgets.PreferenceGroupHeader
  */
 @Composable
 fun PreferenceScreen(
-    items: PersistentList<Preference>,
+    items: List<Preference>,
     incomingHighlightKey: String? = null,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp),

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/SettingsMainScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/SettingsMainScreen.kt
@@ -33,8 +33,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.navigation3.runtime.NavKey
 import eu.kanade.tachiyomi.ui.setting.SettingsScreenType
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.BuildConfig
 import org.nekomanga.R
 import org.nekomanga.presentation.components.UiText
@@ -296,7 +294,7 @@ private fun SearchResult(
 @Composable
 @NonRestartableComposable
 private fun searchTerms() =
-    persistentListOf(
+    listOf(
         SettingsData(
             settingScreenType = SettingsScreenType.General,
             settingsStringTitle = stringResource(R.string.general),
@@ -357,7 +355,7 @@ private fun searchTerms() =
 private data class SettingsData(
     val settingScreenType: SettingsScreenType,
     val settingsStringTitle: String,
-    val contents: PersistentList<SearchTerm>,
+    val contents: List<SearchTerm>,
 )
 
 private data class SearchResultItem(

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/AddEditCategoriesScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/AddEditCategoriesScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.R
 import org.nekomanga.domain.category.CategoryItem
 import org.nekomanga.presentation.components.dialog.AddEditCategoryDialog
@@ -48,7 +47,7 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
 
 internal class AddEditCategoriesScreen(
     val onNavigationIconClick: (() -> Unit)?,
-    val categories: PersistentList<CategoryItem>,
+    val categories: List<CategoryItem>,
     val addUpdateCategory: (String, Int?) -> Unit,
     val onChangeOrder: (CategoryItem, Int) -> Unit,
     val deleteCategory: (Int) -> Unit,

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/AdvancedSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/AdvancedSettingsScreen.kt
@@ -27,9 +27,6 @@ import eu.kanade.tachiyomi.util.system.launchIO
 import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.toast
 import java.io.File
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.flow.SharedFlow
 import org.nekomanga.R
 import org.nekomanga.constants.Constants.DONT_KILL_MY_APP_URL
@@ -74,12 +71,12 @@ internal class AdvancedSettingsScreen(
 
     @SuppressLint("BatteryLife")
     @Composable
-    override fun getPreferences(): PersistentList<Preference> {
+    override fun getPreferences(): List<Preference> {
         val context = LocalContext.current
 
         LaunchedEffect(Unit) { toastEvent.collect { event -> context.toast(event) } }
 
-        return persistentListOf(
+        return listOf(
             Preference.PreferenceItem.SwitchPreference(
                 pref = preferences.sendCrashReports(),
                 title = stringResource(R.string.send_crash_report),
@@ -122,7 +119,7 @@ internal class AdvancedSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.background_activity),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.TextPreference(
                         title = stringResource(R.string.disable_battery_optimization),
                         subtitle = stringResource(R.string.disable_if_issues_with_updating),
@@ -155,7 +152,7 @@ internal class AdvancedSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.system),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.TextPreference(
                         title = stringResource(R.string.supported_links),
                         subtitle = stringResource(R.string.supported_links_summary),
@@ -185,7 +182,7 @@ internal class AdvancedSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.network),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.TextPreference(
                         title = stringResource(R.string.clear_cookies),
                         onClick = { clearNetworkCookies() },
@@ -230,7 +227,7 @@ internal class AdvancedSettingsScreen(
                                     PREF_DOH_NJALLA to stringResource(R.string.njalla),
                                     PREF_DOH_SHECAN to stringResource(R.string.shecan),
                                 )
-                                .toImmutableMap(),
+                                .toMap(),
                         onValueChanged = {
                             context.toast(R.string.requires_app_restart)
                             true
@@ -255,7 +252,7 @@ internal class AdvancedSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.reader),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.TextPreference(
                         title = stringResource(R.string.display_profile),
                         subtitle = readerPreferences.displayProfile().get(),
@@ -303,7 +300,7 @@ internal class AdvancedSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.data_management),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.TextPreference(
                         title = stringResource(R.string.reindex_downloads),
                         subtitle = stringResource(R.string.reindex_downloads_summary),
@@ -330,8 +327,8 @@ internal class AdvancedSettingsScreen(
 
     companion object : SearchTermProvider {
         @Composable
-        override fun getSearchTerms(): PersistentList<SearchTerm> {
-            return persistentListOf(
+        override fun getSearchTerms(): List<SearchTerm> {
+            return listOf(
                 SearchTerm(
                     title = stringResource(R.string.send_crash_report),
                     subtitle = stringResource(R.string.helps_fix_bugs),

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/AppearanceSettingsScreen.kt
@@ -16,9 +16,6 @@ import eu.kanade.tachiyomi.ui.main.states.SideNavAlignment
 import eu.kanade.tachiyomi.ui.main.states.SideNavMode
 import eu.kanade.tachiyomi.ui.manga.MangaConstants
 import eu.kanade.tachiyomi.util.system.getActivity
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
 import org.nekomanga.R
 import org.nekomanga.domain.details.MangaDetailsPreferences
 import org.nekomanga.domain.library.LibraryPreferences
@@ -39,13 +36,13 @@ internal class AppearanceSettingsScreen(
     override fun getTitleRes(): Int = R.string.appearance
 
     @Composable
-    override fun getPreferences(): PersistentList<Preference> {
+    override fun getPreferences(): List<Preference> {
 
         val context = LocalContext.current
 
         val nightMode by preferences.nightMode().collectAsState()
 
-        return persistentListOf(appearanceGroup(nightMode), detailGroup(), navigationGroup(context))
+        return listOf(appearanceGroup(nightMode), detailGroup(), navigationGroup(context))
     }
 
     @Composable
@@ -53,7 +50,7 @@ internal class AppearanceSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.app_theme),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.CustomPreference(
                         title = stringResource(R.string.light_theme),
                         content = {
@@ -106,7 +103,7 @@ internal class AppearanceSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.details_page),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.SwitchPreference(
                         pref = mangaDetailsPreferences.forcePortrait(),
                         title = stringResource(R.string.force_portrait_details),
@@ -129,7 +126,7 @@ internal class AppearanceSettingsScreen(
                         pref = mangaDetailsPreferences.backdropSize(),
                         title = stringResource(R.string.backdrop_size),
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 MangaConstants.BackdropSize.Small to stringResource(R.string.small),
                                 MangaConstants.BackdropSize.Default to
                                     stringResource(R.string.default_size),
@@ -149,12 +146,12 @@ internal class AppearanceSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.navigation),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.ListPreference(
                         pref = preferences.sideNavIconAlignment(),
                         title = stringResource(R.string.side_nav_icon_alignment),
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 SideNavAlignment.Top to stringResource(R.string.top),
                                 SideNavAlignment.Center to stringResource(R.string.center),
                                 SideNavAlignment.Bottom to stringResource(R.string.bottom),
@@ -164,7 +161,7 @@ internal class AppearanceSettingsScreen(
                         pref = preferences.sideNavMode(),
                         title = stringResource(R.string.use_side_navigation),
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 SideNavMode.Default to stringResource(R.string.default_behavior),
                                 SideNavMode.Never to stringResource(R.string.never),
                                 SideNavMode.Always to stringResource(R.string.always),
@@ -185,8 +182,8 @@ internal class AppearanceSettingsScreen(
 
     companion object : SearchTermProvider {
         @Composable
-        override fun getSearchTerms(): PersistentList<SearchTerm> {
-            return persistentListOf(
+        override fun getSearchTerms(): List<SearchTerm> {
+            return listOf(
                 SearchTerm(
                     title = stringResource(R.string.light_theme),
                     group = stringResource(R.string.app_theme),

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/Commons.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/Commons.kt
@@ -3,7 +3,6 @@ package org.nekomanga.presentation.screens.settings.screens
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.res.stringResource
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.R
 import org.nekomanga.domain.category.CategoryItem
 
@@ -11,7 +10,7 @@ import org.nekomanga.domain.category.CategoryItem
 @ReadOnlyComposable
 @Composable
 fun getCategoriesLabel(
-    allCategories: PersistentList<CategoryItem>,
+    allCategories: List<CategoryItem>,
     included: Set<String>,
     excluded: Set<String>,
 ): String {

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/DataStorageSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/DataStorageSettingsScreen.kt
@@ -44,9 +44,6 @@ import eu.kanade.tachiyomi.ui.setting.CacheType
 import eu.kanade.tachiyomi.util.system.MiuiUtil
 import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.system.toTimestampString
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -77,14 +74,14 @@ internal class DataStorageSettingsScreen(
     override fun getTitleRes(): Int = R.string.data_storage
 
     @Composable
-    override fun getPreferences(): PersistentList<Preference> {
+    override fun getPreferences(): List<Preference> {
         val context = LocalContext.current
 
         LaunchedEffect(Unit) { toastEvent.collect { event -> context.toast(event.resourceId) } }
 
         val pickStorageLocation = storageLocationPicker(storagePreferences.baseStorageDirectory())
 
-        return persistentListOf(
+        return listOf(
             Preference.PreferenceItem.TextPreference(
                 title = stringResource(R.string.storage_location),
                 subtitle = storageLocationText(storagePreferences.baseStorageDirectory()),
@@ -103,7 +100,7 @@ internal class DataStorageSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.storage_usage),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.InfoPreference(stringResource(R.string.storage_usage_info)),
                     Preference.PreferenceItem.CustomPreference(
                         title = "",
@@ -219,7 +216,7 @@ internal class DataStorageSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.backup_and_restore),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.CustomPreference(
                         title = stringResource(R.string.backup),
                         content = {
@@ -267,7 +264,7 @@ internal class DataStorageSettingsScreen(
                         pref = storagePreferences.backupInterval(),
                         title = stringResource(R.string.automatic_backups),
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 0 to stringResource(R.string.off),
                                 6 to stringResource(R.string.every_6_hours),
                                 12 to stringResource(R.string.every_12_hours),
@@ -290,7 +287,7 @@ internal class DataStorageSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.cache),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.TextPreference(
                         title = stringResource(R.string.parent_cache_folder),
                         subtitle = stringResource(R.string.used_, cacheData.parentCacheSize),
@@ -337,8 +334,8 @@ internal class DataStorageSettingsScreen(
 
     companion object : SearchTermProvider {
         @Composable
-        override fun getSearchTerms(): PersistentList<SearchTerm> {
-            return persistentListOf(
+        override fun getSearchTerms(): List<SearchTerm> {
+            return listOf(
                 SearchTerm(title = stringResource(R.string.storage_location)),
                 SearchTerm(
                     title = stringResource(R.string.storage_usage),

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/DebugSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/DebugSettingsScreen.kt
@@ -7,8 +7,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import com.google.firebase.analytics.FirebaseAnalytics
 import eu.kanade.tachiyomi.util.system.toast
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.SharedFlow
 import org.nekomanga.R
 import org.nekomanga.presentation.components.UiText
@@ -29,12 +27,12 @@ internal class DebugSettingsScreen(
 
     @SuppressLint("BatteryLife")
     @Composable
-    override fun getPreferences(): PersistentList<Preference> {
+    override fun getPreferences(): List<Preference> {
         val context = LocalContext.current
 
         LaunchedEffect(Unit) { toastEvent.collect { event -> context.toast(event) } }
 
-        return persistentListOf(
+        return listOf(
             Preference.PreferenceItem.TextPreference(
                 title = "Send a test firebase event",
                 onClick = {

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/DownloadSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/DownloadSettingsScreen.kt
@@ -8,9 +8,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentMap
 import org.nekomanga.R
 import org.nekomanga.domain.category.CategoryItem
 import org.nekomanga.domain.reader.ReaderPreferences
@@ -23,15 +20,15 @@ internal class DownloadSettingsScreen(
     incognitoMode: Boolean,
     val preferences: PreferencesHelper,
     val readerPreferences: ReaderPreferences,
-    val allCategories: PersistentList<CategoryItem>,
+    val allCategories: List<CategoryItem>,
     onNavigationIconClick: (() -> Unit)?,
 ) : SearchableSettings(onNavigationIconClick, incognitoMode) {
     override fun getTitleRes(): Int = R.string.downloads
 
     @Composable
-    override fun getPreferences(): PersistentList<Preference> {
+    override fun getPreferences(): List<Preference> {
 
-        return persistentListOf(
+        return listOf(
             Preference.PreferenceItem.SwitchPreference(
                 pref = preferences.downloadOnlyOverUnmetered(),
                 title = stringResource(R.string.only_download_over_unmetered),
@@ -57,7 +54,7 @@ internal class DownloadSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.remove_after_read),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.SwitchPreference(
                         pref = preferences.removeAfterMarkedAsRead(),
                         title = stringResource(R.string.remove_when_marked_as_read),
@@ -75,7 +72,7 @@ internal class DownloadSettingsScreen(
                                     4 to stringResource(R.string.fifth_to_last),
                                 )
                                 .toMap()
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                 ),
         )
@@ -118,7 +115,7 @@ internal class DownloadSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.download_new_chapters),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.SwitchPreference(
                         pref = preferences.downloadNewChapters(),
                         title = stringResource(R.string.download_new_chapters),
@@ -143,7 +140,7 @@ internal class DownloadSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.download_ahead),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.ListPreference(
                         pref = preferences.autoDownloadWhileReading(),
                         title = stringResource(R.string.auto_download_while_reading),
@@ -158,7 +155,7 @@ internal class DownloadSettingsScreen(
                                     20 to
                                         pluralStringResource(R.plurals.next_unread_chapters, 20, 20),
                                 )
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.InfoPreference(
                         title = stringResource(R.string.download_ahead_info)
@@ -172,7 +169,7 @@ internal class DownloadSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.automatic_removal),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.ListPreference(
                         pref = preferences.deleteRemovedChapters(),
                         title = stringResource(R.string.delete_removed_chapters),
@@ -183,7 +180,7 @@ internal class DownloadSettingsScreen(
                                     1 to stringResource(R.string.always_keep),
                                     2 to stringResource(R.string.always_delete),
                                 )
-                                .toPersistentMap(),
+                                .toMap(),
                     )
                 ),
         )
@@ -191,8 +188,8 @@ internal class DownloadSettingsScreen(
 
     companion object : SearchTermProvider {
         @Composable
-        override fun getSearchTerms(): PersistentList<SearchTerm> {
-            return persistentListOf(
+        override fun getSearchTerms(): List<SearchTerm> {
+            return listOf(
                 SearchTerm(title = stringResource(R.string.only_download_over_unmetered)),
                 SearchTerm(title = stringResource(R.string.save_chapters_as_cbz)),
                 SearchTerm(

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/GeneralSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/GeneralSettingsScreen.kt
@@ -3,9 +3,6 @@ package org.nekomanga.presentation.screens.settings.screens
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
 import org.nekomanga.R
 import org.nekomanga.presentation.screens.settings.Preference
 import org.nekomanga.presentation.screens.settings.widgets.SearchTerm
@@ -21,13 +18,13 @@ internal class GeneralSettingsScreen(
     override fun getTitleRes(): Int = R.string.general
 
     @Composable
-    override fun getPreferences(): PersistentList<Preference> {
-        return persistentListOf(
+    override fun getPreferences(): List<Preference> {
+        return listOf(
             Preference.PreferenceItem.ListPreference(
                 pref = preferencesHelper.startingTab(),
                 title = stringResource(R.string.starting_screen),
                 entries =
-                    persistentMapOf(
+                    mapOf(
                         1 to stringResource(R.string.last_used_library_recents),
                         -1 to stringResource(R.string.library),
                         -2 to stringResource(R.string.feed),
@@ -41,7 +38,7 @@ internal class GeneralSettingsScreen(
                 pref = preferencesHelper.dateFormatPreference(),
                 title = stringResource(R.string.date_format),
                 entries =
-                    persistentMapOf(
+                    mapOf(
                         "" to stringResource(R.string.system_default),
                         "MM/dd/yy" to "MM/dd/yy",
                         "dd/MM/yy" to "dd/MM/yy",
@@ -63,7 +60,7 @@ internal class GeneralSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.app_shortcuts),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.SwitchPreference(
                         pref = preferencesHelper.showSeriesInShortcuts(),
                         title = stringResource(R.string.show_recent_series),
@@ -83,12 +80,12 @@ internal class GeneralSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.auto_updates),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.ListPreference(
                         pref = preferencesHelper.appShouldAutoUpdate(),
                         title = stringResource(R.string.auto_update_app),
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 0 to stringResource(R.string.over_any_network),
                                 1 to stringResource(R.string.over_wifi_only),
                                 2 to stringResource(R.string.dont_auto_update),
@@ -100,8 +97,8 @@ internal class GeneralSettingsScreen(
 
     companion object : SearchTermProvider {
         @Composable
-        override fun getSearchTerms(): PersistentList<SearchTerm> {
-            return persistentListOf(
+        override fun getSearchTerms(): List<SearchTerm> {
+            return listOf(
                 SearchTerm(title = stringResource(R.string.starting_screen)),
                 SearchTerm(title = stringResource(R.string.date_format)),
                 SearchTerm(title = stringResource(R.string.manage_notifications)),

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/LibrarySettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/LibrarySettingsScreen.kt
@@ -15,10 +15,6 @@ import eu.kanade.tachiyomi.util.system.isBackgroundDataRestricted
 import eu.kanade.tachiyomi.util.system.launchNonCancellable
 import eu.kanade.tachiyomi.util.system.launchUI
 import eu.kanade.tachiyomi.util.system.openDataSaverSettings
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
-import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.CoroutineScope
 import org.nekomanga.R
 import org.nekomanga.domain.category.CategoryItem
@@ -42,7 +38,7 @@ internal class LibrarySettingsScreen(
     incognitoMode: Boolean,
     val libraryPreferences: LibraryPreferences,
     onNavigationIconClick: (() -> Unit)?,
-    val categories: PersistentList<CategoryItem>,
+    val categories: List<CategoryItem>,
     val viewModelScope: CoroutineScope,
     val onAddEditCategoryClick: () -> Unit,
 ) : SearchableSettings(onNavigationIconClick, incognitoMode) {
@@ -50,10 +46,10 @@ internal class LibrarySettingsScreen(
     override fun getTitleRes(): Int = R.string.library
 
     @Composable
-    override fun getPreferences(): PersistentList<Preference> {
+    override fun getPreferences(): List<Preference> {
         val context = LocalContext.current
 
-        return persistentListOf(
+        return listOf(
             generalGroup(context),
             categoriesGroup(categories),
             globalUpdateGroup(context, categories),
@@ -65,7 +61,7 @@ internal class LibrarySettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.general),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.SwitchPreference(
                         pref = libraryPreferences.enableLocalChapters(),
                         title = stringResource(R.string.enable_local_manga),
@@ -89,7 +85,7 @@ internal class LibrarySettingsScreen(
                             }
                         },
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 0 to stringResource(R.string.chapter_filter_all),
                                 1 to stringResource(R.string.chapter_filter_any),
                             ),
@@ -100,19 +96,19 @@ internal class LibrarySettingsScreen(
 
     @Composable
     private fun categoriesGroup(
-        categories: PersistentList<CategoryItem>
+        categories: List<CategoryItem>
     ): Preference.PreferenceGroup {
         val alwaysAsk = Pair(-1, stringResource(R.string.always_ask))
         val nonSystemCategories =
             remember(categories) { categories.filterNot { it.isSystemCategory } }
         val categoryMap =
             remember(categories) {
-                (listOf(alwaysAsk) + categories.map { it.id to it.name }).toMap().toImmutableMap()
+                (listOf(alwaysAsk) + categories.map { it.id to it.name }).toMap().toMap()
             }
         return Preference.PreferenceGroup(
             title = stringResource(R.string.categories),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.TextPreference(
                         title =
                             if (nonSystemCategories.isNotEmpty())
@@ -142,7 +138,7 @@ internal class LibrarySettingsScreen(
     @Composable
     private fun globalUpdateGroup(
         context: Context,
-        allCategoryList: PersistentList<CategoryItem>,
+        allCategoryList: List<CategoryItem>,
     ): Preference.PreferenceGroup {
 
         val libraryUpdateInterval by libraryPreferences.updateInterval().collectAsState()
@@ -194,12 +190,12 @@ internal class LibrarySettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.global_updates),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.ListPreference(
                         pref = libraryPreferences.updateInterval(),
                         title = stringResource(R.string.library_update_frequency),
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 0 to stringResource(R.string.manual),
                                 12 to stringResource(R.string.every_12_hours),
                                 24 to stringResource(R.string.daily),
@@ -221,7 +217,7 @@ internal class LibrarySettingsScreen(
                         title = stringResource(R.string.library_update_device_restriction),
                         subtitle = stringResource(R.string.restrictions_),
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 DEVICE_NETWORK_NOT_METERED to
                                     stringResource(R.string.network_not_metered),
                                 DEVICE_CHARGING to stringResource(R.string.charging),
@@ -246,7 +242,7 @@ internal class LibrarySettingsScreen(
                         pref = libraryPreferences.autoUpdateMangaRestrictions(),
                         title = stringResource(R.string.smart_library_update_restrictions),
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 MANGA_HAS_UNREAD to
                                     stringResource(R.string.smart_library_has_unread),
                                 MANGA_NOT_STARTED to
@@ -295,8 +291,8 @@ internal class LibrarySettingsScreen(
 
     companion object : SearchTermProvider {
         @Composable
-        override fun getSearchTerms(): PersistentList<SearchTerm> {
-            return persistentListOf(
+        override fun getSearchTerms(): List<SearchTerm> {
+            return listOf(
                 SearchTerm(
                     title = stringResource(R.string.enable_local_manga),
                     subtitle = stringResource(R.string.enable_local_manga_summary),

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/MangaDexSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/MangaDexSettingsScreen.kt
@@ -14,12 +14,6 @@ import eu.kanade.tachiyomi.ui.setting.MangaDexSettingsViewModel
 import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.openInFirefox
 import eu.kanade.tachiyomi.util.system.toast
-import kotlinx.collections.immutable.ImmutableSet
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
-import kotlinx.collections.immutable.toImmutableMap
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.BuildConfig
 import org.nekomanga.R
 import org.nekomanga.constants.MdConstants
@@ -43,10 +37,10 @@ internal class MangaDexSettingsScreen(
     override fun getTitleRes(): Int = R.string.site_specific_settings
 
     @Composable
-    override fun getPreferences(): PersistentList<Preference> {
+    override fun getPreferences(): List<Preference> {
         val context = LocalContext.current
 
-        return persistentListOf(
+        return listOf(
                 generalGroup(context, deleteSavedFilters, mangaDexPreferences),
                 chapterGroup(
                     context,
@@ -57,7 +51,7 @@ internal class MangaDexSettingsScreen(
                 imageGroup(mangaDexPreferences),
                 libraryGroup(context, mangaDexPreferences),
             )
-            .toPersistentList()
+            .toList()
     }
 
     @Composable
@@ -100,7 +94,7 @@ internal class MangaDexSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.general),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.SitePreference(
                         title = loginText,
                         isLoggedIn = mangaDexSettingsState.isLoggedIn,
@@ -123,7 +117,7 @@ internal class MangaDexSettingsScreen(
                                 selected.joinToString()
                         },
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 MdConstants.ContentRating.safe to
                                     stringResource(R.string.content_rating_safe),
                                 MdConstants.ContentRating.suggestive to
@@ -148,8 +142,8 @@ internal class MangaDexSettingsScreen(
     fun chapterGroup(
         context: Context,
         mangaDexPreferences: MangaDexPreferences,
-        blockedGroups: ImmutableSet<String>,
-        blockedUploaders: ImmutableSet<String>,
+        blockedGroups: Set<String>,
+        blockedUploaders: Set<String>,
     ): Preference.PreferenceGroup {
 
         var showBlockedGroupDialog by rememberSaveable { mutableStateOf(false) }
@@ -193,7 +187,7 @@ internal class MangaDexSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.chapter_group),
             preferenceItems =
-                persistentListOf(
+                listOf(
                         Preference.PreferenceItem.SwitchPreference(
                             pref = mangaDexPreferences.includeUnavailableChapters(),
                             title = stringResource(R.string.include_unavailable),
@@ -210,7 +204,7 @@ internal class MangaDexSettingsScreen(
                             entries =
                                 MdLang.entries
                                     .associate { lang -> lang.lang to lang.prettyPrint }
-                                    .toImmutableMap(),
+                                    .toMap(),
                             pref = mangaDexPreferences.enabledChapterLanguages(),
                         ),
                         Preference.PreferenceItem.TextPreference(
@@ -241,7 +235,7 @@ internal class MangaDexSettingsScreen(
                             subtitle = stringResource(R.string.reading_sync_summary),
                         ),
                     )
-                    .toPersistentList(),
+                    .toList(),
         )
     }
 
@@ -250,7 +244,7 @@ internal class MangaDexSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.image_group),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.SwitchPreference(
                         title = stringResource(R.string.data_saver),
                         subtitle = stringResource(R.string.data_saver_summary),
@@ -264,7 +258,7 @@ internal class MangaDexSettingsScreen(
                     Preference.PreferenceItem.ListPreference(
                         title = stringResource(R.string.cover_quality),
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 0 to stringResource(R.string.original_cover_quality),
                                 1 to stringResource(R.string.medium_cover_quality),
                                 2 to stringResource(R.string.low_cover_quality),
@@ -296,11 +290,11 @@ internal class MangaDexSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.library),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.ListPreference(
                         title = stringResource(R.string.auto_add_to_mangadex_library),
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 0 to stringResource(R.string.disabled),
                                 1 to stringResource(R.string.follows_plan_to_read),
                                 2 to stringResource(R.string.follows_on_hold),
@@ -328,8 +322,8 @@ internal class MangaDexSettingsScreen(
 
     companion object : SearchTermProvider {
         @Composable
-        override fun getSearchTerms(): PersistentList<SearchTerm> {
-            return persistentListOf(
+        override fun getSearchTerms(): List<SearchTerm> {
+            return listOf(
                 SearchTerm(
                     title = stringResource(R.string.show_content_rating_filter_in_search),
                     group = stringResource(R.string.general),

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/MergeSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/MergeSettingsScreen.kt
@@ -11,10 +11,6 @@ import eu.kanade.tachiyomi.source.online.merged.suwayomi.LoginMode
 import eu.kanade.tachiyomi.ui.setting.MergeLoginEvent
 import eu.kanade.tachiyomi.ui.setting.MergeScreenState
 import eu.kanade.tachiyomi.ui.setting.MergeScreenType
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableMap
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.SharedFlow
 import org.nekomanga.R
 import org.nekomanga.presentation.components.dialog.LoginDialog
@@ -36,8 +32,8 @@ internal class MergeSettingsScreen(
     override fun getTitleRes(): Int = R.string.merge_source_settings
 
     @Composable
-    override fun getPreferences(): PersistentList<Preference> {
-        return persistentListOf(
+    override fun getPreferences(): List<Preference> {
+        return listOf(
             mergeGroup(
                 mergeState = komgaState,
                 sourceName = stringResource(R.string.komga),
@@ -117,19 +113,19 @@ internal class MergeSettingsScreen(
                                 entries =
                                     LoginMode.entries
                                         .associateWith { stringResource(it.titleResId) }
-                                        .toImmutableMap(),
+                                        .toMap(),
                             )
                         } else null,
                         Preference.PreferenceItem.InfoPreference(title = infoText),
                     )
-                    .toPersistentList(),
+                    .toList(),
         )
     }
 
     companion object : SearchTermProvider {
         @Composable
-        override fun getSearchTerms(): PersistentList<SearchTerm> {
-            return persistentListOf(
+        override fun getSearchTerms(): List<SearchTerm> {
+            return listOf(
                 SearchTerm(title = stringResource(R.string.komga)),
                 SearchTerm(title = stringResource(R.string.suwayomi)),
             )

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/ReaderSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/ReaderSettingsScreen.kt
@@ -16,10 +16,6 @@ import eu.kanade.tachiyomi.ui.reader.settings.PageLayout
 import eu.kanade.tachiyomi.ui.reader.settings.ReaderBottomButton
 import eu.kanade.tachiyomi.ui.reader.settings.ReadingModeType
 import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
-import kotlinx.collections.immutable.toPersistentMap
 import org.nekomanga.R
 import org.nekomanga.core.preferences.PreferenceValues
 import org.nekomanga.domain.reader.ReaderPreferences
@@ -36,8 +32,8 @@ internal class ReaderSettingsScreen(
     override fun getTitleRes(): Int = R.string.reader_settings
 
     @Composable
-    override fun getPreferences(): PersistentList<Preference> {
-        return persistentListOf(
+    override fun getPreferences(): List<Preference> {
+        return listOf(
             generalGroup(),
             displayGroup(),
             einkGroup(),
@@ -54,7 +50,7 @@ internal class ReaderSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.general),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.ListPreference(
                         pref = readerPreferences.defaultReadingMode(),
                         title = stringResource(R.string.default_reading_mode),
@@ -64,13 +60,13 @@ internal class ReaderSettingsScreen(
                                 .associate { type ->
                                     type.prefValue to stringResource(type.stringRes)
                                 }
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.ListPreference(
                         pref = readerPreferences.doubleTapAnimSpeed(),
                         title = stringResource(R.string.double_tap_anim_speed),
                         entries =
-                            persistentMapOf(
+                            mapOf(
                                 1 to
                                     stringResource(
                                         R.string.no_animation
@@ -88,7 +84,7 @@ internal class ReaderSettingsScreen(
                                 .associateWith {
                                     pluralStringResource(R.plurals.pages_plural, it, it)
                                 }
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.MultiSelectListPreference(
                         pref = readerPreferences.readerBottomButtons(),
@@ -96,7 +92,7 @@ internal class ReaderSettingsScreen(
                         entries =
                             ReaderBottomButton.entries
                                 .associate { it.value to stringResource(it.stringRes) }
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.InfoPreference(
                         title = stringResource(R.string.certain_buttons_can_be_found)
@@ -110,7 +106,7 @@ internal class ReaderSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.display),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.ListPreference(
                         pref = readerPreferences.defaultOrientationType(),
                         title = stringResource(R.string.default_orientation),
@@ -120,7 +116,7 @@ internal class ReaderSettingsScreen(
                                 .associate { type ->
                                     type.flagValue to stringResource(type.stringRes)
                                 }
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.ListPreference(
                         pref = readerPreferences.readerTheme(),
@@ -136,7 +132,7 @@ internal class ReaderSettingsScreen(
                                             R.string.smart_based_on_page_and_theme_use_black
                                         ),
                                 )
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.SwitchPreference(
                         pref = readerPreferences.fullscreen(),
@@ -159,7 +155,7 @@ internal class ReaderSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.eink),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.SwitchPreference(
                         pref = readerPreferences.grayscale(),
                         title = stringResource(R.string.grayscale),
@@ -184,7 +180,7 @@ internal class ReaderSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.reading),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.SwitchPreference(
                         pref = readerPreferences.skipRead(),
                         title = stringResource(R.string.skip_read_chapters),
@@ -226,7 +222,7 @@ internal class ReaderSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.paged),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.ListPreference(
                         pref = readerPreferences.navigationModePager(),
                         title = stringResource(R.string.tap_zones),
@@ -234,7 +230,7 @@ internal class ReaderSettingsScreen(
                             stringArrayResource(R.array.reader_nav)
                                 .mapIndexed { index, string -> index to string }
                                 .toMap()
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.ListPreference(
                         pref = readerPreferences.pagerNavInverted(),
@@ -250,7 +246,7 @@ internal class ReaderSettingsScreen(
                                     ViewerNavigation.TappingInvertMode.BOTH to
                                         stringResource(R.string.both_axes),
                                 )
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.ListPreference(
                         pref = readerPreferences.imageScaleType(),
@@ -264,7 +260,7 @@ internal class ReaderSettingsScreen(
                                     5 to stringResource(R.string.original_size),
                                     6 to stringResource(R.string.smart_fit),
                                 )
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.ListPreference(
                         pref = readerPreferences.pagerCutoutBehavior(),
@@ -276,7 +272,7 @@ internal class ReaderSettingsScreen(
                                     1 to stringResource(R.string.start_past_cutout),
                                     2 to stringResource(R.string.ignore_cutout_areas),
                                 )
-                                .toPersistentMap(),
+                                .toMap(),
                         enabled = hasDisplayCutout,
                     ),
                     Preference.PreferenceItem.SwitchPreference(
@@ -294,7 +290,7 @@ internal class ReaderSettingsScreen(
                                     3 to stringResource(R.string.right),
                                     4 to stringResource(R.string.center),
                                 )
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.SwitchPreference(
                         pref = readerPreferences.cropBorders(),
@@ -316,7 +312,7 @@ internal class ReaderSettingsScreen(
                                 .associate { layout ->
                                     layout.value to stringResource(layout.fullStringRes)
                                 }
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.InfoPreference(
                         title = stringResource(R.string.automatic_can_still_switch)
@@ -354,7 +350,7 @@ internal class ReaderSettingsScreen(
                                     60 to stringResource(R.string.double_page_gap_60),
                                     70 to stringResource(R.string.double_page_gap_70),
                                 )
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                 ),
         )
@@ -365,7 +361,7 @@ internal class ReaderSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.webtoon),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.ListPreference(
                         pref = readerPreferences.navigationModeWebtoon(),
                         title = stringResource(R.string.tap_zones),
@@ -373,7 +369,7 @@ internal class ReaderSettingsScreen(
                             stringArrayResource(R.array.reader_nav)
                                 .mapIndexed { index, string -> index to string }
                                 .toMap()
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.ListPreference(
                         pref = readerPreferences.webtoonNavInverted(),
@@ -389,7 +385,7 @@ internal class ReaderSettingsScreen(
                                     ViewerNavigation.TappingInvertMode.BOTH to
                                         stringResource(R.string.both_axes),
                                 )
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.ListPreference(
                         pref = readerPreferences.webtoonReaderHideThreshold(),
@@ -397,7 +393,7 @@ internal class ReaderSettingsScreen(
                         entries =
                             PreferenceValues.ReaderHideThreshold.entries
                                 .associate { it to stringResource(it.titleResId) }
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.SwitchPreference(
                         pref = readerPreferences.cropBordersWebtoon(),
@@ -419,7 +415,7 @@ internal class ReaderSettingsScreen(
                                     20 to stringResource(R.string.webtoon_side_padding_20),
                                     25 to stringResource(R.string.webtoon_side_padding_25),
                                 )
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.ListPreference(
                         pref = readerPreferences.webtoonPageLayout(),
@@ -431,7 +427,7 @@ internal class ReaderSettingsScreen(
                                     PageLayout.SPLIT_PAGES.webtoonValue to
                                         stringResource(PageLayout.SPLIT_PAGES.fullStringRes),
                                 )
-                                .toPersistentMap(),
+                                .toMap(),
                     ),
                     Preference.PreferenceItem.SwitchPreference(
                         pref = readerPreferences.splitTallImagesReader(),
@@ -459,7 +455,7 @@ internal class ReaderSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.navigation),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.SwitchPreference(
                         pref = readerPreferences.readWithVolumeKeys(),
                         title = stringResource(R.string.volume_keys),
@@ -478,7 +474,7 @@ internal class ReaderSettingsScreen(
         return Preference.PreferenceGroup(
             title = stringResource(R.string.actions),
             preferenceItems =
-                persistentListOf(
+                listOf(
                     Preference.PreferenceItem.SwitchPreference(
                         pref = readerPreferences.readWithLongTap(),
                         title = stringResource(R.string.show_on_long_press),
@@ -494,8 +490,8 @@ internal class ReaderSettingsScreen(
 
     companion object : SearchTermProvider {
         @Composable
-        override fun getSearchTerms(): PersistentList<SearchTerm> {
-            return persistentListOf(
+        override fun getSearchTerms(): List<SearchTerm> {
+            return listOf(
                 SearchTerm(
                     title = stringResource(R.string.default_reading_mode),
                     group = stringResource(R.string.general),

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/SearchItem.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/SearchItem.kt
@@ -1,9 +1,8 @@
 package org.nekomanga.presentation.screens.settings.screens
 
 import androidx.compose.runtime.Composable
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.presentation.screens.settings.widgets.SearchTerm
 
 interface SearchTermProvider {
-    @Composable fun getSearchTerms(): PersistentList<SearchTerm>
+    @Composable fun getSearchTerms(): List<SearchTerm>
 }

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/SearchableSettings.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/SearchableSettings.kt
@@ -5,7 +5,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import kotlinx.collections.immutable.PersistentList
 import org.nekomanga.presentation.components.scaffold.ChildScreenScaffold
 import org.nekomanga.presentation.screens.settings.Preference
 import org.nekomanga.presentation.screens.settings.PreferenceScreen
@@ -18,7 +17,7 @@ internal abstract class SearchableSettings(
 
     @StringRes abstract fun getTitleRes(): Int
 
-    @Composable abstract fun getPreferences(): PersistentList<Preference>
+    @Composable abstract fun getPreferences(): List<Preference>
 
     @Composable
     fun Content() {

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/SecuritySettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/SecuritySettingsScreen.kt
@@ -9,9 +9,6 @@ import eu.kanade.tachiyomi.ui.security.SecureActivityDelegate
 import eu.kanade.tachiyomi.util.system.AuthenticatorUtil.authenticate
 import eu.kanade.tachiyomi.util.system.AuthenticatorUtil.isAuthenticationSupported
 import eu.kanade.tachiyomi.util.system.getActivity
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableMap
 import org.nekomanga.R
 import org.nekomanga.core.security.SecurityPreferences
 import org.nekomanga.presentation.screens.settings.Preference
@@ -26,9 +23,9 @@ internal class SecuritySettingsScreen(
     override fun getTitleRes(): Int = R.string.security
 
     @Composable
-    override fun getPreferences(): PersistentList<Preference> {
+    override fun getPreferences(): List<Preference> {
         val context = LocalContext.current
-        return persistentListOf(
+        return listOf(
             Preference.PreferenceItem.SwitchPreference(
                 pref = securityPreferences.useBiometrics(),
                 title = stringResource(R.string.lock_with_biometrics),
@@ -53,7 +50,7 @@ internal class SecuritySettingsScreen(
                                 else -> it to pluralStringResource(R.plurals.after_minutes, it, it)
                             }
                         }
-                        .toImmutableMap(),
+                        .toMap(),
             ),
             Preference.PreferenceItem.SwitchPreference(
                 pref = securityPreferences.hideNotificationContent(),
@@ -65,7 +62,7 @@ internal class SecuritySettingsScreen(
                 entries =
                     SecurityPreferences.SecureScreenMode.entries
                         .associate { it to stringResource(it.titleResId) }
-                        .toImmutableMap(),
+                        .toMap(),
                 onValueChanged = {
                     val activity = context.getActivity()
                     if (activity != null) {
@@ -82,8 +79,8 @@ internal class SecuritySettingsScreen(
 
     companion object : SearchTermProvider {
         @Composable
-        override fun getSearchTerms(): PersistentList<SearchTerm> {
-            return persistentListOf(
+        override fun getSearchTerms(): List<SearchTerm> {
+            return listOf(
                 SearchTerm(stringResource(R.string.lock_with_biometrics)),
                 SearchTerm(stringResource(R.string.lock_when_idle)),
                 SearchTerm(stringResource(R.string.hide_notification_content)),

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/TrackingSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/TrackingSettingsScreen.kt
@@ -15,10 +15,6 @@ import eu.kanade.tachiyomi.jobs.tracking.TrackingSyncJob
 import eu.kanade.tachiyomi.ui.setting.MergeLoginEvent
 import eu.kanade.tachiyomi.ui.setting.TrackingSettingsViewModel
 import eu.kanade.tachiyomi.util.system.openInBrowser
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
-import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.flow.SharedFlow
 import org.nekomanga.R
 import org.nekomanga.constants.MdConstants
@@ -41,7 +37,7 @@ internal class TrackingSettingsScreen(
     override fun getTitleRes(): Int = R.string.tracking
 
     @Composable
-    override fun getPreferences(): PersistentList<Preference> {
+    override fun getPreferences(): List<Preference> {
 
         val context = LocalContext.current
 
@@ -74,7 +70,7 @@ internal class TrackingSettingsScreen(
                                 MdConstants.ContentRating.pornographic to
                                     stringResource(R.string.content_rating_pornographic),
                             )
-                            .toPersistentMap(),
+                            .toMap(),
                 ),
                 Preference.PreferenceItem.TextPreference(
                     title = stringResource(R.string.refresh_tracking_metadata),
@@ -82,7 +78,7 @@ internal class TrackingSettingsScreen(
                     onClick = { TrackingSyncJob.doWorkNow(context) },
                 ),
             ) + servicesGroup(context))
-            .toPersistentList()
+            .toList()
     }
 
     @Composable
@@ -142,7 +138,7 @@ internal class TrackingSettingsScreen(
             Preference.PreferenceGroup(
                 title = stringResource(R.string.anilist),
                 preferenceItems =
-                    persistentListOf(
+                    listOf(
                         Preference.PreferenceItem.TrackerPreference(
                             tracker = trackingScreenState.anilist,
                             title =
@@ -174,7 +170,7 @@ internal class TrackingSettingsScreen(
             Preference.PreferenceGroup(
                 title = stringResource(R.string.kitsu),
                 preferenceItems =
-                    persistentListOf(
+                    listOf(
                         Preference.PreferenceItem.TrackerPreference(
                             tracker = trackingScreenState.kitsu,
                             title =
@@ -210,7 +206,7 @@ internal class TrackingSettingsScreen(
             Preference.PreferenceGroup(
                 title = stringResource(R.string.myanimelist),
                 preferenceItems =
-                    persistentListOf(
+                    listOf(
                         Preference.PreferenceItem.TrackerPreference(
                             tracker = trackingScreenState.mal,
                             title =
@@ -242,7 +238,7 @@ internal class TrackingSettingsScreen(
             Preference.PreferenceGroup(
                 title = stringResource(R.string.manga_updates),
                 preferenceItems =
-                    persistentListOf(
+                    listOf(
                         Preference.PreferenceItem.TrackerPreference(
                             tracker = trackingScreenState.mangaUpdates,
                             title =
@@ -278,7 +274,7 @@ internal class TrackingSettingsScreen(
             Preference.PreferenceGroup(
                 title = stringResource(R.string.mangabaka),
                 preferenceItems =
-                    persistentListOf(
+                    listOf(
                         Preference.PreferenceItem.TrackerPreference(
                             tracker = trackingScreenState.mangaBaka,
                             title =
@@ -316,8 +312,8 @@ internal class TrackingSettingsScreen(
 
     companion object : SearchTermProvider {
         @Composable
-        override fun getSearchTerms(): PersistentList<SearchTerm> {
-            return persistentListOf(
+        override fun getSearchTerms(): List<SearchTerm> {
+            return listOf(
                 SearchTerm(title = stringResource(R.string.update_tracking_after_reading)),
                 SearchTerm(title = stringResource(R.string.update_tracking_marked_read)),
                 SearchTerm(

--- a/app/src/main/java/org/nekomanga/presentation/screens/similar/SimilarScreenState.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/similar/SimilarScreenState.kt
@@ -1,10 +1,6 @@
 package org.nekomanga.presentation.screens.similar
 
 import androidx.compose.runtime.Immutable
-import kotlinx.collections.immutable.ImmutableMap
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
 import org.nekomanga.domain.category.CategoryItem
 import org.nekomanga.domain.manga.DisplayManga
 
@@ -12,8 +8,8 @@ import org.nekomanga.domain.manga.DisplayManga
 data class SimilarScreenState(
     val isRefreshing: Boolean = false,
     val incognitoMode: Boolean = false,
-    val allDisplayManga: ImmutableMap<Int, PersistentList<DisplayManga>> = persistentMapOf(),
-    val filteredDisplayManga: ImmutableMap<Int, PersistentList<DisplayManga>> = persistentMapOf(),
+    val allDisplayManga: Map<Int, List<DisplayManga>> = mapOf(),
+    val filteredDisplayManga: Map<Int, List<DisplayManga>> = mapOf(),
     val error: String? = null,
     val isList: Boolean,
     val libraryEntryVisibility: Int,
@@ -22,5 +18,5 @@ data class SimilarScreenState(
     val isComfortableGrid: Boolean,
     val rawColumnCount: Float,
     val promptForCategories: Boolean = false,
-    val categories: PersistentList<CategoryItem> = persistentListOf(),
+    val categories: List<CategoryItem> = listOf(),
 )

--- a/app/src/main/java/org/nekomanga/presentation/screens/similar/SimilarViewModel.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/similar/SimilarViewModel.kt
@@ -11,11 +11,6 @@ import eu.kanade.tachiyomi.ui.source.browse.LibraryEntryVisibility
 import eu.kanade.tachiyomi.util.category.CategoryUtil
 import eu.kanade.tachiyomi.util.system.launchIO
 import java.util.Date
-import kotlinx.collections.immutable.ImmutableMap
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentMapOf
-import kotlinx.collections.immutable.toImmutableMap
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -77,7 +72,7 @@ class SimilarViewModel(val mangaUUID: String) : ViewModel() {
                 categoryRepository
                     .getCategories()
                     .map { category -> category.toCategoryItem() }
-                    .toPersistentList()
+                    .toList()
             _similarScreenState.update {
                 it.copy(
                     categories = categories,
@@ -110,16 +105,16 @@ class SimilarViewModel(val mangaUUID: String) : ViewModel() {
                 _similarScreenState.update {
                     it.copy(
                         isRefreshing = true,
-                        allDisplayManga = persistentMapOf(),
-                        filteredDisplayManga = persistentMapOf(),
+                        allDisplayManga = mapOf(),
+                        filteredDisplayManga = mapOf(),
                     )
                 }
 
                 val list = repo.fetchSimilar(mangaUUID, forceRefresh)
                 val allDisplayManga =
                     list
-                        .associate { group -> group.type to group.manga.toPersistentList() }
-                        .toImmutableMap()
+                        .associate { group -> group.type to group.manga.toList() }
+                        .toMap()
                 _similarScreenState.update {
                     it.copy(
                         isRefreshing = false,
@@ -176,9 +171,9 @@ class SimilarViewModel(val mangaUUID: String) : ViewModel() {
         preferences.browseDisplayMode().set(visibility)
     }
 
-    fun ImmutableMap<Int, PersistentList<DisplayManga>>.filterByVisibility(
+    fun Map<Int, List<DisplayManga>>.filterByVisibility(
         prefs: PreferencesHelper
-    ): ImmutableMap<Int, PersistentList<DisplayManga>> {
+    ): Map<Int, List<DisplayManga>> {
         val visibilityMode = prefs.browseDisplayMode().get()
 
         return this.mapValues { (_, displayMangaList) ->
@@ -190,9 +185,9 @@ class SimilarViewModel(val mangaUUID: String) : ViewModel() {
                             else -> true
                         }
                     }
-                    .toPersistentList()
+                    .toList()
             }
-            .toImmutableMap()
+            .toMap()
     }
 
     private fun updateDisplayManga(mangaId: Long, favorite: Boolean) {
@@ -215,13 +210,13 @@ class SimilarViewModel(val mangaUUID: String) : ViewModel() {
                 val tempDisplayManga = tempList[mangaIndex].copy(inLibrary = favorite)
                 tempList[mangaIndex] = tempDisplayManga
 
-                tempMap[mapKey] = tempList.toPersistentList()
+                tempMap[mapKey] = tempList.toList()
             }
 
             _similarScreenState.update {
                 it.copy(
-                    allDisplayManga = tempMap.toImmutableMap(),
-                    filteredDisplayManga = tempMap.toImmutableMap().filterByVisibility(preferences),
+                    allDisplayManga = tempMap.toMap(),
+                    filteredDisplayManga = tempMap.toMap().filterByVisibility(preferences),
                 )
             }
         }
@@ -240,7 +235,7 @@ class SimilarViewModel(val mangaUUID: String) : ViewModel() {
                         categoryRepository
                             .getCategories()
                             .map { category -> category.toCategoryItem() }
-                            .toPersistentList()
+                            .toList()
                 )
             }
         }
@@ -288,11 +283,11 @@ class SimilarViewModel(val mangaUUID: String) : ViewModel() {
                                         it
                                     }
                                 }
-                                .toPersistentList(),
+                                .toList(),
                         )
                     }
                     .toMap()
-                    .toImmutableMap()
+                    .toMap()
             _similarScreenState.update {
                 it.copy(
                     allDisplayManga = newDisplayManga,

--- a/app/src/main/java/org/nekomanga/presentation/screens/stats/DetailedStats.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/stats/DetailedStats.kt
@@ -59,10 +59,6 @@ import eu.kanade.tachiyomi.util.lang.capitalizeWords
 import eu.kanade.tachiyomi.util.system.roundToTwoDecimal
 import jp.wasabeef.gap.Gap
 import kotlin.random.Random
-import kotlinx.collections.immutable.ImmutableMap
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toImmutableMap
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.R
 import org.nekomanga.presentation.components.NekoColors
 import org.nekomanga.presentation.screens.stats.StatsConstants.DetailedState
@@ -72,7 +68,7 @@ import org.nekomanga.presentation.theme.Size
 @Composable
 fun DetailedStats(
     detailedStats: DetailedState,
-    colors: PersistentList<Color>,
+    colors: List<Color>,
     contentPadding: PaddingValues,
     windowSizeClass: WindowSizeClass,
 ) {
@@ -211,7 +207,7 @@ private fun FilterChipHeader(filterState: Filter, filterStateClick: (Filter) -> 
 private fun TagView(
     sortType: Sort,
     detailedStats: DetailedState,
-    colors: PersistentList<Color>,
+    colors: List<Color>,
     contentPadding: PaddingValues,
     viewType: ViewType,
     sortChipClick: () -> Unit,
@@ -235,7 +231,7 @@ private fun TagView(
                                 .compareTo(t.second.sumOf { it.readDuration })
                     }
                 }
-                .toPersistentList()
+                .toList()
         }
     StatCardView(
         contentPadding = contentPadding,
@@ -254,7 +250,7 @@ private fun TagView(
 private fun ContentRatingView(
     sortType: Sort,
     detailedStats: DetailedState,
-    colors: PersistentList<Color>,
+    colors: List<Color>,
     contentPadding: PaddingValues,
     viewType: ViewType,
     sortChipClick: () -> Unit,
@@ -265,7 +261,7 @@ private fun ContentRatingView(
                 .groupBy { it.contentRating.prettyPrint() }
                 .entries
                 .sortedWith(mapEntryComparator(sortType))
-                .toPersistentList()
+                .toList()
         }
     val colorMap = remember { colorMap(sortedSeries.map { it.key }, colors) }
     val totalCount = remember { sortedSeries.sumOf { it.value.size } }
@@ -292,7 +288,7 @@ private fun ContentRatingView(
 private fun CategoryView(
     sortType: Sort,
     detailedStats: DetailedState,
-    colors: PersistentList<Color>,
+    colors: List<Color>,
     contentPadding: PaddingValues,
     viewType: ViewType,
     sortChipClick: () -> Unit,
@@ -308,7 +304,7 @@ private fun CategoryView(
                 .entries
                 .filter { it.key != defaultCategoryName || it.value.isNotEmpty() }
                 .sortedWith(mapEntryComparator(sortType))
-                .toPersistentList()
+                .toList()
         }
     val colorsToUse = remember {
         when (sortedSeries.size <= colors.size) {
@@ -316,7 +312,7 @@ private fun CategoryView(
             false ->
                 sortedSeries
                     .map { Color(Random.nextInt(256), Random.nextInt(256), Random.nextInt(256)) }
-                    .toPersistentList()
+                    .toList()
         }
     }
 
@@ -344,7 +340,7 @@ private fun CategoryView(
 @Composable
 private fun StartYearView(
     detailedStats: DetailedState,
-    colors: PersistentList<Color>,
+    colors: List<Color>,
     contentPadding: PaddingValues,
     viewType: ViewType,
 ) {
@@ -354,7 +350,7 @@ private fun StartYearView(
             .groupBy { it.startYear?.toString() ?: notStartedString }
             .entries
             .sortedBy { it.key }
-            .toPersistentList()
+            .toList()
     }
 
     val lineData = remember {
@@ -366,9 +362,9 @@ private fun StartYearView(
                     null
                 }
             }
-            .toPersistentList()
+            .toList()
     }
-    val colorMap = remember { sortedSeries.associate { it.key to colors[0] }.toImmutableMap() }
+    val colorMap = remember { sortedSeries.associate { it.key to colors[0] }.toMap() }
 
     DefaultView(
         contentPadding = contentPadding,
@@ -391,7 +387,7 @@ private fun StatusView(
     sortType: Sort,
     detailedStats: DetailedState,
     context: Context,
-    colors: PersistentList<Color>,
+    colors: List<Color>,
     contentPadding: PaddingValues,
     viewType: ViewType,
     sortChipClick: () -> Unit,
@@ -402,7 +398,7 @@ private fun StatusView(
                 .groupBy { context.getString(it.status.statusRes) }
                 .entries
                 .sortedWith(mapEntryComparator(sortType))
-                .toPersistentList()
+                .toList()
         }
     val colorMap = remember { colorMap(sortedSeries.map { it.key }, colors) }
     val totalCount = remember { sortedSeries.sumOf { it.value.size } }
@@ -430,7 +426,7 @@ private fun TypeView(
     sortType: Sort,
     detailedStats: DetailedState,
     context: Context,
-    colors: PersistentList<Color>,
+    colors: List<Color>,
     contentPadding: PaddingValues,
     viewType: ViewType,
     sortChipClick: () -> Unit,
@@ -441,7 +437,7 @@ private fun TypeView(
                 .groupBy { context.getString(it.type.typeRes) }
                 .entries
                 .sortedWith(mapEntryComparator(sortType))
-                .toPersistentList()
+                .toList()
         }
     val colorMap = remember { colorMap(sortedSeries.map { it.key }, colors) }
     val totalCount = remember { sortedSeries.sumOf { it.value.size } }
@@ -469,8 +465,8 @@ private fun DefaultView(
     contentPadding: PaddingValues,
     sortType: Sort = Sort.Entries,
     sortChipClick: () -> Unit = {},
-    sortedSeries: PersistentList<Map.Entry<String, List<StatsConstants.DetailedStatManga>>>,
-    colorMap: ImmutableMap<String, Color>,
+    sortedSeries: List<Map.Entry<String, List<StatsConstants.DetailedStatManga>>>,
+    colorMap: Map<String, Color>,
     totalCount: Int = 0,
     totalDuration: Long = 0L,
     viewType: ViewType,
@@ -537,7 +533,7 @@ private fun DefaultView(
 
 @Composable
 private fun DetailedCardView(
-    mangaList: PersistentList<StatsConstants.DetailedStatManga>,
+    mangaList: List<StatsConstants.DetailedStatManga>,
     contentPadding: PaddingValues,
     viewType: ViewType,
 ) {
@@ -560,7 +556,7 @@ private fun DetailedCardView(
 private fun StatCardView(
     contentPadding: PaddingValues,
     viewType: ViewType,
-    sortedSeries: PersistentList<Pair<String, PersistentList<StatsConstants.DetailedStatManga>>>,
+    sortedSeries: List<Pair<String, List<StatsConstants.DetailedStatManga>>>,
     color: Color,
     totalCount: Int,
     totalReadDuration: Long,
@@ -913,15 +909,15 @@ private fun <T : Comparable<T>> mapEntryComparator(sortType: Sort) =
     }
 
 /** Creates the color map using the unique key so changing sort order doesnt change the color */
-private fun <T> colorMap(sortedSeries: List<T>, colors: List<Color>): ImmutableMap<T, Color> {
-    return sortedSeries.mapIndexed { index, T -> T to colors[index] }.toMap().toImmutableMap()
+private fun <T> colorMap(sortedSeries: List<T>, colors: List<Color>): Map<T, Color> {
+    return sortedSeries.mapIndexed { index, T -> T to colors[index] }.toMap().toMap()
 }
 
 private fun <T> pieData(
-    sortedSeries: PersistentList<Map.Entry<T, List<StatsConstants.DetailedStatManga>>>,
-    colorMap: ImmutableMap<T, Color>,
+    sortedSeries: List<Map.Entry<T, List<StatsConstants.DetailedStatManga>>>,
+    colorMap: Map<T, Color>,
     sortType: Sort,
-): PersistentList<PieData> {
+): List<PieData> {
     return sortedSeries
         .mapNotNull { entry ->
             val data =
@@ -936,7 +932,7 @@ private fun <T> pieData(
                 null
             }
         }
-        .toPersistentList()
+        .toList()
 }
 
 private enum class Filter {

--- a/app/src/main/java/org/nekomanga/presentation/screens/stats/SimpleStats.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/stats/SimpleStats.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.R
 import org.nekomanga.presentation.theme.Size
 
@@ -99,7 +98,7 @@ fun SimpleStats(
                 numberFormat.format(statsState.tagCount).toString() to
                     context.getString(R.string.total_tags),
             ) + mergeCounts)
-            .toPersistentList()
+            .toList()
     }
 
     val isTablet = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded

--- a/app/src/main/java/org/nekomanga/presentation/screens/stats/StatsConstants.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/stats/StatsConstants.kt
@@ -1,8 +1,6 @@
 package org.nekomanga.presentation.screens.stats
 
 import eu.kanade.tachiyomi.data.database.models.MergeType
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 import org.nekomanga.domain.manga.MangaContentRating
 import org.nekomanga.domain.manga.MangaStatus
 import org.nekomanga.domain.manga.MangaType
@@ -19,7 +17,7 @@ object StatsConstants {
         val globalUpdateCount: Int = 0,
         val downloadCount: Int = 0,
         val tagCount: Int = 0,
-        val mergeCounts: PersistentList<Pair<MergeType, Int>> = persistentListOf(),
+        val mergeCounts: List<Pair<MergeType, Int>> = listOf(),
         val averageMangaRating: Double = 0.0,
         val averageUserRating: Double = 0.0,
         val trackerCount: Int = 0,
@@ -31,17 +29,17 @@ object StatsConstants {
 
     data class DetailedState(
         val isLoading: Boolean = true,
-        val manga: PersistentList<DetailedStatManga> = persistentListOf(),
-        val categories: PersistentList<String> = persistentListOf(),
-        val tags: PersistentList<String> = persistentListOf(),
+        val manga: List<DetailedStatManga> = listOf(),
+        val categories: List<String> = listOf(),
+        val tags: List<String> = listOf(),
         val detailTagState: DetailedTagState = DetailedTagState(),
     )
 
     data class DetailedTagState(
         val totalReadDuration: Long = 0L,
         val totalChapters: Int = 0,
-        val sortedTagPairs: PersistentList<Pair<String, PersistentList<DetailedStatManga>>> =
-            persistentListOf(),
+        val sortedTagPairs: List<Pair<String, List<DetailedStatManga>>> =
+            listOf(),
     )
 
     data class DetailedStatManga(
@@ -58,9 +56,9 @@ object StatsConstants {
         val rating: Double?,
         val userScore: Double?,
         val startYear: Int?,
-        val trackers: PersistentList<String>,
-        val tags: PersistentList<String>,
-        val categories: PersistentList<String>,
+        val trackers: List<String>,
+        val tags: List<String>,
+        val categories: List<String>,
     )
 
     sealed class ScreenState {

--- a/app/src/main/java/org/nekomanga/presentation/screens/stats/StatsViewModel.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/stats/StatsViewModel.kt
@@ -16,7 +16,6 @@ import eu.kanade.tachiyomi.util.system.launchIO
 import eu.kanade.tachiyomi.util.system.roundToTwoDecimal
 import eu.kanade.tachiyomi.util.system.timeSpanFromNow
 import java.util.Calendar
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -108,7 +107,7 @@ class StatsViewModel() : ViewModel() {
                 }
             }
 
-        mergedMangaList.groupBy { it.mergeType }.map { it.key to it.value.size }.toPersistentList()
+        mergedMangaList.groupBy { it.mergeType }.map { it.key to it.value.size }.toList()
 
         _simpleState.update {
             StatsConstants.SimpleState(
@@ -123,7 +122,7 @@ class StatsViewModel() : ViewModel() {
                     mergedMangaList
                         .groupBy { it.mergeType }
                         .map { it.key to it.value.size }
-                        .toPersistentList(),
+                        .toList(),
                 globalUpdateCount = getGlobalUpdateManga(libraryList, tracksByMangaId).count(),
                 downloadCount = libraryList.sumOf { getDownloadCount(it) },
                 tagCount =
@@ -205,29 +204,29 @@ class StatsViewModel() : ViewModel() {
                         readDuration = getReadDurationFromHistory(history),
                         startYear = getStartYear(history),
                         rating = it.rating?.toDoubleOrNull()?.roundToTwoDecimal(),
-                        tags = (it.getGenres() ?: emptyList()).toPersistentList(),
+                        tags = (it.getGenres() ?: emptyList()).toList(),
                         userScore = getUserScore(tracks),
                         trackers =
                             tracks
                                 .mapNotNull { trackManager.getService(it.sync_id) }
                                 .map { prefs.context.getString(it.nameRes()) }
-                                .toPersistentList(),
+                                .toList(),
                         categories =
                             (catNames.takeUnless { it.isEmpty() }
                                     ?: listOf(prefs.context.getString(R.string.default_value)))
                                 .sorted()
-                                .toPersistentList(),
+                                .toList(),
                     )
                 }
                 .sortedBy { it.title }
         _detailState.update {
             DetailedState(
                 isLoading = false,
-                manga = detailedStatMangaList.toPersistentList(),
+                manga = detailedStatMangaList.toList(),
                 categories =
                     (categoryRepository.getCategories().map { it.name } +
                             listOf(prefs.context.getString(R.string.default_value)))
-                        .toPersistentList(),
+                        .toList(),
                 tags =
                     detailedStatMangaList
                         .asSequence()
@@ -236,7 +235,7 @@ class StatsViewModel() : ViewModel() {
                         .distinct()
                         .filter { !it.contains("content rating:", true) }
                         .sortedBy { it }
-                        .toPersistentList(),
+                        .toList(),
             )
         }
 
@@ -244,10 +243,10 @@ class StatsViewModel() : ViewModel() {
             _detailState.value.tags
                 .map { tag ->
                     tag to
-                        _detailState.value.manga.filter { it.tags.contains(tag) }.toPersistentList()
+                        _detailState.value.manga.filter { it.tags.contains(tag) }.toList()
                 }
                 .sortedByDescending { it.second.count() }
-                .toPersistentList()
+                .toList()
         val totalCount = sortedSeries.sumOf { it.second.size }
         val totalDuration = sortedSeries.sumOf { pair -> pair.second.sumOf { it.readDuration } }
 

--- a/app/src/main/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCase.kt
+++ b/app/src/main/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCase.kt
@@ -3,9 +3,6 @@ package org.nekomanga.usecases.library
 import eu.kanade.tachiyomi.ui.library.LibraryCategoryItem
 import eu.kanade.tachiyomi.ui.library.LibraryGroup
 import eu.kanade.tachiyomi.ui.library.LibrarySort
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import org.nekomanga.domain.category.CategoryItem
 import org.nekomanga.domain.category.CategoryItem.Companion.ALL_CATEGORY
 import org.nekomanga.domain.manga.LibraryMangaItem
@@ -18,7 +15,7 @@ class GroupLibraryMangaUseCase {
         sortOrder: LibrarySort,
         sortAscending: Boolean,
         loggedInTrackStatus: Map<Long, List<String>>,
-    ): PersistentList<LibraryCategoryItem> {
+    ): List<LibraryCategoryItem> {
         val groupedMap = mutableMapOf<String, MutableList<LibraryMangaItem>>()
         val notTrackedList = listOf("Not tracked")
 
@@ -60,17 +57,17 @@ class GroupLibraryMangaUseCase {
                     )
                 LibraryCategoryItem(
                     categoryItem = categoryItem,
-                    libraryItems = items.toPersistentList(),
+                    libraryItems = items.toList(),
                 )
             }
-            .toPersistentList()
+            .toList()
     }
 
     fun groupByUngrouped(
         libraryMangaList: List<LibraryMangaItem>,
         sortOrder: LibrarySort,
         isAscending: Boolean,
-    ): PersistentList<LibraryCategoryItem> {
+    ): List<LibraryCategoryItem> {
 
         val allCategoryItem =
             CategoryItem(
@@ -83,9 +80,9 @@ class GroupLibraryMangaUseCase {
             )
 
         val distinctList =
-            libraryMangaList.distinctBy { it.displayManga.mangaId }.toPersistentList()
+            libraryMangaList.distinctBy { it.displayManga.mangaId }.toList()
 
-        return persistentListOf(
+        return listOf(
             LibraryCategoryItem(categoryItem = allCategoryItem, libraryItems = distinctList)
         )
     }
@@ -117,7 +114,7 @@ class GroupLibraryMangaUseCase {
 
             LibraryCategoryItem(
                 categoryItem = categoryItem,
-                libraryItems = unsortedMangaList.toPersistentList(),
+                libraryItems = unsortedMangaList.toList(),
             )
         }
     }

--- a/app/src/main/java/org/nekomanga/usecases/tracking/SearchTracker.kt
+++ b/app/src/main/java/org/nekomanga/usecases/tracking/SearchTracker.kt
@@ -3,7 +3,6 @@ package org.nekomanga.usecases.tracking
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.track.TrackManager
 import eu.kanade.tachiyomi.ui.manga.TrackingConstants
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
@@ -35,7 +34,7 @@ class SearchTracker(private val trackManager: TrackManager = Injekt.get()) {
                         true -> TrackingConstants.TrackSearchResult.NoResult
                         false ->
                             TrackingConstants.TrackSearchResult.Success(
-                                results.map { it.toTrackSearchItem() }.toPersistentList(),
+                                results.map { it.toTrackSearchItem() }.toList(),
                                 hasMatchingId = id.isNotEmpty(),
                             )
                     }
@@ -76,7 +75,7 @@ class SearchTracker(private val trackManager: TrackManager = Injekt.get()) {
                     true -> TrackingConstants.TrackSearchResult.NoResult
                     false ->
                         TrackingConstants.TrackSearchResult.Success(
-                            results.map { it.toTrackSearchItem() }.toPersistentList()
+                            results.map { it.toTrackSearchItem() }.toList()
                         )
                 }
             }

--- a/app/src/test/java/org/nekomanga/usecases/chapters/GetChapterFilterTextTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/chapters/GetChapterFilterTextTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.state.ToggleableState
 import eu.kanade.tachiyomi.ui.manga.MangaConstants
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.collections.immutable.persistentListOf
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -69,7 +68,7 @@ class GetChapterFilterTextTest {
         val scanlator =
             MangaConstants.ScanlatorFilter(
                 scanlators =
-                    persistentListOf(MangaConstants.ScanlatorOption("test", disabled = true))
+                    listOf(MangaConstants.ScanlatorOption("test", disabled = true))
             )
         val language = MangaConstants.LanguageFilter()
 

--- a/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/library/GroupLibraryMangaUseCaseTest.kt
@@ -5,8 +5,6 @@ import eu.kanade.tachiyomi.ui.library.LibraryGroup
 import eu.kanade.tachiyomi.ui.library.LibrarySort
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.nekomanga.domain.category.CategoryItem
@@ -56,7 +54,7 @@ class GroupLibraryMangaUseCaseTest {
                     isDynamic = true,
                     isHidden = false,
                 ),
-            libraryItems = items.toPersistentList(),
+            libraryItems = items.toList(),
         )
     }
 
@@ -270,7 +268,7 @@ class GroupLibraryMangaUseCaseTest {
             listOf(
                 LibraryCategoryItem(
                     categoryItem = expectedCategoryItem,
-                    libraryItems = persistentListOf(manga1, manga2),
+                    libraryItems = listOf(manga1, manga2),
                 )
             )
 
@@ -298,11 +296,11 @@ class GroupLibraryMangaUseCaseTest {
             listOf(
                 LibraryCategoryItem(
                     categoryItem = category2,
-                    libraryItems = persistentListOf(manga2),
+                    libraryItems = listOf(manga2),
                 ),
                 LibraryCategoryItem(
                     categoryItem = category1,
-                    libraryItems = persistentListOf(manga1, manga3),
+                    libraryItems = listOf(manga1, manga3),
                 ),
             )
 
@@ -346,7 +344,7 @@ class GroupLibraryMangaUseCaseTest {
             listOf(
                 LibraryCategoryItem(
                     categoryItem = category1,
-                    libraryItems = persistentListOf(manga1),
+                    libraryItems = listOf(manga1),
                 )
             )
 
@@ -372,7 +370,7 @@ class GroupLibraryMangaUseCaseTest {
             listOf(
                 LibraryCategoryItem(
                     categoryItem = category1,
-                    libraryItems = persistentListOf(manga1),
+                    libraryItems = listOf(manga1),
                 )
             )
 
@@ -398,11 +396,11 @@ class GroupLibraryMangaUseCaseTest {
             listOf(
                 LibraryCategoryItem(
                     categoryItem = category1,
-                    libraryItems = persistentListOf(manga1),
+                    libraryItems = listOf(manga1),
                 ),
                 LibraryCategoryItem(
                     categoryItem = systemCategory,
-                    libraryItems = persistentListOf(),
+                    libraryItems = listOf(),
                 ),
             )
 
@@ -429,7 +427,7 @@ class GroupLibraryMangaUseCaseTest {
             listOf(
                 LibraryCategoryItem(
                     categoryItem = category1,
-                    libraryItems = persistentListOf(manga1),
+                    libraryItems = listOf(manga1),
                 )
             )
 
@@ -456,11 +454,11 @@ class GroupLibraryMangaUseCaseTest {
             listOf(
                 LibraryCategoryItem(
                     categoryItem = category1,
-                    libraryItems = persistentListOf(manga1),
+                    libraryItems = listOf(manga1),
                 ),
                 LibraryCategoryItem(
                     categoryItem = systemCategory,
-                    libraryItems = persistentListOf(),
+                    libraryItems = listOf(),
                 ),
             )
 
@@ -484,7 +482,7 @@ class GroupLibraryMangaUseCaseTest {
             listOf(
                 LibraryCategoryItem(
                     categoryItem = systemCategory,
-                    libraryItems = persistentListOf(manga1),
+                    libraryItems = listOf(manga1),
                 )
             )
 
@@ -516,7 +514,7 @@ class GroupLibraryMangaUseCaseTest {
             )
 
         val expected =
-            listOf(LibraryCategoryItem(categoryItem = category1, libraryItems = persistentListOf()))
+            listOf(LibraryCategoryItem(categoryItem = category1, libraryItems = listOf()))
 
         assertEquals(expected, result)
     }

--- a/app/src/test/java/org/nekomanga/usecases/tracking/LoginToTrackServiceTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/tracking/LoginToTrackServiceTest.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.data.track.TrackManager
 import eu.kanade.tachiyomi.data.track.TrackService
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -31,14 +30,14 @@ class LoginToTrackServiceTest {
                 nameRes = 1,
                 logoRes = 1,
                 logoColor = 1,
-                statusList = persistentListOf(1, 2, 3),
+                statusList = listOf(1, 2, 3),
                 supportsReadingDates = false,
                 canRemoveFromService = false,
                 isAutoAddTracker = false,
                 isMdList = false,
                 status = { "status" },
                 displayScore = { "score" },
-                scoreList = persistentListOf("1", "2"),
+                scoreList = listOf("1", "2"),
                 indexToScore = { 1f },
             )
 

--- a/app/src/test/java/org/nekomanga/usecases/tracking/UpdateTrackingServiceTest.kt
+++ b/app/src/test/java/org/nekomanga/usecases/tracking/UpdateTrackingServiceTest.kt
@@ -7,7 +7,6 @@ import eu.kanade.tachiyomi.ui.manga.TrackingUpdate
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -41,14 +40,14 @@ class UpdateTrackingServiceTest {
             nameRes = 0,
             logoRes = 0,
             logoColor = 0,
-            statusList = persistentListOf(),
+            statusList = listOf(),
             supportsReadingDates = false,
             canRemoveFromService = false,
             isAutoAddTracker = false,
             isMdList = false,
             status = { "" },
             displayScore = { "" },
-            scoreList = persistentListOf(),
+            scoreList = listOf(),
             indexToScore = { 0f },
         )
 

--- a/gradle/kotlinx.versions.toml
+++ b/gradle/kotlinx.versions.toml
@@ -16,11 +16,9 @@ serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization
 serialization-okio = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json-okio", version.ref = "serializationVersion" }
 
 
-immutables = "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.5.0"
-
 [bundles]
 
-kotlin = ["stdlib", "reflect", "coroutines-core", "coroutines-android", "serialization-json", "serialization-protobuf", "serialization-okio", "immutables"]
+kotlin = ["stdlib", "reflect", "coroutines-core", "coroutines-android", "serialization-json", "serialization-protobuf", "serialization-okio"]
 
 [plugins]
 


### PR DESCRIPTION
 ### 1. Dependency Cleanup
  
  • Removed  kotlinx-collections-immutable  from  gradle/kotlinx.versions.toml .
  
  ### 2. Refactoring Immutable Collections to Standard Kotlin Collections
  
  • Replaced references to  PersistentList ,  ImmutableList ,  PersistentSet ,  ImmutableSet ,  PersistentMap , and  ImmutableMap  with standard Kotlin read-   
  only collections ( List ,  Set ,  Map ).
  • Replaced builders/constructors  persistentListOf() ,  persistentSetOf() ,  persistentMapOf()  with  listOf() ,  setOf() , and  mapOf() .
  • Replaced converters  .toPersistentList() ,  .toImmutableList() ,  .toPersistentSet() ,  .toImmutableSet() ,  .toPersistentMap() , and  .toImmutableMap()    
  with standard  .toList() ,  .toSet() , and  .toMap() .
  • Recursively processed 91 source files and 4 unit test files to clean up the imports and collection classes.
  
  ### 3. List Creation Optimization using  buildList {} 
  
  • Refactored list mutations in  LibraryViewModel.kt ,  MangaViewModel.kt ,  BrowseViewModel.kt , and  DisplayViewModel.kt  to use  buildList {}  rather than  
  manual manipulation/operators.
  • Refactored  ButtonBlock.kt 's  actionButtons  builder from the old builder pattern to use  buildList {}  natively.
  • Refactored multi-list concatenations in  ApiMangaParser.kt ,  LibraryUpdateJob.kt , and  SourceChapterSorter.kt  using  buildList {}  to improve readability
  and performance.
  
  ### 4. Resolving JVM Signature Clashes
  
  • Addressed type-erasure JVM signature clashes on  updateVisibility()  in  MangaExtensions.kt  by annotating the  List<HomePageManga>  variant with           
  @JvmName("updateHomePageMangaVisibility") .