### PR TITLE
fix: resolve missing chapter and tracking filters not working

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenState.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenState.kt
@@ -42,6 +42,7 @@ data class LibraryScreenState(
     val incognitoMode: Boolean = false,
     val groupByOptions: List<LibraryGroup> = listOf(),
     val trackMap: Map<Long, List<String>> = mapOf(),
+    val showTrackedFilter: Boolean = false,
     val showUnavailableFilter: Boolean = false,
     val showStartReadingButton: Boolean = true,
     val currentGroupBy: LibraryGroup = LibraryGroup.ByCategory,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryViewModel.kt
@@ -142,6 +142,12 @@ class LibraryViewModel() : ViewModel() {
             .distinctUntilChanged()
             .shareIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1)
 
+    private val hasLoggedTrackersFlow: Flow<Boolean> =
+        loggedServicesFlow
+            .map { loggedServices -> loggedServices.any { !it.isMdList() } }
+            .distinctUntilChanged()
+            .shareIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1)
+
     /** Save the current list to speed up loading later */
     override fun onCleared() {
         super.onCleared()
@@ -188,6 +194,21 @@ class LibraryViewModel() : ViewModel() {
             .distinctUntilChanged()
             .shareIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1)
 
+    val trackCountMapFlow: Flow<Map<Long, Int>> =
+        combine(trackRepository.observeAllTracks(), loggedServicesFlow) { tracks, loggedServices ->
+                val serviceMap = loggedServices.associateBy { it.id }
+
+                tracks
+                    .filter { track ->
+                        val trackService = serviceMap[track.sync_id]
+                        trackService != null && !trackService.isMdList()
+                    }
+                    .groupBy { it.manga_id }
+                    .mapValues { it.value.size }
+            }
+            .distinctUntilChanged()
+            .shareIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1)
+
     private val rawLibraryMangaListFlow =
         mangaRepository
             .observeLibrary()
@@ -230,14 +251,15 @@ class LibraryViewModel() : ViewModel() {
      * from frequent updates of counts.
      */
     val libraryMangaListFlow: Flow<List<LibraryMangaItem>> =
-        combine(initialLibraryItemsFlow, trackMapFlow, downloadCountMapFlow) {
+        combine(initialLibraryItemsFlow, trackMapFlow, trackCountMapFlow, downloadCountMapFlow) {
                 items,
                 trackMap,
+                trackCountMap,
                 downloadCountMap ->
                 items.map { item ->
                     val mangaId = item.displayManga.mangaId
                     val newDownloadCount = downloadCountMap[mangaId] ?: 0
-                    val newTrackCount = trackMap[mangaId]?.size ?: 0
+                    val newTrackCount = trackCountMap[mangaId] ?: 0
 
                     if (
                         item.downloadCount == newDownloadCount && item.trackCount == newTrackCount
@@ -601,13 +623,15 @@ class LibraryViewModel() : ViewModel() {
                 categoryListFlow,
                 libraryViewFlow,
                 uiSettingsFlow,
+                hasLoggedTrackersFlow,
             ) {
                 state,
                 (itemsWithRefreshing, allCollapsed),
                 trackMap,
                 categories,
                 viewPrefs,
-                uiSettings ->
+                uiSettings,
+                hasLoggedTrackers ->
                 state.copy(
                     items = itemsWithRefreshing,
                     allCollapsed = allCollapsed,
@@ -618,6 +642,7 @@ class LibraryViewModel() : ViewModel() {
                     recentSearches = uiSettings.recentSearches.toList(),
                     currentGroupBy = viewPrefs.groupBy,
                     trackMap = trackMap.toMap(),
+                    showTrackedFilter = hasLoggedTrackers,
                     userCategories =
                         categories.filterNot { it.isSystemCategory }.toList(),
                     isFirstLoad = false,

--- a/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
@@ -228,7 +228,7 @@ fun LibraryManga.toLibraryMangaItem(): LibraryMangaItem {
         author = authorList,
         contentRating = listOf(contentRating),
         isMerged = this.isMerged,
-        hasMissingChapters = this.missing_chapters != null,
+        hasMissingChapters = !this.missing_chapters.isNullOrBlank(),
         language = listOf(language),
         status = listOf(status),
         seriesType = seriesType,

--- a/app/src/main/java/org/nekomanga/presentation/screens/library/LibraryButtonBar.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/library/LibraryButtonBar.kt
@@ -158,7 +158,7 @@ fun LibraryButtonBar(
             mergedToggleList,
             libraryScreenActions.filterToggled,
         )
-        if (libraryScreenState.trackMap.isNotEmpty()) {
+        if (libraryScreenState.showTrackedFilter) {
             ConnectedToggleButtons(
                 libraryScreenState.libraryFilters.filterTracked,
                 trackedToggleList,


### PR DESCRIPTION
 ### 1. Fixed "Missing Chapters" / "No Missing Chapters" Filter
  
  • Root Cause: The database updates the  missing_chapters  field to  ""  (empty string) when there are no missing chapters. However, the UI conversion logic   
  used  hasMissingChapters = this.missing_chapters != null , which incorrectly evaluated  ""  as  true  (since an empty string is not null), causing the filter 
  to treat all updated mangas as having missing chapters.
  • Fix: Updated MangaExtensions.kt to use  !this.missing_chapters.isNullOrBlank() , ensuring that  ""  is correctly recognized as having no missing chapters.
  
  ### 2. Fixed "Tracked" / "Not Tracked" Filter
  
  • Root Cause: All library mangas automatically have a tracking entry for MangaDex ( MdList ) to keep track of their MangaDex follow status. The library screen
  was counting this source-level tracking service toward the total tracker count ( item.trackCount ). As a result, every manga was counted as "tracked" (with at
  least 1 track), which broke the "Tracked" / "Not Tracked" filter buttons.
  • Fix:
      • Introduced  trackCountMapFlow  in LibraryViewModel.kt that specifically excludes the  MdList  service when counting tracks per manga.
      • Updated LibraryViewModel.kt to assign this clean count to  LibraryMangaItem.trackCount .
      • Added  showTrackedFilter  to LibraryScreenState.kt to determine if the user has logged in to at least one third-party tracker (e.g. AniList, MAL, Kitsu).
      • Updated LibraryButtonBar.kt to toggle the visibility of the tracked filter buttons based on  showTrackedFilter  rather than whether  trackMap  is non-
empty. 