### PR TITLE
fix: synchronize WebView and OkHttp User-Agents to fix Cloudflare bypass for merge sources

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/webview/WebViewActivity.kt
@@ -59,7 +59,12 @@ open class WebViewActivity : AppCompatActivity() {
 
         setContent {
             NekoTheme {
-                WebViewScreen(title = title.toString(), url = url, onBackPressed = { finish() })
+                WebViewScreen(
+                    title = title.toString(),
+                    url = url,
+                    headers = headers,
+                    onBackPressed = { finish() },
+                )
             }
         }
     }

--- a/app/src/main/java/org/nekomanga/presentation/screens/WebViewScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/WebViewScreen.kt
@@ -3,10 +3,12 @@ package org.nekomanga.presentation.screens
 import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.graphics.Bitmap
+import android.webkit.CookieManager
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.widget.Toast
+import org.nekomanga.constants.Constants
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -39,7 +41,12 @@ import tachiyomi.core.util.system.setDefaultSettings
 import tachiyomi.core.util.system.shouldOverrideUrlLoading
 
 @Composable
-fun WebViewScreen(title: String, url: String, onBackPressed: () -> Unit) {
+fun WebViewScreen(
+    title: String,
+    url: String,
+    headers: Map<String, String> = emptyMap(),
+    onBackPressed: () -> Unit,
+) {
 
     val context = LocalContext.current
 
@@ -53,6 +60,7 @@ fun WebViewScreen(title: String, url: String, onBackPressed: () -> Unit) {
     WebViewWrapper(
         title = title,
         url = url,
+        headers = headers,
         onShare = { url ->
             val intent =
                 Intent(Intent.ACTION_SEND).apply {
@@ -169,10 +177,15 @@ fun WebViewWrapper(
                         WebView.setWebContentsDebuggingEnabled(true)
                     }
 
-                    headers["user-agent"]?.let { webView.settings.userAgentString = it }
+                    val userAgent = headers.entries.firstOrNull { it.key.equals("user-agent", ignoreCase = true) }?.value
+                        ?: Constants.USER_AGENT
+                    webView.settings.userAgentString = userAgent
                 },
                 client = webClient,
-                onDispose = { webview -> webview.destroy() },
+                onDispose = { webview ->
+                    runCatching { CookieManager.getInstance().flush() }
+                    webview.destroy()
+                },
             )
         }
     }


### PR DESCRIPTION
When opening a merge source in the WebView to bypass Cloudflare, the WebView used the Android system's default 
  WebView User-Agent since no custom User-Agent was passed.
  
  However, Neko’s OkHttp network clients (such as  cloudFlareClient , which all merge sources use as their base client) enforce a default mobile User-Agent (   
  Constants.USER_AGENT ) via a  UserAgentInterceptor .
  
  Because Cloudflare clearance cookies are cryptographically bound to the User-Agent that solved the challenge, Cloudflare rejected subsequent OkHttp requests  
  from Neko because the OkHttp User-Agent ( Constants.USER_AGENT ) did not match the default WebView User-Agent that was used to solve the captcha.             
  
  ### Resolution
  
  1. Added custom headers support to  WebViewScreen : Updated  WebViewScreen  to accept a  headers: Map<String, String>  parameter and passed it down to        
  WebViewWrapper .
  2. Propagated headers from  WebViewActivity : Updated  WebViewActivity  to pass the source's headers to  WebViewScreen .
  3. Synchronized User-Agents: Inside  WebViewWrapper 's  onCreated  configuration:
      • It checks the passed headers case-insensitively for a custom  user-agent .
      • If not present (as is the case with merge sources when opened via Compose navigation), it falls back to  Constants.USER_AGENT .
      • It sets  webView.settings.userAgentString  to this value.
  4. Persisted Cookies Immediately: Added a call to  CookieManager.getInstance().flush()  inside the WebView's  onDispose  block to ensure any obtained         
  Cloudflare cookies are saved to disk immediately when exiting the WebView.