### PR TITLE
ref: extract hardcoded dp dimension in CrashScreen to theme token

### DIFF
--- a/app/src/main/java/org/nekomanga/presentation/screens/CrashScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/CrashScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import eu.kanade.tachiyomi.util.CrashLogUtil
 import kotlinx.coroutines.launch
 import org.nekomanga.R
@@ -87,7 +86,7 @@ fun CrashScreen(exception: Throwable?, onRestartClick: () -> Unit) {
             Icon(
                 imageVector = Icons.Outlined.BugReport,
                 contentDescription = null,
-                modifier = Modifier.size(64.dp),
+                modifier = Modifier.size(Size.extraExtraHuge),
             )
             Text(
                 text = stringResource(R.string.crash_screen_title),


### PR DESCRIPTION
💡 **What:**
Extracted the hardcoded `64.dp` size for the `BugReport` icon in `CrashScreen.kt` and replaced it with the existing theme token `Size.extraExtraHuge`. Removed the unused `dp` import.

🎯 **Why:**
To ensure strict adherence to the project's central UI theming (`Size` constants), making the Compose UI layer more maintainable and consistent by eliminating isolated, hardcoded dimension values.

---
*PR created automatically by Jules for task [15610979841332629458](https://jules.google.com/task/15610979841332629458) started by @nonproto*