### PR TITLE
ref: switch chapterScanlatorFilterOption setting to ScanlatorFilterOption enum

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,3 @@
+# Custom Rules
+
+- **Do NOT auto commit anything**: Never automatically run `git commit`. Keep all modifications unstaged in the working tree so that the user can review them and commit them manually.

--- a/.github/workflows/pr-agent.yaml
+++ b/.github/workflows/pr-agent.yaml
@@ -21,8 +21,8 @@ jobs:
         uses: the-pr-agent/pr-agent@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          config.model: "gemini/gemini-3.5-flash"
-          config.fallback_models: '["gemini/gemini-3.1-flash"]'
+          config.model: "gemini/gemini-3.1-flash"
+          config.fallback_models: '["gemini/gemini-3.1-pro"]'
           GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_KEY }}
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -96,6 +96,7 @@ import org.nekomanga.data.database.repository.TrackRepository
 import org.nekomanga.domain.library.LibraryPreferences
 import org.nekomanga.domain.library.LibraryPreferences.Companion.DEVICE_CHARGING
 import org.nekomanga.domain.library.LibraryPreferences.Companion.DEVICE_NETWORK_NOT_METERED
+import org.nekomanga.domain.library.ScanlatorFilterOption
 import org.nekomanga.domain.network.message
 import org.nekomanga.domain.site.MangaDexPreferences
 import org.nekomanga.logging.TimberKt
@@ -537,7 +538,7 @@ class LibraryUpdateJob(private val context: Context, workerParameters: WorkerPar
                                             val scanlatorMatchAll =
                                                 libraryPreferences
                                                     .chapterScanlatorFilterOption()
-                                                    .get() == 0
+                                                    .get() == ScanlatorFilterOption.ALL
                                             ChapterUtil.filterByScanlator(
                                                 scanlators,
                                                 it.uploader ?: "",

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterItemFilter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterItemFilter.kt
@@ -9,6 +9,7 @@ import org.nekomanga.constants.MdConstants
 import org.nekomanga.domain.chapter.ChapterItem
 import org.nekomanga.domain.details.MangaDetailsPreferences
 import org.nekomanga.domain.library.LibraryPreferences
+import org.nekomanga.domain.library.ScanlatorFilterOption
 import org.nekomanga.domain.reader.ReaderPreferences
 import org.nekomanga.domain.site.MangaDexPreferences
 import uy.kohesive.injekt.Injekt
@@ -186,7 +187,7 @@ class ChapterItemFilter(
         val filteredLanguages = ChapterUtil.getLanguages(manga.filtered_language).toSet()
 
         val sources = SourceManager.mergeSourceNames + MdConstants.name
-        val scanlatorMatchAll = libraryPreferences.chapterScanlatorFilterOption().get() == 0
+        val scanlatorMatchAll = libraryPreferences.chapterScanlatorFilterOption().get() == ScanlatorFilterOption.ALL
 
         return chapters.filterNot { chapterItem ->
             val scanlators = ChapterUtil.getScanlators(chapterItem.chapter.scanlator)

--- a/app/src/main/java/org/nekomanga/data/database/mapper/LibraryMangaMappers.kt
+++ b/app/src/main/java/org/nekomanga/data/database/mapper/LibraryMangaMappers.kt
@@ -8,11 +8,12 @@ import org.nekomanga.constants.Constants
 import org.nekomanga.constants.MdConstants
 import org.nekomanga.data.database.dao.LibraryDao
 import org.nekomanga.data.database.model.LibraryMangaRaw
+import org.nekomanga.domain.library.ScanlatorFilterOption
 
 fun LibraryMangaRaw.toLibraryManga(
     blockedGroups: Set<String>,
     blockedUploaders: Set<String>,
-    scanlatorFilterOption: Int,
+    scanlatorFilterOption: ScanlatorFilterOption,
 ): LibraryManga {
     val raw = this
 
@@ -92,13 +93,11 @@ private fun parseChapterCount(
     filteredScanlatorsString: String?,
     blockedGroups: Set<String>,
     blockedUploaders: Set<String>,
-    scanlatorFilterOption: Int,
+    scanlatorFilterOption: ScanlatorFilterOption,
 ): Int {
     if (countString.isNullOrBlank()) return 0
 
-    // TODO switch this to enum
-    // 0 is all 1 is any
-    val scanlatorMatchAll = scanlatorFilterOption == 0
+    val scanlatorMatchAll = scanlatorFilterOption == ScanlatorFilterOption.ALL
     var validChapterCount = 0
     var startIndex = 0
 

--- a/app/src/main/java/org/nekomanga/data/database/repository/MangaRepositoryImpl.kt
+++ b/app/src/main/java/org/nekomanga/data/database/repository/MangaRepositoryImpl.kt
@@ -15,6 +15,7 @@ import org.nekomanga.data.database.mapper.toEntity
 import org.nekomanga.data.database.mapper.toLibraryManga
 import org.nekomanga.data.database.mapper.toManga
 import org.nekomanga.domain.library.LibraryPreferences
+import org.nekomanga.domain.library.ScanlatorFilterOption
 import org.nekomanga.domain.site.MangaDexPreferences
 
 // SQLite caps a statement at 999 bind variables (SQLITE_MAX_VARIABLE_NUMBER) on older Android.

--- a/app/src/main/java/org/nekomanga/domain/library/LibraryPreferences.kt
+++ b/app/src/main/java/org/nekomanga/domain/library/LibraryPreferences.kt
@@ -210,7 +210,12 @@ class LibraryPreferences(private val preferenceStore: PreferenceStore) {
     fun removeArticles() = this.preferenceStore.getBoolean("remove_articles")
 
     fun chapterScanlatorFilterOption() =
-        this.preferenceStore.getInt("chapter_scanlator_filter_option", 1)
+        this.preferenceStore.getObjectFromInt(
+            key = "chapter_scanlator_filter_option",
+            defaultValue = ScanlatorFilterOption.ANY,
+            serializer = { it.value },
+            deserializer = { i -> ScanlatorFilterOption.fromInt(i) },
+        )
 
     companion object {
 

--- a/app/src/main/java/org/nekomanga/domain/library/ScanlatorFilterOption.kt
+++ b/app/src/main/java/org/nekomanga/domain/library/ScanlatorFilterOption.kt
@@ -1,0 +1,15 @@
+package org.nekomanga.domain.library
+
+enum class ScanlatorFilterOption(val value: Int) {
+    ALL(0),
+    ANY(1);
+
+    companion object {
+        fun fromInt(value: Int): ScanlatorFilterOption {
+            return when (value) {
+                0 -> ALL
+                else -> ANY
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/LibrarySettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/LibrarySettingsScreen.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.CoroutineScope
 import org.nekomanga.R
 import org.nekomanga.domain.category.CategoryItem
 import org.nekomanga.domain.library.LibraryPreferences
+import org.nekomanga.domain.library.ScanlatorFilterOption
 import org.nekomanga.domain.library.LibraryPreferences.Companion.DEVICE_CHARGING
 import org.nekomanga.domain.library.LibraryPreferences.Companion.DEVICE_NETWORK_NOT_METERED
 import org.nekomanga.domain.library.LibraryPreferences.Companion.MANGA_HAS_UNREAD
@@ -79,15 +80,15 @@ internal class LibrarySettingsScreen(
                         pref = libraryPreferences.chapterScanlatorFilterOption(),
                         title = stringResource(R.string.chapter_scanlator_filter_option),
                         subtitleProvider = { value, options ->
-                            when (value == 0) {
-                                true -> stringResource(R.string.chapter_filter_all_summary)
-                                false -> stringResource(R.string.chapter_filter_any_summary)
+                            when (value) {
+                                ScanlatorFilterOption.ALL -> stringResource(R.string.chapter_filter_all_summary)
+                                ScanlatorFilterOption.ANY -> stringResource(R.string.chapter_filter_any_summary)
                             }
                         },
                         entries =
                             mapOf(
-                                0 to stringResource(R.string.chapter_filter_all),
-                                1 to stringResource(R.string.chapter_filter_any),
+                                ScanlatorFilterOption.ALL to stringResource(R.string.chapter_filter_all),
+                                ScanlatorFilterOption.ANY to stringResource(R.string.chapter_filter_any),
                             ),
                     ),
                 ),


### PR DESCRIPTION
    - Replaced raw Int preference chapterScanlatorFilterOption in LibraryPreferences with a typed ScanlatorFilterOption enum.
    - Removed hardcoded integer flags (0 and 1) in favor of ScanlatorFilterOption.ALL and ScanlatorFilterOption.ANY.
    - Updated all client usages across repository, database mapping, filter, background update, and settings layers.
    - Resolved the pending "// TODO switch this to enum" in LibraryMangaMappers.kt.