### PR TITLE
fix: check for successful request in merged chapter pages

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -186,6 +186,10 @@ class HttpPageLoader(
             if (!chapterCache.isImageInCache(imageUrl)) {
                 page.status = Page.State.DOWNLOAD_IMAGE
                 val imageResponse = source.getImage(page)
+                if (!imageResponse.isSuccessful) {
+                    imageResponse.close()
+                    throw Exception("HTTP error ${imageResponse.code}")
+                }
                 chapterCache.putImageToCache(imageUrl, imageResponse)
             }
 


### PR DESCRIPTION
This was affecting Suwayomi, since it returns an html page on status 500, I had to delete the cache to be able to read the chapters a few times.