### PR TITLE
fix: prevent stale binds and re-eval page splits

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
@@ -103,13 +103,13 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
      * split into multiple chunks.
      */
     fun notifyPageSplit(originalPage: ReaderPage, insertPages: List<ReaderPageSplit>) {
-        tallSplitPages.add(originalPage)
         val position = items.indexOf(originalPage)
         if (position < 0) return
         val newItems = items.toMutableList()
         newItems.addAll(position + 1, insertPages)
         val result = DiffUtil.calculateDiff(Callback(items, newItems))
         items = newItems
+        tallSplitPages.add(originalPage)
         result.dispatchUpdatesTo(this)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -317,7 +317,7 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
                 regionHeight = firstSplit.topOffset
                 return decodeRegion(imageBytes, 0, regionHeight)
             }
-            return Buffer().write(imageBytes)
+            viewer.adapter.tallSplitPages.remove(page)
         }
 
         val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }


### PR DESCRIPTION
I tested in the emulator and on my phone, fixes the "load only first split" bug when scrolling too fast