### PR TITLE
fix: only populate MangaBaka total chapters for completed series

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangabaka/MangaBaka.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangabaka/MangaBaka.kt
@@ -127,6 +127,7 @@ class MangaBaka(private val context: Context, id: Int) : TrackService(id) {
             track.copyPersonalFrom(remoteTrack)
             track.title = remoteTrack.title
             track.media_id = remoteTrack.media_id
+            track.total_chapters = remoteTrack.total_chapters
             update(track)
         } else {
             // Set default fields if it's not found in the list
@@ -156,6 +157,7 @@ class MangaBaka(private val context: Context, id: Int) : TrackService(id) {
         track.copyPersonalFrom(remoteTrack)
         track.media_id = remoteTrack.media_id
         track.title = remoteTrack.title
+        track.total_chapters = remoteTrack.total_chapters
         return track
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangabaka/MangaBakaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangabaka/MangaBakaApi.kt
@@ -28,6 +28,7 @@ import org.nekomanga.core.network.PUT
 import org.nekomanga.data.network.mangabaka.dto.MangaBakaLibraryListResult
 import org.nekomanga.data.network.mangabaka.dto.MangaBakaOAuth
 import org.nekomanga.data.network.mangabaka.dto.MangaBakaProfile
+import org.nekomanga.data.network.mangabaka.dto.MangaBakaPublicationStatus
 import org.nekomanga.data.network.mangabaka.dto.MangaBakaSeries
 import org.nekomanga.data.network.mangabaka.dto.MangaBakaSeriesResult
 import org.nekomanga.data.network.mangabaka.dto.MangaBakaSeriesSearchResult
@@ -128,7 +129,12 @@ class MangaBakaApi(
                             userData.finishDate?.let { Instant.parse(it).toEpochMilliseconds() }
                                 ?: 0
                         last_chapter_read = userData.progressChapter?.toFloat() ?: 0.0f
-                        total_chapters = additionalData.totalChapters?.toIntOrNull() ?: 0
+                        total_chapters =
+                            if (additionalData.status == MangaBakaPublicationStatus.COMPLETED) {
+                                additionalData.totalChapters?.toIntOrNull() ?: 0
+                            } else {
+                                0
+                            }
                         // private = userData.isPrivate
                     }
                 } catch (e: Exception) {
@@ -223,7 +229,12 @@ class MangaBakaApi(
             start_date = item.published?.startDate.orEmpty()
             publishing_status = item.status.toString().lowercase()
             publishing_type = ""
-            total_chapters = item.totalChapters?.toIntOrNull() ?: 0
+            total_chapters =
+                if (item.status == MangaBakaPublicationStatus.COMPLETED) {
+                    item.totalChapters?.toIntOrNull() ?: 0
+                } else {
+                    0
+                }
         }
     }
 


### PR DESCRIPTION
MangaBaka API sets total_chapters to the count of currently available
chapters for ongoing/releasing series, which caused Neko to falsely mark
the tracker entry as completed when catching up to the latest chapter.
Only populate total_chapters when publication status is COMPLETED.