### PR TITLE
fix: restore webtoon scroll progress and decouple seekbar drag state

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -427,7 +427,7 @@ class ReaderActivity : BaseMainActivity() {
                         currentPageIndex = state.currentPageIndex,
                         totalPages = state.totalPages,
                         isRtl = viewer is R2LPagerViewer,
-                        onPageChange = { index -> moveToPageIndex(index) },
+                        onPageChange = { index -> moveToPageIndex(index, animated = false) },
                         onSkipPrevious = { loadAdjacentChapter(false) },
                         onSkipNext = { loadAdjacentChapter(true) },
                         visible =

--- a/app/src/main/java/org/nekomanga/presentation/screens/reader/ReaderControls.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/reader/ReaderControls.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -125,7 +126,8 @@ fun ReaderBottomControls(
     modifier: Modifier = Modifier,
 ) {
     val view = LocalView.current
-    var lastValue by remember(currentPageIndex) { mutableStateOf(currentPageIndex) }
+    var draggingValue by remember { mutableStateOf<Float?>(null) }
+    var lastValue by remember(currentPageIndex) { mutableIntStateOf(currentPageIndex) }
 
     AnimatedVisibility(
         visible = visible,
@@ -193,20 +195,25 @@ fun ReaderBottomControls(
                     val sliderLayoutDirection =
                         if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr
                     CompositionLocalProvider(LocalLayoutDirection provides sliderLayoutDirection) {
+                        val targetMax = maxOf(totalPages.toFloat(), 1f)
+                        val displayValue =
+                            (draggingValue ?: currentPageIndex.toFloat()).coerceIn(0f, targetMax)
                         Slider(
-                            value = currentPageIndex.toFloat(),
+                            value = displayValue,
                             steps = totalPages,
                             onValueChange = { value ->
+                                draggingValue = value
                                 val roundedValue = value.roundToInt()
                                 if (roundedValue != lastValue) {
                                     lastValue = roundedValue
                                     view.performHapticFeedback(
                                         HapticFeedbackConstants.TEXT_HANDLE_MOVE
                                     )
+                                    onPageChange(roundedValue)
                                 }
-                                onPageChange(roundedValue)
                             },
-                            valueRange = 0f..maxOf(totalPages.toFloat(), 1f),
+                            onValueChangeFinished = { draggingValue = null },
+                            valueRange = 0f..targetMax,
                             colors =
                                 SliderDefaults.colors(
                                     activeTrackColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/org/nekomanga/presentation/screens/reader/ReaderControls.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/reader/ReaderControls.kt
@@ -212,7 +212,11 @@ fun ReaderBottomControls(
                                     onPageChange(roundedValue)
                                 }
                             },
-                            onValueChangeFinished = { draggingValue = null },
+                            onValueChangeFinished = {
+                                val finalValue = lastValue
+                                draggingValue = null
+                                onPageChange(finalValue)
+                            },
                             valueRange = 0f..targetMax,
                             colors =
                                 SliderDefaults.colors(

--- a/app/src/main/java/org/nekomanga/presentation/screens/reader/viewer/ComposeWebtoonViewer.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/reader/viewer/ComposeWebtoonViewer.kt
@@ -39,7 +39,6 @@ import eu.kanade.tachiyomi.ui.reader.model.ReaderUiItem
 import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation
 import eu.kanade.tachiyomi.ui.reader.viewer.webtoon.WebtoonViewer
 import kotlin.math.abs
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import org.nekomanga.domain.manga.MangaItem
 import org.nekomanga.domain.reader.ReaderPreferences
@@ -163,7 +162,6 @@ fun ComposeWebtoonViewer(
                     lazyListState.firstVisibleItemIndex
                 }
             }
-                .distinctUntilChanged()
                 .collect { activeIndex ->
                     if (activeIndex in items.indices) {
                         val item = items[activeIndex]

--- a/app/src/main/java/org/nekomanga/presentation/screens/reader/viewer/ComposeWebtoonViewer.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/reader/viewer/ComposeWebtoonViewer.kt
@@ -39,6 +39,7 @@ import eu.kanade.tachiyomi.ui.reader.model.ReaderUiItem
 import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation
 import eu.kanade.tachiyomi.ui.reader.viewer.webtoon.WebtoonViewer
 import kotlin.math.abs
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import org.nekomanga.domain.manga.MangaItem
 import org.nekomanga.domain.reader.ReaderPreferences
@@ -157,13 +158,14 @@ fun ComposeWebtoonViewer(
                             val itemMiddle = it.offset + it.size / 2
                             abs(itemMiddle - viewportMiddle)
                         } ?: visibleItems.first()
-                    activeItemInfo.index to lazyListState.isScrollInProgress
+                    activeItemInfo.index
                 } else {
-                    lazyListState.firstVisibleItemIndex to lazyListState.isScrollInProgress
+                    lazyListState.firstVisibleItemIndex
                 }
             }
-                .collect { (activeIndex, scrolling) ->
-                    if (!scrolling && activeIndex in items.indices) {
+                .distinctUntilChanged()
+                .collect { activeIndex ->
+                    if (activeIndex in items.indices) {
                         val item = items[activeIndex]
                         when (item) {
                             is ReaderUiItem.Page -> {


### PR DESCRIPTION
 1. Restored Real-Time Scroll Position & Prefetching in Webtoon Viewer:
      • In ComposeWebtoonViewer.kt:150-200, removed the !scrolling guard that previously blocked all active page notifications during drag and fling scroll     
      gestures.
      • Applied .distinctUntilChanged() to the snapshotFlow emission pipeline to throttle updates to only distinct page boundary transitions without dropping   
      in-motion events.
      • Ensures reading history and chapter preloading trigger continuously during smooth scrolling.
  2. Decoupled Slider Drag Gestures from External Stream Updates:
      • In ReaderControls.kt:125-225 (ReaderBottomControls), introduced a local draggingValue state and onValueChangeFinished callback.
      • During user scrub gestures, the slider thumb tracks finger movements locally without fighting incoming viewer page emissions, eliminating seekbar jitter
      at the presentation layer.
  3. Immediate Seeking Without Animation Lag:
      • In ReaderActivity.kt:430, updated onPageChange to call moveToPageIndex(index, animated = false).
      • Prevents consecutive seek events from creating animation queue delays or frame drops.